### PR TITLE
Graph diagram generation and synaptic read optimisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,5 @@ setup(
                   'spynnaker.pyNN.utilities.conf': ['spynnaker.cfg.template'],
                   'spynnaker.pyNN.overridden_pacman_functions': ['*.xml']},
     install_requires=['SpiNNFrontEndCommon >= 3.0.0, < 4.0.0',
-                      'pyNN >= 0.7, < 0.8', 'numpy', 'scipy', 'lxml', 'six',
-                      'graphviz']
+                      'pyNN >= 0.7, < 0.8', 'numpy', 'scipy', 'lxml', 'six']
 )

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
                   'spynnaker.pyNN.utilities.conf': ['spynnaker.cfg.template'],
                   'spynnaker.pyNN.overridden_pacman_functions': ['*.xml']},
     install_requires=['SpiNNFrontEndCommon >= 3.0.0, < 4.0.0',
-                      'pyNN >= 0.7, < 0.8', 'numpy', 'scipy', 'lxml', 'six']
+                      'pyNN >= 0.7, < 0.8', 'numpy', 'scipy', 'lxml', 'six',
+                      'graphviz']
 )

--- a/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
@@ -164,3 +164,6 @@ class AllToAllConnector(AbstractConnector):
             self._delays, n_connections, connection_slices)
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "AllToAllConnector()"

--- a/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
@@ -173,3 +173,7 @@ class DistanceDependentProbabilityConnector(AbstractConnector):
             self._delays, n_connections, None)
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "DistanceDependentProbabilityConnector({})".format(
+            self._d_expression)

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -158,3 +158,6 @@ class FixedNumberPostConnector(AbstractConnector):
             self._delays, n_connections, None)
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "FixedNumberPostConnector({})".format(self._post_n)

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -164,3 +164,6 @@ class FixedNumberPreConnector(AbstractConnector):
             self._delays, n_connections, None)
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "FixedNumberPreConnector({})".format(self._n_pre)

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -127,3 +127,6 @@ class FixedProbabilityConnector(AbstractConnector):
             self._delays, n_connections, None)
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "FixedProbabilityConnector({})".format(self._p_connect)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_file_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_file_connector.py
@@ -10,6 +10,7 @@ class FromFileConnector(FromListConnector):
     def __init__(
             self, file,  # @ReservedAssignment
             distributed=False, safe=True, verbose=False):
+        self._file = file
 
         real_file = file
         opened_file = False
@@ -36,3 +37,6 @@ class FromFileConnector(FromListConnector):
             real_file.close()
 
         FromListConnector.__init__(self, conn_list, safe, verbose)
+
+    def __repr__(self):
+        return "FromFileConnector({})".format(self._file)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -144,3 +144,7 @@ class FromListConnector(AbstractConnector):
         block["delay"] = self._clip_delays(items["delay"])
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "FromListConnector(n_connections={})".format(
+            len(self._conn_list))

--- a/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
@@ -200,3 +200,6 @@ class MultapseConnector(AbstractConnector):
             self._delays, n_connections, [connection_slice])
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "MultapseConnector({})".format(self._num_synapses)

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -148,3 +148,6 @@ class OneToOneConnector(AbstractConnector):
             self._delays, n_connections, [connection_slice])
         block["synapse_type"] = synapse_type
         return block
+
+    def __repr__(self):
+        return "OneToOneConnector()"

--- a/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
@@ -25,6 +25,7 @@ class SmallWorldConnector(AbstractConnector):
         post_positions = self._post_population.positions
         distances = self._space.distances(
             pre_positions, post_positions, False)
+        self._degree = degree
         self._mask = (distances < degree).as_type(float)
         self._n_connections = numpy.sum(self._mask)
 
@@ -117,3 +118,7 @@ class SmallWorldConnector(AbstractConnector):
             post_vertex_slice.lo_atom)
 
         return block
+
+    def __repr__(self):
+        return "SmallWorldConnector(degree={}, rewiring={})".format(
+            self._degree, self._rewiring)

--- a/spynnaker/pyNN/models/neuron/connection_holder.py
+++ b/spynnaker/pyNN/models/neuron/connection_holder.py
@@ -14,7 +14,7 @@ class ConnectionHolder(object):
         self._n_post_atoms = n_post_atoms
         self._connections = connections
         self._merged_connections = None
-        self._filename = None
+        self._filename = filename
 
     def add_connections(self, connections):
         if self._connections is None:

--- a/spynnaker/pyNN/overridden_pacman_functions/algorithms_metadata.xml
+++ b/spynnaker/pyNN/overridden_pacman_functions/algorithms_metadata.xml
@@ -98,55 +98,25 @@
     </algorithm>
     <algorithm name="SynapticMatrixReport">
         <python_module>spynnaker.pyNN.utilities.spynnaker_synaptic_matrix_report</python_module>
