### PR TITLE
Fix if curr alpha max atoms per core default

### DIFF
--- a/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
@@ -13,6 +13,7 @@ from spynnaker.pyNN.models.neuron.threshold_types.threshold_type_static \
 # global objects
 DEFAULT_MAX_ATOMS_PER_CORE = 255
 
+
 class IFCurrAlpha(AbstractPopulationVertex):
     """ Leaky integrate and fire neuron with an alpha-shaped current-based
      input

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
@@ -10,6 +10,8 @@ from spynnaker.pyNN.models.neuron.input_types.input_type_current \
 from spynnaker.pyNN.models.neuron.threshold_types.threshold_type_static \
     import ThresholdTypeStatic
 
+# global objects
+DEFAULT_MAX_ATOMS_PER_CORE = 255
 
 class IFCurrAlpha(AbstractPopulationVertex):
     """ Leaky integrate and fire neuron with an alpha-shaped current-based
@@ -87,5 +89,5 @@ class IFCurrAlpha(AbstractPopulationVertex):
         return IFCurrAlpha._model_based_max_atoms_per_core
 
     @staticmethod
-    def set_model_max_atoms_per_core(new_value):
+    def set_model_max_atoms_per_core(new_value=DEFAULT_MAX_ATOMS_PER_CORE):
         IFCurrAlpha._model_based_max_atoms_per_core = new_value

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
@@ -20,7 +20,7 @@ class IFCurrAlpha(AbstractPopulationVertex):
     """
 
     # noinspection PyPep8Naming
-    _model_based_max_atoms_per_core = 255
+    _model_based_max_atoms_per_core = DEFAULT_MAX_ATOMS_PER_CORE
 
     default_parameters = {
         'tau_m': 20.0,


### PR DESCRIPTION
Small fix to add a default entry to the set max atoms per core function (which is called on reset without an argument)