### PR TITLE
Getter for SynapseInformation in MachineEdge

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
@@ -26,6 +26,10 @@ class ProjectionMachineEdge(
 
         self._synapse_information = synapse_information
 
+    @property
+    def synapse_information(self):
+        return self._synapse_information
+
     @overrides(AbstractFilterableEdge.filter_edge)
     def filter_edge(self, graph_mapper):
         pre_vertex = graph_mapper.get_application_vertex(


### PR DESCRIPTION
I need SynapseInformation from Machine edges for some filtering. Added a getter for it so I don't access private variables.