-        <python_function>SpYNNakerSynapticMatrixReport</python_function>
+        <python_class>SpYNNakerSynapticMatrixReport</python_class>
         <input_definitions>
             <parameter>
-                <param_name>common_report_directory</param_name>
                 <param_type>ReportFolder</param_type>
+                <param_name>report_folder</param_name>
             </parameter>
             <parameter>
-                <param_name>machine_graph</param_name>
-                <param_type>MemoryMachineGraph</param_type>
+                <param_type>ConnectionHolders</param_type>
+                <param_name>connection_holder</param_name>
             </parameter>
             <parameter>
-                <param_name>graph_mapper</param_name>
-                <param_type>MemoryGraphMapper</param_type>
-            </parameter>
-            <parameter>
-                <param_name>routing_infos</param_name>
-                <param_type>MemoryRoutingInfos</param_type>
-            </parameter>
-            <parameter>
-                <param_name>placements</param_name>
-                <param_type>MemoryPlacements</param_type>
-            </parameter>
-            <parameter>
-                <param_name>application_graph</param_name>
-                <param_type>MemoryApplicationGraph</param_type>
-            </parameter>
-            <parameter>
-                <param_name>txrx</param_name>
-                <param_type>MemoryTransceiver</param_type>
-            </parameter>
-            <parameter>
-                <param_name>loaded_application_data_token</param_name>
-                <param_type>LoadedApplicationDataToken</param_type>
-            </parameter>
-            <parameter>
-                <param_name>machine_time_step</param_name>
-                <param_type>MachineTimeStep</param_type>
+                <param_type>DataSpecificationTargets</param_type>
+                <param_name>dsg_targets</param_name>
             </parameter>
         </input_definitions>
         <required_inputs>
-            <param_name>common_report_directory</param_name>
-            <param_name>machine_graph</param_name>
-            <param_name>graph_mapper</param_name>
-            <param_name>routing_infos</param_name>
-            <param_name>placements</param_name>
-            <param_name>application_graph</param_name>
-            <param_name>txrx</param_name>
-            <param_name>loaded_application_data_token</param_name>
-            <param_name>machine_time_step</param_name>
+            <param_name>report_folder</param_name>
+            <param_name>connection_holder</param_name>
+            <param_name>dsg_targets</param_name>
         </required_inputs>
     </algorithm>
     <algorithm name="SpYNNakerConnectionHolderGenerator">
@@ -157,14 +127,9 @@
                 <param_type>MemoryApplicationGraph</param_type>
                 <param_name>application_graph</param_name>
             </parameter>
-            <parameter>
-                <param_type>MemoryGraphMapper</param_type>
-                <param_name>graph_mapper</param_name>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>application_graph</param_name>
-            <param_name>graph_mapper</param_name>
         </required_inputs>
         <outputs>
             <param_type>ConnectionHolders</param_type>

--- a/spynnaker/pyNN/overridden_pacman_functions/algorithms_metadata.xml
+++ b/spynnaker/pyNN/overridden_pacman_functions/algorithms_metadata.xml
@@ -97,8 +97,8 @@
         </outputs>
     </algorithm>
     <algorithm name="SynapticMatrixReport">
-        <python_module>spynnaker.pyNN.utilities.reports</python_module>
-        <python_function>generate_synaptic_matrix_reports</python_function>
+        <python_module>spynnaker.pyNN.utilities.spynnaker_synaptic_matrix_report</python_module>
+        <python_function>SpYNNakerSynapticMatrixReport</python_function>
         <input_definitions>
             <parameter>
                 <param_name>common_report_directory</param_name>
@@ -147,6 +147,55 @@
             <param_name>txrx</param_name>
             <param_name>loaded_application_data_token</param_name>
             <param_name>machine_time_step</param_name>
