### PR TITLE
Fix buffered out

### DIFF
--- a/neural_modelling/src/neuron/c_main.c
+++ b/neural_modelling/src/neuron/c_main.c
@@ -57,7 +57,7 @@ typedef enum extra_provenance_data_region_entries{
 
 //! values for the priority for each callback
 typedef enum callback_priorities{
-    MC = -1, SDP_AND_DMA_AND_USER = 0, TIMER_AND_BUFFERING = 2
+    MC = -1, DMA = 0, USER = 0, SDP = 1, TIMER = 2
 } callback_priorities;
 
 //! The number of regions that are to be used for recording
@@ -122,7 +122,7 @@ static bool initialise(uint32_t *timer_period) {
     if (!simulation_initialise(
             data_specification_get_region(SYSTEM_REGION, address),
             APPLICATION_NAME_HASH, timer_period, &simulation_ticks,
-            &infinite_run, SDP_AND_DMA_AND_USER, SDP_AND_DMA_AND_USER)) {
+            &infinite_run, SDP, DMA)) {
         return false;
     }
     simulation_set_provenance_function(
@@ -178,7 +178,7 @@ static bool initialise(uint32_t *timer_period) {
     }
 
     if (!spike_processing_initialise(
-            row_max_n_words, MC, SDP_AND_DMA_AND_USER,
+            row_max_n_words, MC, USER,
             incoming_spike_buffer_size)) {
         return false;
     }
@@ -283,7 +283,7 @@ void c_main(void) {
     spin1_set_timer_tick(timer_period);
 
     // Set up the timer tick callback (others are handled elsewhere)
-    spin1_callback_on(TIMER_TICK, timer_callback, TIMER_AND_BUFFERING);
+    spin1_callback_on(TIMER_TICK, timer_callback, TIMER);
 
     simulation_run();
 }

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -632,7 +632,7 @@ class AbstractPopulationVertex(
         return self._neuron_recorder.get_data(
             self.label, buffer_manager, self.RECORDING_REGION[variable],
             placements, graph_mapper, self, machine_time_step,
-            self.VARIABLE_LONG[variable])
+            self.VARIABLE_LONG[variable], n_machine_time_steps)
 
     @overrides(AbstractPopulationInitializable.initialize)
     def initialize(self, variable, value):

--- a/spynnaker/pyNN/spynnaker.cfg
+++ b/spynnaker/pyNN/spynnaker.cfg
@@ -56,7 +56,7 @@ gsyn_buffer_size = 2097152
 
 # Advanced parameters to further control buffering
 buffer_size_before_receive = 16384
-time_between_requests = 50
+time_between_requests = 250
 
 minimum_buffer_sdram = 1048576
 


### PR DESCRIPTION
This mostly fixes what happens when the data contains missing sections, by adding a "NaN" value at these points.  This appears to work correctly when graphing, although the graphs then stop at the first NaN.

- [ ] Wait for merge of SpiNNakerManchester/SpiNNFrontEndCommon#222