### PR TITLE
adds the ability to not autodetect the bmp if needed by the end user

### DIFF
--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -228,7 +228,8 @@ class Spinnaker(FrontEndCommonConfigurationFunctions,
             number_of_boards=number_of_boards, width=width, height=height,
             is_virtual=config.getboolean("Machine", "virtual_board"),
             virtual_has_wrap_arounds=config.getboolean(
-                "Machine", "requires_wrap_arounds"))
+                "Machine", "requires_wrap_arounds"),
+            auto_detect_bmp=config.getboolean("Machine", "auto_detect_bmp"))
 
         # adds extra stuff needed by the reload script which cannot be given
         # directly.

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -370,7 +370,7 @@ class Spinnaker(FrontEndCommonConfigurationFunctions,
                 self._load_application_data(
                     self._placements, self._graph_mapper,
                     processor_to_app_data_base_address, self._hostname,
-                    app_data_folder=self._app_data_runtime_folder, 
+                    app_data_folder=self._app_data_runtime_folder,
                     verify=config.getboolean("Mode", "verify_writes"))
                 self.load_routing_tables(self._router_tables, self._app_id)
                 logger.info("*** Loading executables ***")

--- a/spynnaker/pyNN/utilities/conf/spynnaker.cfg.template
+++ b/spynnaker/pyNN/utilities/conf/spynnaker.cfg.template
@@ -5,16 +5,28 @@
 [Machine]
 #-------
 # Information about the target SpiNNaker board or machine:
-# machineName:     The name or IP address of the target board
-# version:         Version of the Spinnaker Hardware Board (1-5)
-# machineTimeStep: Internal time step in simulations in usecs.
-# timeScaleFactor: Change this to slow down the simulation time
-#                      relative to real time.
+# machineName:      The name or IP address of the target board
+# version:          Version of the Spinnaker Hardware Board (1-5)
+# down_chips:       A list of chips that don't work, as x,y separated by ;
+# down_cores:       A list of cores that don't work, as x,y,p separated by ;
+# bmp_names:        A list of connected BMP IP addresses, separated by :
+# auto_detect_bmp:  True if the BMP IP address should be computed from the
+                        machine IP address, False if no BMP should be used if
+                        not specified
+# turn_off_machine: True if the machine should be turned off after simulation
+# machineTimeStep:  Internal time step in simulations in usecs.
+# timeScaleFactor:  Change this to slow down the simulation time
+#                       relative to real time.
 #-------
-machineName     = None
-version         = None
-#machineTimeStep = 1000
-#timeScaleFactor = 1
+machineName       = None
+version           = None
+#down_cores       = None
+#down_chips       = None
+#bmp_names        = None
+#auto_detect_bmp  = True
+#turn_off_machine = True
+#machineTimeStep  = 1000
+#timeScaleFactor  = 1
 
 [Database]
 #---------

--- a/spynnaker/pyNN/utilities/conf/spynnaker.cfg.template
+++ b/spynnaker/pyNN/utilities/conf/spynnaker.cfg.template
@@ -7,8 +7,8 @@
 # Information about the target SpiNNaker board or machine:
 # machineName:      The name or IP address of the target board
 # version:          Version of the Spinnaker Hardware Board (1-5)
-# down_chips:       A list of chips that don't work, as x,y separated by ;
-# down_cores:       A list of cores that don't work, as x,y,p separated by ;
+# down_chips:       A list of chips that don't work, as x,y separated by :
+# down_cores:       A list of cores that don't work, as x,y,p separated by :
 # bmp_names:        A list of connected BMP IP addresses, separated by :
 # auto_detect_bmp:  True if the BMP IP address should be computed from the
                         machine IP address, False if no BMP should be used if

--- a/spynnaker/spynnaker.cfg
+++ b/spynnaker/spynnaker.cfg
@@ -116,7 +116,7 @@ height = None
 
 virtual_board = False
 requires_wrap_arounds = False
-
+auto_detect_bmp = True
 turn_off_machine = True
 clear_routing_tables = True
 clear_tags = True


### PR DESCRIPTION
fixes a issue if you have a spinn-4/ spinn-5 board and havent got the bmp connected