+        </required_inputs>
+    </algorithm>
+    <algorithm name="SpYNNakerConnectionHolderGenerator">
+        <python_module>spynnaker.pyNN.utilities.spynnaker_connection_holder_generations</python_module>
+        <python_class>SpYNNakerConnectionHolderGenerator</python_class>
+        <input_definitions>
+            <parameter>
+                <param_type>MemoryApplicationGraph</param_type>
+                <param_name>application_graph</param_name>
+            </parameter>
+            <parameter>
+                <param_type>MemoryGraphMapper</param_type>
+                <param_name>graph_mapper</param_name>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>application_graph</param_name>
+            <param_name>graph_mapper</param_name>
+        </required_inputs>
+        <outputs>
+            <param_type>ConnectionHolders</param_type>
+        </outputs>
+    </algorithm>
+    <algorithm name="SpYNNakerNeuronGraphNetworkSpecificationReport">
+        <python_module>spynnaker.pyNN.utilities.spynnaker_neuron_network_specification_report</python_module>
+        <python_class>SpYNNakerNeuronGraphNetworkSpecificationReport</python_class>
+        <input_definitions>
+            <parameter>
+                <param_type>ReportFolder</param_type>
+                <param_name>report_folder</param_name>
+            </parameter>
+            <parameter>
+                <param_type>MemoryApplicationGraph</param_type>
+                <param_name>application_graph</param_name>
+            </parameter>
+            <parameter>
+                <param_type>ConnectionHolders</param_type>
+                <param_name>connection_holder</param_name>
+            </parameter>
+            <parameter>
+                <param_type>DataSpecificationTargets</param_type>
+                <param_name>dsg_targets</param_name>
+            </parameter>
+        </input_definitions>
+        <required_inputs>
+            <param_name>report_folder</param_name>
+            <param_name>application_graph</param_name>
+            <param_name>connection_holder</param_name>
+            <param_name>dsg_targets</param_name>
         </required_inputs>
     </algorithm>
 </algorithms>

--- a/spynnaker/pyNN/overridden_pacman_functions/algorithms_metadata.xml
+++ b/spynnaker/pyNN/overridden_pacman_functions/algorithms_metadata.xml
@@ -147,20 +147,10 @@
                 <param_type>MemoryApplicationGraph</param_type>
                 <param_name>application_graph</param_name>
             </parameter>
-            <parameter>
-                <param_type>ConnectionHolders</param_type>
-                <param_name>connection_holder</param_name>
-            </parameter>
-            <parameter>
-                <param_type>DataSpecificationTargets</param_type>
-                <param_name>dsg_targets</param_name>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>report_folder</param_name>
             <param_name>application_graph</param_name>
-            <param_name>connection_holder</param_name>
-            <param_name>dsg_targets</param_name>
         </required_inputs>
     </algorithm>
 </algorithms>

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -71,6 +71,11 @@ class Spinnaker(SpinnakerMainInterface):
         extra_mapping_inputs['CreateAtomToEventIdMapping'] = config.getboolean(
             "Database", "create_routing_info_to_neuron_id_mapping")
 
+        extra_mapping_algorithms = list()
+        if config.getboolean("Reports", "draw_network_graph"):
+            extra_mapping_algorithms.append(
+                "SpYNNakerConnectionHolderGenerator")
+
         extra_algorithms_pre_run = list()
         if config.getboolean("Reports", "ReportsEnabled"):
             if config.getboolean("Reports", "writeSynapticReport"):
@@ -82,6 +87,7 @@ class Spinnaker(SpinnakerMainInterface):
             database_socket_addresses=database_socket_addresses,
             extra_algorithm_xml_paths=extra_algorithm_xml_path,
             extra_mapping_inputs=extra_mapping_inputs,
+            extra_mapping_algorithms=extra_mapping_algorithms,
             n_chips_required=n_chips_required,
             extra_pre_run_algorithms=extra_algorithms_pre_run)
 

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -72,11 +72,15 @@ class Spinnaker(SpinnakerMainInterface):
             "Database", "create_routing_info_to_neuron_id_mapping")
 
         extra_mapping_algorithms = list()
+        extra_load_algorithms = list()
+        extra_algorithms_pre_run = list()
+
         if config.getboolean("Reports", "draw_network_graph"):
             extra_mapping_algorithms.append(
                 "SpYNNakerConnectionHolderGenerator")
+            extra_load_algorithms.append(
+                "SpYNNakerNeuronGraphNetworkSpecificationReport")
 
-        extra_algorithms_pre_run = list()
         if config.getboolean("Reports", "ReportsEnabled"):
             if config.getboolean("Reports", "writeSynapticReport"):
                 extra_algorithms_pre_run.append("SynapticMatrixReport")
@@ -88,6 +92,7 @@ class Spinnaker(SpinnakerMainInterface):
             extra_algorithm_xml_paths=extra_algorithm_xml_path,
             extra_mapping_inputs=extra_mapping_inputs,
             extra_mapping_algorithms=extra_mapping_algorithms,
+            extra_load_algorithms=extra_load_algorithms,
             n_chips_required=n_chips_required,
             extra_pre_run_algorithms=extra_algorithms_pre_run)
 

--- a/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
+++ b/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
@@ -1,6 +1,8 @@
 import logging
 from spinn_machine.utilities.progress_bar import ProgressBar
 from spynnaker.pyNN.models.neuron.connection_holder import ConnectionHolder
+from spynnaker.pyNN.models.neural_projections.projection_application_edge \
+    import ProjectionApplicationEdge
 
 logger = logging.getLogger(__name__)
 
