### PR TITLE
Fix delays int 0

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -357,10 +357,10 @@ class AbstractConnector(object):
     def _generate_delays(self, values, n_connections, connection_slices):
         """ Generate valid delay values
         """
-        
+
         # Ensure datatype is float to facilitate clipping
-        values = float(values)        
-        
+        values = float(values)
+
         delays = self._generate_values(
             values, n_connections, connection_slices)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -295,14 +295,14 @@ class AbstractConnector(object):
     def _generate_values(self, values, n_connections, connection_slices):
         if globals_variables.get_simulator().is_a_pynn_random(values):
             if n_connections == 1:
-                return numpy.array([values.next(n_connections)])
+                return numpy.array([values.next(n_connections)], dtype="float64")
             return values.next(n_connections)
         elif numpy.isscalar(values):
-            return numpy.repeat([values], n_connections)
+            return numpy.repeat([values], n_connections).astype("float64")
         elif hasattr(values, "__getitem__"):
             return numpy.concatenate([
                 values[connection_slice]
-                for connection_slice in connection_slices])
+                for connection_slice in connection_slices]).astype("float64")
         elif isinstance(values, basestring) or callable(values):
             if self._space is None:
                 raise Exception(
@@ -357,9 +357,6 @@ class AbstractConnector(object):
     def _generate_delays(self, values, n_connections, connection_slices):
         """ Generate valid delay values
         """
-
-        # Ensure datatype is float to facilitate clipping
-        values = float(values)
 
         delays = self._generate_values(
             values, n_connections, connection_slices)

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -295,7 +295,8 @@ class AbstractConnector(object):
     def _generate_values(self, values, n_connections, connection_slices):
         if globals_variables.get_simulator().is_a_pynn_random(values):
             if n_connections == 1:
-                return numpy.array([values.next(n_connections)], dtype="float64")
+                return numpy.array([values.next(n_connections)],
+                                   dtype="float64")
             return values.next(n_connections)
         elif numpy.isscalar(values):
             return numpy.repeat([values], n_connections).astype("float64")

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -357,6 +357,10 @@ class AbstractConnector(object):
     def _generate_delays(self, values, n_connections, connection_slices):
         """ Generate valid delay values
         """
+        
+        # Ensure datatype is float to facilitate clipping
+        values = float(values)        
+        
         delays = self._generate_values(
             values, n_connections, connection_slices)
 


### PR DESCRIPTION
Enabling a delay of '0' to be specified as an integer, but still be clipped to a single timestep (rather than zero, which results in a 16 timestep delay).