### PR TITLE
Encoding and decoding of binary data should use precompiled patterns.

### DIFF
--- a/spynnaker/pyNN/models/common/eieio_spike_recorder.py
+++ b/spynnaker/pyNN/models/common/eieio_spike_recorder.py
@@ -6,6 +6,7 @@ import struct
 import logging
 
 logger = logging.getLogger(__name__)
+_ONE_WORD = struct.Struct("<I")
 
 
 class EIEIOSpikeRecorder(object):
@@ -60,7 +61,7 @@ class EIEIOSpikeRecorder(object):
 
             offset = 0
             while offset < number_of_bytes_written:
-                length = struct.unpack_from("<I", spike_data, offset)[0]
+                length = _ONE_WORD.unpack_from(spike_data, offset)[0]
                 data_offset = offset + 4
                 eieio_header = EIEIODataHeader.from_bytestring(
                     spike_data, data_offset)

--- a/spynnaker/pyNN/models/common/recording_utils.py
+++ b/spynnaker/pyNN/models/common/recording_utils.py
@@ -7,8 +7,7 @@ import logging
 import numpy
 
 logger = logging.getLogger(__name__)
-
-_RECORDING_COUNT_SIZE = 4
+_RECORDING_COUNT = struct.Struct("<I")
 
 
 def get_recording_region_size_in_bytes(
@@ -30,11 +29,11 @@ def get_data(transceiver, placement, region, region_size):
         placement, region, transceiver)
     number_of_bytes_written_buf = buffer(transceiver.read_memory(
         placement.x, placement.y, region_base_address, 4))
-    number_of_bytes_written = struct.unpack_from(
-        "<I", number_of_bytes_written_buf)[0]
+    number_of_bytes_written = _RECORDING_COUNT.unpack_from(
+        number_of_bytes_written_buf)[0]
 
     # Subtract 4 for the word representing the size itself
-    expected_size = region_size - _RECORDING_COUNT_SIZE
+    expected_size = region_size - _RECORDING_COUNT.size
     if number_of_bytes_written > expected_size:
         raise MemReadException(
             "Expected {} bytes but read {}".format(

--- a/spynnaker/pyNN/models/neuron/master_pop_table_generators/master_pop_table_as_binary_search.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table_generators/master_pop_table_as_binary_search.py
@@ -15,6 +15,7 @@ import sys
 import math
 
 logger = logging.getLogger(__name__)
+_TWO_WORDS = struct.Struct("<II")
 
 
 class _MasterPopEntry(object):
@@ -260,7 +261,7 @@ class MasterPopTableAsBinarySearch(AbstractMasterPopTableFactory):
         # get entries in master pop
         count_data = txrx.read_memory(
             chip_x, chip_y, master_pop_base_mem_address, 8)
-        n_entries, n_addresses = struct.unpack("<II", buffer(count_data))
+        n_entries, n_addresses = _TWO_WORDS.unpack(buffer(count_data))
         n_entry_bytes = (
             n_entries * _MasterPopEntry.MASTER_POP_ENTRY_SIZE_BYTES)
         n_address_bytes = (

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -47,6 +47,8 @@ _SYNAPSES_BASE_N_CPU_CYCLES = 8
 # Amount to scale synapse SDRAM estimate by to make sure the synapses fit
 _SYNAPSE_SDRAM_OVERSCALE = 1.1
 
+_ONE_WORD = struct.Struct("<I")
+
 
 class SynapticManager(object):
     """ Deals with synapses
@@ -813,8 +815,8 @@ class SynapticManager(object):
             transceiver)
         direct_synapses_address = (
             self._get_static_synaptic_matrix_sdram_requirements() +
-            synaptic_matrix_address + struct.unpack_from(
-                "<I", str(transceiver.read_memory(
+            synaptic_matrix_address + _ONE_WORD.unpack_from(
+                str(transceiver.read_memory(
                     placement.x, placement.y, synaptic_matrix_address, 4)))[0])
         indirect_synapses_address = synaptic_matrix_address + 4
         data, max_row_length = self._retrieve_synaptic_block(


### PR DESCRIPTION
I was reading through the [struct documentation](https://docs.python.org/2/library/struct.html#classes) and I noted that it said

 > "Creating a Struct object once and calling its methods is more efficient than calling the struct functions with the same format since the format string only needs to be compiled once."
 
which I think is highly relevant to us, especially in an area that is a bit of a bottleneck. And this is a feature of a core Python library that we already use too.