@@ -23,19 +25,22 @@ class SpYNNakerConnectionHolderGenerator(object):
         data_holders = dict()
         for edge in application_graph.edges:
 
-            # build connection holders
-            connection_holder = ConnectionHolder(
-                None, True, edge.pre_vertex.n_atoms,
-                edge.post_vertex.n_atoms)
-
             # add pre run generators so that reports can extract without
             # going to machine.
-            for synapse_information in edge.synapse_information:
-                edge.post_vertex.add_pre_run_connection_holder(
-                    connection_holder, edge, synapse_information)
+            if isinstance(edge, ProjectionApplicationEdge):
 
-                # store for the report generations
-                data_holders[(edge, synapse_information)] = connection_holder
+                # build connection holders
+                connection_holder = ConnectionHolder(
+                    None, True, edge.pre_vertex.n_atoms,
+                    edge.post_vertex.n_atoms)
+
+                for synapse_information in edge.synapse_information:
+                    edge.post_vertex.add_pre_run_connection_holder(
+                        connection_holder, edge, synapse_information)
+
+                    # store for the report generations
+                    data_holders[(edge, synapse_information)] = \
+                        connection_holder
             progress_bar.update()
         progress_bar.end()
 

--- a/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
+++ b/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
@@ -1,4 +1,5 @@
 import logging
+from spinn_machine.utilities.progress_bar import ProgressBar
 from spynnaker.pyNN.models.neuron.connection_holder import ConnectionHolder
 
 logger = logging.getLogger(__name__)
@@ -9,12 +10,15 @@ class SpYNNakerConnectionHolderGenerator(object):
     method that sets up connection holders for reports to use.
     """
 
-    def __call__(self, application_graph, graph_mapper):
+    def __call__(self, application_graph):
         """
-        :param application_graph:
-        :param graph_mapper:
-        :return:
+        :param application_graph: app graph
+        :return: the set of connection holders for after dsg generation
         """
+
+        progress_bar = ProgressBar(
+            len(application_graph.edges),
+            "Generating connection holders for reporting connection data.")
 
         data_holders = dict()
         for edge in application_graph.edges:
@@ -32,6 +36,8 @@ class SpYNNakerConnectionHolderGenerator(object):
 
                 # store for the report generations
                 data_holders[(edge, synapse_information)] = connection_holder
+            progress_bar.update()
+        progress_bar.end()
 
         # return the two holders
         return data_holders

--- a/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
+++ b/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
@@ -1,0 +1,38 @@
+import logging
+from spynnaker.pyNN.models.neuron.connection_holder import ConnectionHolder
+
+logger = logging.getLogger(__name__)
+
+
+class SpYNNakerConnectionHolderGenerator(object):
+    """
+    method that sets up connection holders for reports to use.
+    """
+
+    def __call__(self, application_graph, graph_mapper):
+        """
+        :param application_graph:
+        :param graph_mapper:
+        :return:
+        """
+
+        data_holders = dict()
+        for edge in application_graph.edges:
+
+            # build connection holders
+            connection_holder = ConnectionHolder(
+                None, True, edge.pre_vertex.n_atoms,
+                edge.post_vertex.n_atoms)
+
+            # add pre run generators so that reports can extract without
+            # going to machine.
+            edge.post_vertex.add_pre_run_connection_holder(
+                connection_holder,
+                graph_mapper.get_application_edge(edge),
+                edge.synapse_information)
+
+            # store for the report generations
+            data_holders[edge] = connection_holder
+
+        # return the two holders
+        return data_holders

--- a/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
+++ b/spynnaker/pyNN/utilities/spynnaker_connection_holder_generations.py
@@ -26,13 +26,12 @@ class SpYNNakerConnectionHolderGenerator(object):
 
             # add pre run generators so that reports can extract without
             # going to machine.
-            edge.post_vertex.add_pre_run_connection_holder(
-                connection_holder,
-                graph_mapper.get_application_edge(edge),
-                edge.synapse_information)
+            for synapse_information in edge.synapse_information:
+                edge.post_vertex.add_pre_run_connection_holder(
+                    connection_holder, edge, synapse_information)
 
-            # store for the report generations
-            data_holders[edge] = connection_holder
+                # store for the report generations
+                data_holders[(edge, synapse_information)] = connection_holder
 
         # return the two holders
         return data_holders

--- a/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
@@ -13,14 +13,12 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
     """
     """
 
-    def __call__(self, report_folder, application_graph, connection_holder,
-                 dsg_targets):
+    def __call__(self, report_folder, application_graph):
         """
 
         :param report_folder: the report folder to put figure into
         :param application_graph: the app graph
         :param connection_holder: the set of connection holders
