### PR TITLE
Spread neuron spikes

### DIFF
--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -65,6 +65,7 @@ from abc import ABCMeta
 from six import add_metaclass
 import logging
 import os
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,8 @@ class AbstractPopulationVertex(
     """
 
     BASIC_MALLOC_USAGE = 2
+
+    _n_vertices = 0
 
     def __init__(
             self, n_neurons, binary, label, max_atoms_per_core,
@@ -270,6 +273,8 @@ class AbstractPopulationVertex(
         self._check_for_auto_pause_and_resume_functionality(
             vertex_slice, vertex, n_machine_time_steps)
 
+        self._n_vertices += 1
+
         # return machine vertex
         return vertex
 
@@ -425,7 +430,8 @@ class AbstractPopulationVertex(
             time_between_requests)
 
     def _write_neuron_parameters(
-            self, spec, key, vertex_slice):
+            self, spec, key, vertex_slice, machine_time_step,
+            time_scale_factor):
 
         n_atoms = (vertex_slice.hi_atom - vertex_slice.lo_atom) + 1
         spec.comment("\nWriting Neuron Parameters for {} Neurons:\n".format(
@@ -434,6 +440,15 @@ class AbstractPopulationVertex(
         # Set the focus to the memory region 2 (neuron parameters):
         spec.switch_write_focus(
             region=constants.POPULATION_BASED_REGIONS.NEURON_PARAMS.value)
+
+        # Write the random back off value
+        spec.write_value(random.randint(0, self._n_vertices))
+
+        # Write the number of microseconds between sending spikes
+        time_between_spikes = (
+            (machine_time_step * time_scale_factor) /
+            (n_atoms * 2.0))
+        spec.write_value(data=int(time_between_spikes))
 
         # Write whether the key is to be used, and then the key, or 0 if it
         # isn't to be used
@@ -555,7 +570,8 @@ class AbstractPopulationVertex(
             spec, spike_history_sz, v_history_sz, gsyn_history_sz,
             iptags, buffer_size_before_receive, self._time_between_requests,
             vertex, machine_time_step, time_scale_factor)
-        self._write_neuron_parameters(spec, key, vertex_slice)
+        self._write_neuron_parameters(
+            spec, key, vertex_slice, machine_time_step, time_scale_factor)
 
         # allow the synaptic matrix to write its data spec-able data
         self._synapse_manager.write_data_spec(

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -485,8 +485,6 @@ class SynapticManager(object):
                             prob, spikes_per_tick)
                     rate_stats[synapse_type].add_items(
                         spikes_per_second, 0, n_connections)
-
-                    print machine_edge.pre_vertex.label, synapse_type, weight_max, n_connections
                     total_weights[synapse_type] += spikes_per_tick * (
                         weight_max * n_connections)
 
@@ -508,8 +506,6 @@ class SynapticManager(object):
                     total_weights[synapse_type])
                 max_weights[synapse_type] = max(
                     max_weights[synapse_type], biggest_weight[synapse_type])
-
-        print machine_vertex.label, max_weights
 
         # Convert these to powers
         max_weight_powers = [0 if w <= 0

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -485,6 +485,8 @@ class SynapticManager(object):
                             prob, spikes_per_tick)
                     rate_stats[synapse_type].add_items(
                         spikes_per_second, 0, n_connections)
+
+                    print machine_edge.pre_vertex.label, synapse_type, weight_max, n_connections
                     total_weights[synapse_type] += spikes_per_tick * (
                         weight_max * n_connections)
 
@@ -506,6 +508,8 @@ class SynapticManager(object):
                     total_weights[synapse_type])
                 max_weights[synapse_type] = max(
                     max_weights[synapse_type], biggest_weight[synapse_type])
+
+        print machine_vertex.label, max_weights
 
         # Convert these to powers
         max_weight_powers = [0 if w <= 0


### PR DESCRIPTION
Added the fix for neuron spikes to enforce them to be spread out.  Note that this is slightly different that that done in the other similar modules as it doesn't use the SARK busy-wait procedure.  This is because the SARK procedure doesn't take account of interrupts in the wait time, which matters more in the neuron model than in the other models.