### PR TITLE
List connector optimisation

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -1,13 +1,8 @@
-from spynnaker.pyNN.models.neural_projections.connectors.seed_info \
-    import SeedInfo
 from spynnaker.pyNN.models.neural_projections.connectors.abstract_connector \
     import AbstractConnector
 from spynnaker.pyNN.models.neural_properties.synaptic_list import SynapticList
 from spynnaker.pyNN.models.neural_properties.synapse_row_info \
     import SynapseRowInfo
-from spynnaker.pyNN.models.neural_properties.randomDistributions \
-    import generate_parameter
-from spinn_front_end_common.utilities import exceptions
 import logging
 import numpy
 
@@ -48,14 +43,11 @@ class FromListConnector(AbstractConnector):
             weight_scale, synapse_type):
 
         prevertex = presynaptic_population._get_vertex
-        postvertex = postsynaptic_population._get_vertex
 
         # Convert connection list into numpy record array
-        conn_list_numpy = numpy.array(self._conn_list,
-                                      dtype=[("i", "uint32"),
-                                             ("j", "uint32"),
-                                             ("weight", "float"),
-                                             ("delay", "float")])
+        conn_list_numpy = numpy.array(
+            self._conn_list, dtype=[("i", "uint32"), ("j", "uint32"),
+                                    ("weight", "float"), ("delay", "float")])
 
         # Sort by pre-synaptic neuron
         conn_list_numpy = numpy.sort(conn_list_numpy, order="i")
@@ -65,8 +57,8 @@ class FromListConnector(AbstractConnector):
         conn_list_numpy["delay"] *= delay_scale
 
         # Count number of connections per pre-synaptic neuron
-        pre_counts = numpy.histogram(conn_list_numpy["i"],
-                                     numpy.arange(prevertex.n_atoms + 1))[0]
+        pre_counts = numpy.histogram(
+            conn_list_numpy["i"], numpy.arange(prevertex.n_atoms + 1))[0]
 
         # Take cumulative sum of these counts to get start and end indices of
         # the blocks of connections coming from each pre-synaptic neuron

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -68,13 +68,14 @@ class FromListConnector(AbstractConnector):
         pre_counts = numpy.histogram(conn_list_numpy["i"],
                                      numpy.arange(prevertex.n_atoms + 1))[0]
 
-        # Convert these into cumulative counts
-        pre_conn_end_indices = numpy.cumsum(pre_counts)
-        pre_conn_start_indices = numpy.append(0, pre_conn_end_indices[:-1])
+        # Take cumulative sum of these counts to get start and end indices of
+        # the blocks of connections coming from each pre-synaptic neuron
+        pre_end_idxs = numpy.cumsum(pre_counts)
+        pre_start_idxs = numpy.append(0, pre_end_idxs[:-1])
 
         # Loop through slices of connections
         synaptic_rows = []
-        for n, (start, end) in enumerate(zip(pre_conn_start_indices, pre_conn_end_indices)):
+        for n, (start, end) in enumerate(zip(pre_start_idxs, pre_end_idxs)):
             # Get slice
             pre_conns = conn_list_numpy[start:end]
 

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -346,7 +346,8 @@ class Spinnaker(FrontEndCommonConfigurationFunctions,
                 self._hostname, self._placements, self._graph_mapper,
                 write_text_specs=config.getboolean(
                     "Reports", "writeTextSpecs"),
-                runtime_application_data_folder=self._app_data_runtime_folder)
+                runtime_application_data_folder=self._app_data_runtime_folder,
+            machine=self._machine)
 
         if self._reports_states is not None:
             reports.write_memory_map_report(self._report_default_directory,


### PR DESCRIPTION
This one may be slightly more controversial, but it speeds up generating big list connectors pretty massively. The previous version supported some stuff I see no sign of in the PyNN spec (http://neuralensemble.org/trac/PyNN/wiki/API-0.7#FromListConnector) - I'm not entirely certain how distributions could be validly used in the context of a list connector, but the support for the alternative 
```
[
    [pre_idx0, pre_idx1, ..., pre_idxN], 
    [pre_idx1, pre_idx2, ..., pre_idxN], 
    [weight0, weight1, ..., weightN], 
    [delay0, delay1, ..., delayN]
]
```
Format could be supported fairly trivially if there's some desire for it.
 