-        :param dsg_targets: the dsg to ensure dsg has been executed
         :return: None
         """
         try:
@@ -30,12 +28,6 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
                 "graphviz is required to use this report.  Please install"
                 " graphviz if you want to use this report.")
 
-        # verify that the dsg has been executed
-        if dsg_targets is None:
-            raise exceptions.SynapticConfigurationException(
-                "dsg targets should not be none, used as a check for "
-                "connection holder data to be generated")
-
         # create holders for data
         vertex_holders = dict()
         dot_diagram = graphviz.Digraph(
@@ -44,7 +36,7 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
         # build progress bar for the vertices, edges, and rendering
         progress_bar = ProgressBar(
             len(application_graph.vertices) +
-            len(connection_holder.keys()) + 1,
+            len(application_graph.edges) + 1,
             "generating the graphical representation of the neural network")
 
         # write vertices into dot diagram
@@ -59,19 +51,19 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
 
         # write edges into dot diagram
         for edge in application_graph.edges:
-                source_vertex_id = vertex_holders[edge.pre_vertex]
-                dest_vertex_id = vertex_holders[edge.post_vertex]
-                if isinstance(edge, ProjectionApplicationEdge):
-                    for synapse_info in edge.synapse_information:
-                        dot_diagram.edge(
-                            "{}".format(source_vertex_id),
-                            "{}".format(dest_vertex_id),
-                            "{}".format(synapse_info.connector))
-                else:
+            source_vertex_id = vertex_holders[edge.pre_vertex]
+            dest_vertex_id = vertex_holders[edge.post_vertex]
+            if isinstance(edge, ProjectionApplicationEdge):
+                for synapse_info in edge.synapse_information:
                     dot_diagram.edge(
                         "{}".format(source_vertex_id),
-                        "{}".format(dest_vertex_id))
-                progress_bar.update()
+                        "{}".format(dest_vertex_id),
+                        "{}".format(synapse_info.connector))
+            else:
+                dot_diagram.edge(
+                    "{}".format(source_vertex_id),
+                    "{}".format(dest_vertex_id))
+            progress_bar.update()
 
         # write dot file and generate pdf
         file_to_output = os.path.join(report_folder, "network_graph.gv")

--- a/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
@@ -1,0 +1,45 @@
+import logging
+import graphviz
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
+    """
+    """
+
+    def __call__(self, report_folder, application_graph, connection_holder):
+        """
+
+        :param report_folder:
+        :param application_graph:
+        :param connection_holder:
+        :return:
+        """
+
+        vertex_holders = dict()
+
+        dot_diagram = graphviz.Digraph(
+            comment="The graph of the network in graphical form")
+
+        vertex_counter = 0
+        for vertex in application_graph.vertices:
+            for atom in range(0, vertex.n_atoms):
+                dot_diagram.node(
+                    "{}:{}".format(vertex_counter, atom),
+                    "atom {} of {}".format(atom, vertex.label))
+                vertex_holders[vertex] = vertex_counter
+            vertex_counter += 1
+
+        for edge in connection_holder.keys():
+            connection_holder = connection_holder[edge]
+            for (source, destination, _, _) in connection_holder:
+                source_vertex_id = vertex_holders[edge.pre_vertex]
+                dest_vertex_id = vertex_holders[edge.post_vertex]
+                dot_diagram.edge(
+                    "{}:{}".format(source_vertex_id, source),
+                    "{}:{}".format(dest_vertex_id, destination))
+
+        file_to_output = os.path.join(report_folder, "visual_graph.gv")
+        dot_diagram.render(file_to_output, view=True)

--- a/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
@@ -50,4 +50,4 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
                         "{}_{}".format(dest_vertex_id, destination))
 
         file_to_output = os.path.join(report_folder, "visual_graph.gv")
-        dot_diagram.render(file_to_output, view=True)
+        dot_diagram.render(file_to_output, view=False)

--- a/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
@@ -1,6 +1,7 @@
 import logging
 import graphviz
 import os
+from spinn_machine.utilities.progress_bar import ProgressBar
 from spynnaker.pyNN import exceptions
 
 logger = logging.getLogger(__name__)
@@ -14,22 +15,31 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
                  dsg_targets):
         """
 
