### PR TITLE
Support for only running the integration tests in a nightly build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: python
-matrix:
-  include:
-    - python: "2.7"
-    - pytest
+python:
+  - "2.7"
 
 virtualenv:
   system_site_packages: true
-
-env:
-  - READTHEDOCS=True
 
 cache: pip
 
@@ -38,6 +33,9 @@ before_script:
 
 script:
   - py.test unittests
+  - if [ "x${TRAVIS_EVENT_TYPE}" = "xcron" ]; then
+      py.test p7_integration_tests;
+    fi
   - flake8 examples spynnaker pyNN-spiNNaker-src
   - flake8 unittests
   - flake8 p7_integration_tests


### PR DESCRIPTION
This is the set of changes needed to support just running the integration tests as part of a nightly build.