### PR TITLE
multiple_executable_per_run

### DIFF
--- a/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
@@ -16,7 +16,7 @@ from spinn_front_end_common.abstract_models\
     import AbstractProvidesOutgoingPartitionConstraints
 from spinn_front_end_common.abstract_models.impl import \
     ProvidesKeyToAtomMappingImpl
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.abstract_models \
     import AbstractVertexWithEdgeToDependentVertices
 from spinn_front_end_common.interface.simulation import simulation_utilities
@@ -188,7 +188,7 @@ class MunichMotorDevice(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     def reserve_memory_regions(self, spec):
         """

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -26,7 +26,7 @@ from spinn_front_end_common.abstract_models.impl\
 from spinn_front_end_common.utilities import constants as common_constants
 from spinn_front_end_common.utilities import helpful_functions
 from spinn_front_end_common.utilities import globals_variables
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.interface.simulation import simulation_utilities
 from spinn_front_end_common.interface.buffer_management\
     import recording_utilities
@@ -595,7 +595,7 @@ class AbstractPopulationVertex(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     @overrides(AbstractSpikeRecordable.is_recording_spikes)
     def is_recording_spikes(self):

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson.py
@@ -30,7 +30,7 @@ from spinn_front_end_common.abstract_models \
 from spinn_front_end_common.abstract_models.impl\
     import ProvidesKeyToAtomMappingImpl
 from spinn_front_end_common.utilities import globals_variables
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 from spynnaker.pyNN.models.common.abstract_spike_recordable \
     import AbstractSpikeRecordable
@@ -717,7 +717,7 @@ class SpikeSourcePoisson(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     @overrides(AbstractSpikeRecordable.get_spikes)
     def get_spikes(

--- a/spynnaker/pyNN/models/utility_models/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delay_extension_vertex.py
@@ -19,7 +19,7 @@ from spinn_front_end_common.abstract_models \
 from spinn_front_end_common.abstract_models import \
     AbstractProvidesOutgoingPartitionConstraints
 from spinn_front_end_common.interface.simulation import simulation_utilities
-from spinn_front_end_common.utilities.utility_objs import ExecutableStartType
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
 from spynnaker.pyNN.models.utility_models.delay_block import DelayBlock
 from spinn_front_end_common.abstract_models \
@@ -261,7 +261,7 @@ class DelayExtensionVertex(
 
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
-        return ExecutableStartType.USES_SIMULATION_INTERFACE
+        return ExecutableType.USES_SIMULATION_INTERFACE
 
     def get_n_keys_for_partition(self, partition, graph_mapper):
         vertex_slice = graph_mapper.get_slice(partition.pre_vertex)


### PR DESCRIPTION
supports the ability to have multiple executableTypes running on the same application. Mainly used for reinjector and extra monitor support (which are to follow pull requests in future). 

this depends upon a FEC pull request
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/214