-        :param report_folder:
-        :param application_graph:
-        :param connection_holder:
-        :return:
+        :param report_folder: the report folder to put figure into
+        :param application_graph: the app graph
+        :param connection_holder: the set of connection holders
+        :param dsg_targets: the dsg to ensure dsg has been executed
+        :return: None
         """
 
+        # verify that the dsg has been exeucted
         if dsg_targets is None:
             raise exceptions.SynapticConfigurationException(
                 "dsg targets should not be none, used as a check for "
                 "connection holder data to be generated")
 
+        # create holders for data
         vertex_holders = dict()
-
         dot_diagram = graphviz.Digraph(
             comment="The graph of the network in graphical form")
 
+        # build prgress bar for the vertices, edges, and rendering
+        progress_bar = ProgressBar(
+            len(application_graph.vertices) +
+            len(connection_holder.keys()) + 1,
+            "generating the graphical representation of the neural network")
+
+        # write vertices into dot diagram
         vertex_counter = 0
         for vertex in application_graph.vertices:
             for atom in range(0, vertex.n_atoms):
@@ -38,7 +48,9 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
                     "atom {} of {}".format(atom, vertex.label))
                 vertex_holders[vertex] = vertex_counter
             vertex_counter += 1
+            progress_bar.update()
 
+        # write edges into dot diagram
         for edge, synapse_information in connection_holder.keys():
                 this_connection_holder = \
                     connection_holder[(edge, synapse_information)]
@@ -48,6 +60,10 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
                     dot_diagram.edge(
                         "{}_{}".format(source_vertex_id, source),
                         "{}_{}".format(dest_vertex_id, destination))
+                progress_bar.update()
 
+        # write dot file and generate pdf
         file_to_output = os.path.join(report_folder, "visual_graph.gv")
         dot_diagram.render(file_to_output, view=False)
+        progress_bar.update()
+        progress_bar.end()

--- a/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
@@ -1,6 +1,7 @@
 import logging
 import graphviz
 import os
+from spynnaker.pyNN import exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -9,7 +10,8 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
     """
     """
 
-    def __call__(self, report_folder, application_graph, connection_holder):
+    def __call__(self, report_folder, application_graph, connection_holder,
+                 dsg_targets):
         """
 
         :param report_folder:
@@ -17,6 +19,11 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
         :param connection_holder:
         :return:
         """
+
+        if dsg_targets is None:
+            raise exceptions.SynapticConfigurationException(
+                "dsg targets should not be none, used as a check for "
+                "connection holder data to be generated")
 
         vertex_holders = dict()
 
@@ -27,19 +34,20 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
         for vertex in application_graph.vertices:
             for atom in range(0, vertex.n_atoms):
                 dot_diagram.node(
-                    "{}:{}".format(vertex_counter, atom),
+                    "{}_{}".format(vertex_counter, atom),
                     "atom {} of {}".format(atom, vertex.label))
                 vertex_holders[vertex] = vertex_counter
             vertex_counter += 1
 
-        for edge in connection_holder.keys():
-            connection_holder = connection_holder[edge]
-            for (source, destination, _, _) in connection_holder:
-                source_vertex_id = vertex_holders[edge.pre_vertex]
-                dest_vertex_id = vertex_holders[edge.post_vertex]
-                dot_diagram.edge(
-                    "{}:{}".format(source_vertex_id, source),
-                    "{}:{}".format(dest_vertex_id, destination))
+        for edge, synapse_information in connection_holder.keys():
+                this_connection_holder = \
+                    connection_holder[(edge, synapse_information)]
+                for (source, destination, _, _) in this_connection_holder:
+                    source_vertex_id = vertex_holders[edge.pre_vertex]
+                    dest_vertex_id = vertex_holders[edge.post_vertex]
+                    dot_diagram.edge(
+                        "{}_{}".format(source_vertex_id, source),
+                        "{}_{}".format(dest_vertex_id, destination))
 
         file_to_output = os.path.join(report_folder, "visual_graph.gv")
         dot_diagram.render(file_to_output, view=True)

--- a/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
@@ -13,10 +13,13 @@ class SpYNNakerSynapticMatrixReport(object):
     """
 
     def __call__(self, report_folder, connection_holder, dsg_targets):
