### PR TITLE
Add default value to SpikeSourceArray spike_times

### DIFF
--- a/spynnaker/pyNN/models/spike_source/spike_source_array.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array.py
@@ -46,7 +46,7 @@ class SpikeSourceArray(
 
     def __init__(
             self, n_neurons, machine_time_step, timescale_factor,
-            spike_times=[], port=None, tag=None, ip_address=None,
+            spike_times=None, port=None, tag=None, ip_address=None,
             board_address=None, max_on_chip_memory_usage_for_spikes_in_bytes=(
                 constants.SPIKE_BUFFER_SIZE_BUFFERING_IN),
             space_before_notification=640,
@@ -61,6 +61,8 @@ class SpikeSourceArray(
         self._port = port
         if port is None:
             self._port = config.getint("Buffers", "receive_buffer_port")
+        if spike_times is None:
+            spike_times = []
 
         ReverseIpTagMultiCastSource.__init__(
             self, n_keys=n_neurons, machine_time_step=machine_time_step,

--- a/spynnaker/pyNN/models/spike_source/spike_source_array.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array.py
@@ -45,9 +45,9 @@ class SpikeSourceArray(
     _model_based_max_atoms_per_core = sys.maxint
 
     def __init__(
-            self, n_neurons, spike_times, machine_time_step, timescale_factor,
-            port=None, tag=None, ip_address=None, board_address=None,
-            max_on_chip_memory_usage_for_spikes_in_bytes=(
+            self, n_neurons, machine_time_step, timescale_factor,
+            spike_times=[], port=None, tag=None, ip_address=None,
+            board_address=None, max_on_chip_memory_usage_for_spikes_in_bytes=(
                 constants.SPIKE_BUFFER_SIZE_BUFFERING_IN),
             space_before_notification=640,
             constraints=None, label="SpikeSourceArray",


### PR DESCRIPTION
SpikeSourceArray did not specify a default value for spike_times
in its constructor. This caused sPyNNaker to crash with the
weird exception

    File "sPyNNaker/spynnaker/pyNN/models/pynn_population.py", line 79, in __init__
      self._vertex = cellclass(**cellparams)
    TypeError: __init__() takes at least 5 arguments (5 given)

if an empty parameter dictionary was passed to the Population
constructor (which supposedly should not happen):

    sim.Population(10, sim.SpikeSourceArray, {})

This fix simply adds the missing default value to the spike_times
parameter. Note, that the parameter order in the
SpikeSourceArray constructor was altered.