-
-        """converts synaptic matrix for every application edge.
-
+        """ converts synaptic matrix for every application edge.
         """
+
+        # Update the print options to display everything
+        import numpy
+        print_opts = numpy.get_printoptions()
+        numpy.set_printoptions(threshold=numpy.nan)
 
         if dsg_targets is None:
             raise exceptions.SynapticConfigurationException(
@@ -35,7 +38,7 @@ class SpYNNakerSynapticMatrixReport(object):
             "Generating synaptic matrix reports")
 
         # for each application edge, write matrix in new file
-        for application_edge, synapse_information in connection_holder.keys():
+        for application_edge, _ in connection_holder.keys():
 
             # only write matrix's for edges which have matrix's
             if isinstance(application_edge, ProjectionApplicationEdge):
@@ -61,5 +64,9 @@ class SpYNNakerSynapticMatrixReport(object):
                     output.write("{}".format(this_connection_holder))
                 output.flush()
                 output.close()
+
             progress.update()
         progress.end()
+
+        # Reset the print options
+        numpy.set_printoptions(**print_opts)

--- a/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
@@ -9,10 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 def generate_synaptic_matrix_reports(
-        common_report_directory, application_graph, machine_graph,
+        common_report_directory, application_graph,
         placements, txrx, routing_infos, graph_mapper,
         loaded_application_data_token, machine_time_step):
-    """converts synaptic matrix for every partitionable edge.
+
+    """converts synaptic matrix for every application edge.
 
     :param loaded_application_data_token: needs to be done after loaded
     :param routing_infos: routing information
@@ -36,7 +37,8 @@ def generate_synaptic_matrix_reports(
 
         if isinstance(application_edge, ProjectionApplicationEdge):
             file_name = os.path.join(
-                top_level_folder, "synaptic_matrix_for_partitionable_edge_{}"
+                top_level_folder,
+                "synaptic_matrix_for_application_edge_{}"
                                   .format(application_edge))
             output = None
             try:

--- a/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
@@ -8,73 +8,78 @@ from spynnaker.pyNN.models.neuron.connection_holder import ConnectionHolder
 logger = logging.getLogger(__name__)
 
 
-def generate_synaptic_matrix_reports(
-        common_report_directory, application_graph,
-        placements, txrx, routing_infos, graph_mapper,
-        loaded_application_data_token, machine_time_step):
-
-    """converts synaptic matrix for every application edge.
-
-    :param loaded_application_data_token: needs to be done after loaded
-    :param routing_infos: routing information
-    :param placements: placements
-    :param txrx: the spinnman instance
-    :param application_graph: the application graph
-    :param common_report_directory: the location for these reports
-    :param machine_graph: the machine graph
-    :param graph_mapper: the mapping between app and machine graphs.
-    :return: None
+class SpYNNakerSynapticMatrixReport(object):
+    """
+    generates the synmaptic matrix for reporting purposes
     """
 
-    if not loaded_application_data_token:
-        raise exceptions.SpynnakerException("Haven't loaded the app data yet.")
+    def __call__(
+            self, common_report_directory, application_graph,
+            placements, txrx, routing_infos, graph_mapper,
+            loaded_application_data_token, machine_time_step):
 
-    top_level_folder = os.path.join(common_report_directory,
-                                    "synaptic_matrix_reports")
-    if not os.path.exists(top_level_folder):
-        os.mkdir(top_level_folder)
-    for application_edge in application_graph.edges:
+        """converts synaptic matrix for every application edge.
 
-        if isinstance(application_edge, ProjectionApplicationEdge):
-            file_name = os.path.join(
-                top_level_folder,
-                "synaptic_matrix_for_application_edge_{}"
-                                  .format(application_edge))
-            output = None
-            try:
-                output = open(file_name, "w")
-            except IOError:
-                logger.error("Generate_placement_reports: Can't open file"
-                             " {} for writing.".format(file_name))
+        :param loaded_application_data_token: needs to be done after loaded
+        :param routing_infos: routing information
+        :param placements: placements
+        :param txrx: the spinnman instance
+        :param application_graph: the application graph
+        :param common_report_directory: the location for these reports
+        :param machine_graph: the machine graph
+        :param graph_mapper: the mapping between app and machine graphs.
+        :return: None
+        """
 
-            connection_holder = ConnectionHolder(
-                None, True, application_edge.pre_vertex.n_atoms,
-                application_edge.post_vertex.n_atoms)
+        if not loaded_application_data_token:
+            raise exceptions.SpynnakerException("Haven't loaded the app data yet.")
 
-            machine_edges = graph_mapper.get_machine_edges(application_edge)
+        top_level_folder = os.path.join(common_report_directory,
+                                        "synaptic_matrix_reports")
+        if not os.path.exists(top_level_folder):
+            os.mkdir(top_level_folder)
+        for application_edge in application_graph.edges:
 
-            progress = ProgressBar(
-                len(machine_edges),
-                "Getting synaptic matrix for projection between {} and {}"
-                .format(
-                    application_edge.pre_vertex.label,
-                    application_edge.post_vertex.label))
+            if isinstance(application_edge, ProjectionApplicationEdge):
+                file_name = os.path.join(
+                    top_level_folder,
+                    "synaptic_matrix_for_application_edge_{}"
+                                      .format(application_edge))
+                output = None
+                try:
+                    output = open(file_name, "w")
+                except IOError:
+                    logger.error("Generate_placement_reports: Can't open file"
+                                 " {} for writing.".format(file_name))
 
-            for machine_edge in machine_edges:
-                placement = placements.get_placement_of_vertex(
-                    machine_edge.post_vertex)
-                connections = application_edge.post_vertex.\
-                    get_connections_from_machine(
-                        txrx, placement, machine_edge, graph_mapper,
-                        routing_infos, application_edge.synapse_information[0],
-                        machine_time_step)
-                if connections is not None:
-                    connection_holder.add_connections(connections)
-                progress.update()
-            progress.end()
-            connection_holder.finish()
+                connection_holder = ConnectionHolder(
+                    None, True, application_edge.pre_vertex.n_atoms,
+                    application_edge.post_vertex.n_atoms)
 
-            output.write("{}".format(connection_holder))
+                machine_edges = graph_mapper.get_machine_edges(application_edge)
 
-            output.flush()
-            output.close()
+                progress = ProgressBar(
+                    len(machine_edges),
+                    "Getting synaptic matrix for projection between {} and {}"
+                    .format(
+                        application_edge.pre_vertex.label,
+                        application_edge.post_vertex.label))
+
+                for machine_edge in machine_edges:
+                    placement = placements.get_placement_of_vertex(
+                        machine_edge.post_vertex)
+                    connections = application_edge.post_vertex.\
+                        get_connections_from_machine(
+                            txrx, placement, machine_edge, graph_mapper,
+                            routing_infos, application_edge.synapse_information[0],
+                            machine_time_step)
+                    if connections is not None:
+                        connection_holder.add_connections(connections)
+                    progress.update()
+                progress.end()
+                connection_holder.finish()
+
+                output.write("{}".format(connection_holder))
+
+                output.flush()
+                output.close()

--- a/spynnaker/spynnaker.cfg
+++ b/spynnaker/spynnaker.cfg
@@ -39,7 +39,7 @@ critical =
 # writeRouterReports: If True, each router file is written in
 #                 text format to reports/routers
 reportsEnabled = True
-writeSynapticReport = False
+writeSynapticReport = True
 writeTextSpecs = False
 writePartitionerReports = True
 writeApplicationGraphPlacerReport = True

--- a/spynnaker/spynnaker.cfg
+++ b/spynnaker/spynnaker.cfg
@@ -52,7 +52,7 @@ writeNetworkSpecificationReport = True
 writeProvenanceData = True
 writeTagAllocationReports = True
 writeAlgorithmTimings = True
-draw_network_graph = False
+draw_network_graph = True
 writeReloadSteps = False
 # options are DEFAULT (hard coded location) or a file path
 defaultReportFilePath = DEFAULT

--- a/spynnaker/spynnaker.cfg
+++ b/spynnaker/spynnaker.cfg
@@ -52,7 +52,7 @@ writeNetworkSpecificationReport = True
 writeProvenanceData = True
 writeTagAllocationReports = True
 writeAlgorithmTimings = True
-draw_network_graph = True
+draw_network_graph = False
 writeReloadSteps = False
 # options are DEFAULT (hard coded location) or a file path
 defaultReportFilePath = DEFAULT

--- a/spynnaker/spynnaker.cfg
+++ b/spynnaker/spynnaker.cfg
@@ -39,7 +39,7 @@ critical =
 # writeRouterReports: If True, each router file is written in
 #                 text format to reports/routers
 reportsEnabled = True
-writeSynapticReport = True
+writeSynapticReport = False
 writeTextSpecs = False
 writePartitionerReports = True
 writeApplicationGraphPlacerReport = True
@@ -52,7 +52,8 @@ writeNetworkSpecificationReport = True
 writeProvenanceData = True
 writeTagAllocationReports = True
 writeAlgorithmTimings = True
-draw_network_graph = True
+# Note: graphviz is required to draw the graph
+draw_network_graph = False
 writeReloadSteps = False
 # options are DEFAULT (hard coded location) or a file path
 defaultReportFilePath = DEFAULT

--- a/spynnaker/spynnaker.cfg
+++ b/spynnaker/spynnaker.cfg
@@ -52,6 +52,7 @@ writeNetworkSpecificationReport = True
 writeProvenanceData = True
 writeTagAllocationReports = True
 writeAlgorithmTimings = True
+draw_network_graph = True
 writeReloadSteps = False
 # options are DEFAULT (hard coded location) or a file path
 defaultReportFilePath = DEFAULT


### PR DESCRIPTION
supports using graphviz to get a diagram of the network being loaded (after filtering and machine graph generation). 

requires the end user to have installed graphviz, so the main installation pages needs a update when this is merged in. 

- [x] got graphviz to use connection holders and to generate figure
- [x] updated the synaptic report to use the connection holders as well. much faster this way.
- [x] documented the changes.
- [x] tested with basic examples. Due to how little is interlinked, this seems a good enough test.
- [x] reviewed by Alan
- [ ] reviewed by Rowley.