### PR TITLE
Fixed number connectors

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -25,6 +25,7 @@ class FixedNumberPostConnector(AbstractConnector):
         AbstractConnector.__init__(self, safe, verbose)
         self._n_post = n
         self._allow_self_connections = allow_self_connections
+        self._verbose = verbose
         self._post_neurons_set = False
 
     def get_delay_maximum(self):
@@ -95,6 +96,12 @@ class FixedNumberPostConnector(AbstractConnector):
 
                 # Sort the neurons now that we have them
                 self._post_neurons[m].sort()
+
+                # If verbose then output the list connected to this pre-neuron
+                if self._verbose:
+                    print 'pre-neuron ', m, ' connects to post-neurons '
+                    print self._post_neurons[m]
+
         return self._post_neurons
 
     def _post_neurons_in_slice(self, post_vertex_slice, n):

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -46,6 +46,16 @@ class FixedNumberPostConnector(AbstractConnector):
             self._post_neurons_set = True
             self._rng_parameters = self.get_rng_parameters(
                 self._n_post_neurons)
+            # if verbose open a file to output the connectivity
+            if self._verbose:
+                filename = self._pre_population.label+'_to_'+\
+                    self._post_population.label+'_fixednumberpost-conn.csv'
+                print 'Output post-connectivity to ', filename
+                file_handle = file(filename, 'w')
+                numpy.savetxt(file_handle,
+                              [(self._n_pre_neurons, self._n_post_neurons,
+                                self._n_post)],
+                              fmt="%u,%u,%u")
 
         # Loop over all the pre neurons
         for m in range(0, self._n_pre_neurons):
@@ -99,8 +109,9 @@ class FixedNumberPostConnector(AbstractConnector):
 
                 # If verbose then output the list connected to this pre-neuron
                 if self._verbose:
-                    print 'pre-neuron ', m, ' connects to post-neurons '
-                    print self._post_neurons[m]
+                    numpy.savetxt(file_handle,
+                                  self._post_neurons[m][None, :],
+                                  fmt=("%u,"*(self._n_post-1)+"%u"))
 
         return self._post_neurons
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -44,8 +44,6 @@ class FixedNumberPostConnector(AbstractConnector):
         if not self._post_neurons_set:
             self._post_neurons = [None] * self._n_pre_neurons
             self._post_neurons_set = True
-#            self._rng_parameters = self.get_rng_parameters(
-#                self._n_post_neurons)
 
             # if verbose open a file to output the connectivity
             if self._verbose:
@@ -95,41 +93,6 @@ class FixedNumberPostConnector(AbstractConnector):
                         self._n_post_neurons, self._n_post,
                         self.with_replacement)
 
-#                 I'm leaving this here to revisit in the future -
-#                 I don't think it's working as intended, but whether
-#                 we want to rely on numpy.random.choice is another question
-#
-#                 if self.with_replacement:
-#                     # We use numpy.random.choice
-#                     self._post_neurons[m] = numpy.random.choice(
-#                         self._n_post_neurons, self._n_post,
-#                         self.with_replacement)
-#                 elif self._n_post > self._n_post_neurons:
-#                     # Throw an exception
-#                     raise SpynnakerException(
-#                         "FixedNumberPostConnector will not work when "
-#                         "with_replacement=False and n > n_post_neurons")
-#                 else:
-#                     # We can't use numpy.random.choice, so we
-#                     # use a different method of selection
-#                     n = 0
-#                     while (n < self._n_post):
-#                         permutation = numpy.arange(self._n_post_neurons)
-#                         for i in range(0, self._n_post_neurons - 1):
-#                             j = int(self._rng.next(
-#                                 n=1, distribution="uniform",
-#                                 parameters=self._rng_parameters))
-#                             (permutation[i], permutation[j]) = (
-#                                 permutation[j], permutation[i])
-#                         n += self._n_post_neurons
-#                         if self._post_neurons[m] is None:
-#                             self._post_neurons[m] = permutation
-#                         else:
-#                             self._post_neurons[m] = numpy.append(
-#                                 self._post_neurons, permutation)
-#                     self._post_neurons[m] = self._post_neurons[
-#                         m][:self._n_post]
-
                 # Sort the neurons now that we have them
                 self._post_neurons[m].sort()
 
@@ -166,11 +129,10 @@ class FixedNumberPostConnector(AbstractConnector):
         n_connections = 0
         lo = pre_vertex_slice.lo_atom
         hi = pre_vertex_slice.hi_atom
-        for n in range(0, self._n_pre_neurons):
-            if (n >= lo and n <= hi):
-                n_connections = max(n_connections,
-                                    len(self._post_neurons_in_slice(
-                                        post_vertex_slice, n)))
+        for n in range(lo, hi + 1):
+            n_connections = max(n_connections,
+                                len(self._post_neurons_in_slice(
+                                    post_vertex_slice, n)))
 
         if min_delay is None or max_delay is None:
             return n_connections
@@ -203,10 +165,9 @@ class FixedNumberPostConnector(AbstractConnector):
         n_connections = 0
         lo = pre_vertex_slice.lo_atom
         hi = pre_vertex_slice.hi_atom
-        for n in range(0, self._n_pre_neurons):
-            if (n >= lo and n <= hi):
-                n_connections += len(self._post_neurons_in_slice(
-                    post_vertex_slice, n))
+        for n in range(lo, hi + 1):
+            n_connections += len(self._post_neurons_in_slice(
+                post_vertex_slice, n))
 
         return self._get_weight_maximum(
             self._weights, n_connections, None)
@@ -236,61 +197,27 @@ class FixedNumberPostConnector(AbstractConnector):
 
         # Get number of connections
         n_connections = 0
-        for n in range(0, self._n_pre_neurons):
-            if (n >= lo and n <= hi):
-                n_connections += len(
-                    self._post_neurons_in_slice(post_vertex_slice, n))
-
-        # If self-connections are not allowed then subtract those connections
-        if (not self._allow_self_connections and
-                pre_vertex_slice is post_vertex_slice):
-            for n in range(0, self._n_pre_neurons):
-                if (n >= lo and n <= hi):
-                    post_neurons = self._post_neurons_in_slice(
-                        post_vertex_slice, n)
-                    for m in range(0, len(post_neurons)):
-                        if (n == post_neurons[m]):
-                            n_connections -= 1
+        for n in range(lo, hi + 1):
+            n_connections += len(
+                self._post_neurons_in_slice(post_vertex_slice, n))
 
         # Set up the block
         block = numpy.zeros(
             n_connections, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
 
-        # If self connections not allowed set up source and target accordingly
-        if (not self._allow_self_connections and
-                pre_vertex_slice is post_vertex_slice):
-            pre_neurons_in_slice = []
-            post_neurons_in_slice = []
-            pre_vertex_array = numpy.arange(
-                pre_vertex_slice.lo_atom, pre_vertex_slice.hi_atom + 1)
-            for n in range(0, self._n_pre_neurons):
-                if (n >= lo and n <= hi):
-                    post_neurons = self._post_neurons_in_slice(
-                        post_vertex_slice, n)
-                    for m in range(0, len(post_neurons)):
-                        if (n != post_neurons[m]):
-                            post_neurons_in_slice.append(post_neurons[m])
-                            pre_neurons_in_slice.append(
-                                pre_vertex_array[n-pre_vertex_slice.lo_atom])
+        # Set up source and target
+        pre_neurons_in_slice = []
+        post_neurons_in_slice = []
+        pre_vertex_array = numpy.arange(lo, hi + 1)
+        for n in range(lo, hi + 1):  # 0, self._n_pre_neurons):
+            post_neurons = self._post_neurons_in_slice(
+                post_vertex_slice, n)
+            for m in range(0, len(post_neurons)):
+                post_neurons_in_slice.append(post_neurons[m])
+                pre_neurons_in_slice.append(pre_vertex_array[n-lo])
 
-            block["source"] = pre_neurons_in_slice
-            block["target"] = post_neurons_in_slice
-        else:
-            pre_neurons_in_slice = []
-            post_neurons_in_slice = []
-            pre_vertex_array = numpy.arange(
-                pre_vertex_slice.lo_atom, pre_vertex_slice.hi_atom + 1)
-            for n in range(0, self._n_pre_neurons):
-                if (n >= lo and n <= hi):
-                    post_neurons = self._post_neurons_in_slice(
-                        post_vertex_slice, n)
-                    for m in range(0, len(post_neurons)):
-                        post_neurons_in_slice.append(post_neurons[m])
-                        pre_neurons_in_slice.append(
-                            pre_vertex_array[n-pre_vertex_slice.lo_atom])
-
-            block["source"] = pre_neurons_in_slice
-            block["target"] = post_neurons_in_slice
+        block["source"] = pre_neurons_in_slice
+        block["target"] = post_neurons_in_slice
 
         block["weight"] = self._generate_weights(
             self._weights, n_connections, None)

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -77,7 +77,8 @@ class FixedNumberPostConnector(AbstractConnector):
                         else:
                             self._post_neurons[m] = numpy.append(
                                 self._post_neurons, permutation)
-                    self._post_neurons[m] = self._post_neurons[m][:self._n_post]
+                    self._post_neurons[m] = self._post_neurons[
+                        m][:self._n_post]
 
                 # Sort the neurons now that we have them
                 self._post_neurons[m].sort()

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -35,7 +35,17 @@ class FixedNumberPostConnector(AbstractConnector):
     def get_delay_variance(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return 0.0
         return self._get_delay_variance(self._delays, None)
 
@@ -122,7 +132,17 @@ class FixedNumberPostConnector(AbstractConnector):
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             min_delay=None, max_delay=None):
 
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return 0
 
         n_connections = 0
@@ -143,21 +163,51 @@ class FixedNumberPostConnector(AbstractConnector):
     def get_n_connections_to_post_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return 0
         return self._n_post
 
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return 0.0
         return self._get_weight_mean(self._weights, None)
 
     def get_weight_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return 0.0
 
         # Get n_connections by adding length of each set of post neurons
@@ -174,7 +224,17 @@ class FixedNumberPostConnector(AbstractConnector):
     def get_weight_variance(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return 0.0
         return self._get_weight_variance(self._weights, None)
 
@@ -187,7 +247,17 @@ class FixedNumberPostConnector(AbstractConnector):
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             synapse_type):
-        if not self._is_connected(post_vertex_slice, 0):
+        # Get lo and hi for the pre vertex
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(post_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == pre_vertex_slice.n_atoms):
             return numpy.zeros(0, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
 
         # Get lo and hi for the pre vertex

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -147,7 +147,6 @@ class FixedNumberPostConnector(AbstractConnector):
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             min_delay=None, max_delay=None):
-
         # Get lo and hi for the pre vertex
         lo = pre_vertex_slice.lo_atom
         hi = pre_vertex_slice.hi_atom

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -81,6 +81,7 @@ class FixedNumberPostConnector(AbstractConnector):
             return 0
 
         # Need to edit this
+        n_connections = 0
         for n in range(0, self._n_pre_neurons):
             n_connections += len(
                 self._post_neurons_in_slice(post_vertex_slice, n))
@@ -118,7 +119,7 @@ class FixedNumberPostConnector(AbstractConnector):
         hi = pre_vertex_slice.hi_atom
         for n in range(0, self._n_pre_neurons):
             if (n >= lo and n <= hi):
-                n_conections += len(self._post_neurons_in_slice(
+                n_connections += len(self._post_neurons_in_slice(
                     post_vertex_slice, n))
 
         return self._get_weight_maximum(
@@ -148,7 +149,7 @@ class FixedNumberPostConnector(AbstractConnector):
         hi = pre_vertex_slice.hi_atom
 
         # Get number of connections
-        n_conections = 0
+        n_connections = 0
         for n in range(0, self._n_pre_neurons):
             if (n >= lo and n <= hi):
                 n_connections += len(

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -48,8 +48,8 @@ class FixedNumberPostConnector(AbstractConnector):
                 self._n_post_neurons)
             # if verbose open a file to output the connectivity
             if self._verbose:
-                filename = self._pre_population.label+'_to_'+\
-                    self._post_population.label+'_fixednumberpost-conn.csv'
+                filename = self._pre_population.label + '_to_' + \
+                    self._post_population.label + '_fixednumberpost-conn.csv'
                 print 'Output post-connectivity to ', filename
                 file_handle = file(filename, 'w')
                 numpy.savetxt(file_handle,

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -49,7 +49,8 @@ class FixedNumberPostConnector(AbstractConnector):
         # Loop over all the pre neurons
         for m in range(0, self._n_pre_neurons):
             if self._post_neurons[m] is None:
-                if not self.with_replacement and self._n_post > self._n_post_neurons:
+                if (not self.with_replacement and
+                        self._n_post > self._n_post_neurons):
                     raise SpynnakerException(
                         "FixedNumberPostConnector will not work when "
                         "with_replacement=False and n > n_post_neurons")
@@ -57,6 +58,10 @@ class FixedNumberPostConnector(AbstractConnector):
                 self._post_neurons[m] = numpy.random.choice(
                     self._n_post_neurons, self._n_post, self.with_replacement)
 
+#                 I'm leaving this here to revisit in the future -
+#                 I don't think it's working as intended, but whether
+#                 we want to rely on numpy.random.choice is another question
+#
 #                 if self.with_replacement:
 #                     # We use numpy.random.choice
 #                     self._post_neurons[m] = numpy.random.choice(
@@ -114,7 +119,6 @@ class FixedNumberPostConnector(AbstractConnector):
         if not self._is_connected(post_vertex_slice, 0):
             return 0
 
-        # Need to edit this
         n_connections = 0
         lo = pre_vertex_slice.lo_atom
         hi = pre_vertex_slice.hi_atom
@@ -125,11 +129,10 @@ class FixedNumberPostConnector(AbstractConnector):
                                         post_vertex_slice, n)))
 
         if min_delay is None or max_delay is None:
-            return n_connections  # pre_vertex_slice.n_atoms
+            return n_connections
 
         return self._get_n_connections_from_pre_vertex_with_delay_maximum(
             self._delays, self._n_post * self._n_pre_neurons,
-#            pre_vertex_slice.n_atoms, None, min_delay, max_delay)
             n_connections, None, min_delay, max_delay)
 
     def get_n_connections_to_post_vertex_maximum(
@@ -137,7 +140,7 @@ class FixedNumberPostConnector(AbstractConnector):
             post_slice_index, pre_vertex_slice, post_vertex_slice):
         if not self._is_connected(post_vertex_slice, 0):
             return 0
-        return self._n_post  # pre_vertex_slice.n_atoms
+        return self._n_post
 
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -76,7 +76,6 @@ class FixedNumberPostConnector(AbstractConnector):
                 # If the pre and post populations are the same
                 # then deal with allow_self_connections=False
                 if (self._pre_population is self._post_population and
-                        not self.with_replacement and
                         not self._allow_self_connections):
                     # Exclude the current pre-neuron from the post-neuron list
                     no_self_post_neurons = []

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -13,19 +13,28 @@ class FixedNumberPostConnector(AbstractConnector):
     """
 
     def __init__(
-            self, n, allow_self_connections=True, safe=True, verbose=False):
+            self, n, allow_self_connections=True, with_replacement=False,
+            safe=True, verbose=False):
         """
         :param `int` n:
-            number of random post-synaptic neurons connected to output
+            number of random post-synaptic neurons connected to pre-neurons
         :param `bool` allow_self_connections:
             if the connector is used to connect a
             Population to itself, this flag determines whether a neuron is
             allowed to connect to itself, or only to other neurons in the
             Population.
+        :param `bool` with_replacement:
+            this flag determines how the random selection of post-synaptic
+            neurons is performed; if true, then every post-synaptic neuron
+            can be chosen on each occasion, and so multiple connections
+            between neuron pairs are possible; if false, then once a post-
+            synaptic neuron has been connected to a pre-neuron, it can't be
+            connected again
         """
         AbstractConnector.__init__(self, safe, verbose)
         self._n_post = n
         self._allow_self_connections = allow_self_connections
+        self._with_replacement = with_replacement
         self._verbose = verbose
         self._post_neurons_set = False
         self._p_connect = 1.0  # used for getting maxima
@@ -71,13 +80,13 @@ class FixedNumberPostConnector(AbstractConnector):
         # Loop over all the pre neurons
         for m in range(0, self._n_pre_neurons):
             if self._post_neurons[m] is None:
-                if (not self.with_replacement and
+                if (not self._with_replacement and
                         self._n_post > self._n_post_neurons):
                     raise SpynnakerException(
                         "FixedNumberPostConnector will not work when "
                         "with_replacement=False and n > n_post_neurons")
 
-                if (not self.with_replacement and
+                if (not self._with_replacement and
                         not self._allow_self_connections and
                         self._n_post == self._n_post_neurons):
                     raise SpynnakerException(
@@ -98,11 +107,11 @@ class FixedNumberPostConnector(AbstractConnector):
                     # Now use this list in the random choice
                     self._post_neurons[m] = numpy.random.choice(
                         no_self_post_neurons, self._n_post,
-                        self.with_replacement)
+                        self._with_replacement)
                 else:
                     self._post_neurons[m] = numpy.random.choice(
                         self._n_post_neurons, self._n_post,
-                        self.with_replacement)
+                        self._with_replacement)
 
                 # Sort the neurons now that we have them
                 self._post_neurons[m].sort()

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -60,14 +60,14 @@ class FixedNumberPostConnector(AbstractConnector):
         for m in range(0, self._n_pre_neurons):
             if self._post_neurons[m] is None:
                 if (not self.with_replacement and
-                    self._n_post > self._n_post_neurons):
+                        self._n_post > self._n_post_neurons):
                     raise SpynnakerException(
                         "FixedNumberPostConnector will not work when "
                         "with_replacement=False and n > n_post_neurons")
 
                 if (not self.with_replacement and
-                    not self._allow_self_connections and
-                    self._n_post == self._n_post_neurons):
+                        not self._allow_self_connections and
+                        self._n_post == self._n_post_neurons):
                     raise SpynnakerException(
                         "FixedNumberPostConnector will not work when "
                         "with_replacement=False, allow_self_connections=False "
@@ -76,8 +76,8 @@ class FixedNumberPostConnector(AbstractConnector):
                 # If the pre and post populations are the same
                 # then deal with allow_self_connections=False
                 if (self._pre_population is self._post_population and
-                    not self.with_replacement and
-                    not self._allow_self_connections):
+                        not self.with_replacement and
+                        not self._allow_self_connections):
                     # Exclude the current pre-neuron from the post-neuron list
                     no_self_post_neurons = []
                     for n in range(0, self._n_post_neurons):

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -146,8 +146,6 @@ class FixedNumberPostConnector(AbstractConnector):
             return 0
 
         n_connections = 0
-        lo = pre_vertex_slice.lo_atom
-        hi = pre_vertex_slice.hi_atom
         for n in range(lo, hi + 1):
             n_connections = max(n_connections,
                                 len(self._post_neurons_in_slice(
@@ -212,8 +210,6 @@ class FixedNumberPostConnector(AbstractConnector):
 
         # Get n_connections by adding length of each set of post neurons
         n_connections = 0
-        lo = pre_vertex_slice.lo_atom
-        hi = pre_vertex_slice.hi_atom
         for n in range(lo, hi + 1):
             n_connections += len(self._post_neurons_in_slice(
                 post_vertex_slice, n))
@@ -259,10 +255,6 @@ class FixedNumberPostConnector(AbstractConnector):
 
         if (n_not_connected == pre_vertex_slice.n_atoms):
             return numpy.zeros(0, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
-
-        # Get lo and hi for the pre vertex
-        lo = pre_vertex_slice.lo_atom
-        hi = pre_vertex_slice.hi_atom
 
         # Get number of connections
         n_connections = 0

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -66,8 +66,8 @@ class FixedNumberPostConnector(AbstractConnector):
         this_post_neuron_array = post_neurons[n]
 
         return this_post_neuron_array[
-            (post_neurons >= post_vertex_slice.lo_atom) &
-            (post_neurons <= post_vertex_slice.hi_atom)]
+            (this_post_neuron_array >= post_vertex_slice.lo_atom) &
+            (this_post_neuron_array <= post_vertex_slice.hi_atom)]
 
     def _is_connected(self, post_vertex_slice, n):
         return self._post_neurons_in_slice(post_vertex_slice, n).size > 0
@@ -82,9 +82,12 @@ class FixedNumberPostConnector(AbstractConnector):
 
         # Need to edit this
         n_connections = 0
+        lo = pre_vertex_slice.lo_atom
+        hi = pre_vertex_slice.hi_atom
         for n in range(0, self._n_pre_neurons):
-            n_connections += len(
-                self._post_neurons_in_slice(post_vertex_slice, n))
+            if (n >= lo and n <= hi):
+                n_connections += len(self._post_neurons_in_slice(
+                    post_vertex_slice, n))
 
         if min_delay is None or max_delay is None:
             return n_connections

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -125,7 +125,7 @@ class FixedNumberPostConnector(AbstractConnector):
 
     def _get_n_connections(self, out_of):
         return utility_calls.get_probable_maximum_selected(
-                self._n_pre_neurons, self._n_post * self._n_pre_neurons,
+                self._n_pre_neurons, self._n_post * out_of,
                 1.0 / self._n_post_neurons, chance=(1.0 / 100000.0))
 
     def get_n_connections_from_pre_vertex_maximum(

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -81,27 +81,28 @@ class FixedNumberPostConnector(AbstractConnector):
             return 0
 
         # Need to edit this
-        n_connections = 0
-        lo = pre_vertex_slice.lo_atom
-        hi = pre_vertex_slice.hi_atom
-        for n in range(0, self._n_pre_neurons):
-            if (n >= lo and n <= hi):
-                n_connections += len(self._post_neurons_in_slice(
-                    post_vertex_slice, n))
+#         n_connections = 0
+#         lo = pre_vertex_slice.lo_atom
+#         hi = pre_vertex_slice.hi_atom
+#         for n in range(0, self._n_pre_neurons):
+#             if (n >= lo and n <= hi):
+#                 n_connections += len(self._post_neurons_in_slice(
+#                     post_vertex_slice, n))
 
         if min_delay is None or max_delay is None:
-            return n_connections
+            return pre_vertex_slice.n_atoms  # n_connections
 
         return self._get_n_connections_from_pre_vertex_with_delay_maximum(
-            self._delays, self._n_post * self._n_post_neurons,
-            n_connections, None, min_delay, max_delay)
+            self._delays, self._n_post * self._n_pre_neurons,
+            pre_vertex_slice.n_atoms, None, min_delay, max_delay)
+#            n_connections, None, min_delay, max_delay)
 
     def get_n_connections_to_post_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
         if not self._is_connected(post_vertex_slice, 0):
             return 0
-        return pre_vertex_slice.n_atoms
+        return self._n_post  # pre_vertex_slice.n_atoms
 
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -48,8 +48,8 @@ class FixedNumberPreConnector(AbstractConnector):
                 self._n_pre_neurons)
             # if verbose open a file to output the connectivity
             if self._verbose:
-                filename = self._pre_population.label+'_to_'+\
-                    self._post_population.label+'_fixednumberpre-conn.csv'
+                filename = self._pre_population.label + '_to_' + \
+                    self._post_population.label + '_fixednumberpre-conn.csv'
                 file_handle = file(filename, 'w')
                 numpy.savetxt(file_handle,
                               [(self._n_pre_neurons, self._n_post_neurons,

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -49,7 +49,8 @@ class FixedNumberPreConnector(AbstractConnector):
         # Loop over all the post neurons
         for m in range(0, self._n_post_neurons):
             if self._pre_neurons[m] is None:
-                if not self.with_replacement and self._n_pre > self._n_pre_neurons:
+                if (not self.with_replacement and
+                        self._n_pre > self._n_pre_neurons):
                     # Throw an exception
                     raise SpynnakerException(
                         "FixedNumberPreConnector will not work when "
@@ -58,6 +59,10 @@ class FixedNumberPreConnector(AbstractConnector):
                 self._pre_neurons[m] = numpy.random.choice(
                     self._n_pre_neurons, self._n_pre, self.with_replacement)
 
+#                 I'm leaving this here to revisit in the future -
+#                 I don't think it's working as intended, but whether
+#                 we want to rely on numpy.random.choice is another question
+#
 #                 if self.with_replacement:
 #                     self._pre_neurons[m] = numpy.random.choice(
 #                         self._n_pre_neurons, self._n_pre,
@@ -111,19 +116,7 @@ class FixedNumberPreConnector(AbstractConnector):
             min_delay=None, max_delay=None):
 
         if not self._is_connected(pre_vertex_slice, 0):
-            print 'returning 0 from get_n_connections pre_vertex'
             return 0
-
-#         # Need to edit this
-#         n_connections = 0
-#         lo = pre_vertex_slice.lo_atom
-#         hi = pre_vertex_slice.hi_atom
-#         for n in range(0, self._n_pre_neurons):
-#             if (n >= lo and n <= hi):
-#                 n_connections += post_vertex_slice.n_atoms
-#                 #len(self._pre_neurons_in_slice(
-#                  #   pre_vertex_slice, n))
-
 
         # the number of max connections is either n_pre
         # or post_vertex_slice.n_atoms
@@ -133,22 +126,17 @@ class FixedNumberPreConnector(AbstractConnector):
         else:
             n_connections = post_vertex_slice.n_atoms
 
-        print 'pre_vertex maximum, n_connections: ', n_connections
-
         if min_delay is None or max_delay is None:
             return n_connections  # self._n_pre  # post_vertex_slice.n_atoms
 
         return self._get_n_connections_from_pre_vertex_with_delay_maximum(
             self._delays, self._n_pre * self._n_post_neurons,
             n_connections, None, min_delay, max_delay)
-            # self._n_pre, None, min_delay, max_delay)
-            # post_vertex_slice.n_atoms, None, min_delay, max_delay)
 
     def get_n_connections_to_post_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
         if not self._is_connected(pre_vertex_slice, 0):
-            print 'returning 0 from get_n_connections post_vertex'
             return 0
 
         n_connections = 0
@@ -156,13 +144,10 @@ class FixedNumberPreConnector(AbstractConnector):
         hi = post_vertex_slice.hi_atom
         for n in range(0, self._n_post_neurons):
             if (n >= lo and n <= hi):
-                # n_connections += # max(n_connections,
                 n_connections += len(self._pre_neurons_in_slice(
                     pre_vertex_slice, n))
 
-        print 'post vertex maximum n_connections is: ', n_connections
-
-        return n_connections  # self._n_pre
+        return n_connections
 
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,
@@ -185,8 +170,6 @@ class FixedNumberPreConnector(AbstractConnector):
             if (n >= lo and n <= hi):
                 n_connections += len(self._pre_neurons_in_slice(
                     pre_vertex_slice, n))
-
-        print 'get_weight_maximum, n_connections is ', n_connections
 
         return self._get_weight_maximum(
             self._weights, n_connections, None)
@@ -232,8 +215,6 @@ class FixedNumberPreConnector(AbstractConnector):
                         if (n == pre_neurons[m]):
                             n_connections -= 1
 
-        print 'n_connections is ', n_connections
-
         # Set up the block
         block = numpy.zeros(
             n_connections, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
@@ -272,9 +253,6 @@ class FixedNumberPreConnector(AbstractConnector):
                         pre_neurons_in_slice.append(pre_neurons[m])
                         post_neurons_in_slice.append(
                             post_vertex_array[n-post_vertex_slice.lo_atom])
-
-            print 'pre_neurons slice: ', len(pre_neurons_in_slice)
-            print 'post_neurons slice: ', len(post_neurons_in_slice)
 
             block["source"] = pre_neurons_in_slice
             block["target"] = post_neurons_in_slice

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -41,12 +41,12 @@ class FixedNumberPreConnector(AbstractConnector):
         return self._get_delay_variance(self._delays, None)
 
     def _get_pre_neurons(self):
-        # if we haven't set the array up yet, do it now
+        # If we haven't set the array up yet, do it now
         if not self._pre_neurons_set:
             self._pre_neurons = [None] * self._n_post_neurons
             self._pre_neurons_set = True
 
-        # loop over all the post neurons
+        # Loop over all the post neurons
         for n in range(0, self._n_post_neurons):
             if self._pre_neurons[n] is None:
                 self._pre_neurons[n] = numpy.random.choice(
@@ -134,10 +134,12 @@ class FixedNumberPreConnector(AbstractConnector):
         if not self._is_connected(pre_vertex_slice, 0):
             return numpy.zeros(0, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
 
-        # Get number of connections
-        n_connections = 0
+        # Get lo and hi for the post vertex
         lo = post_vertex_slice.lo_atom
         hi = post_vertex_slice.hi_atom
+
+        # Get number of connections
+        n_connections = 0
         for n in range(0, self._n_post_neurons):
             if (n >= lo and n <= hi):
                 n_connections += len(self._pre_neurons_in_slice(

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -76,7 +76,6 @@ class FixedNumberPreConnector(AbstractConnector):
                 # If the pre and post populations are the same
                 # then deal with allow_self_connections=False
                 if (self._pre_population is self._post_population and
-                        not self.with_replacement and
                         not self._allow_self_connections):
                     # Exclude the current pre-neuron from the post-neuron list
                     no_self_pre_neurons = []

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -198,7 +198,7 @@ class FixedNumberPreConnector(AbstractConnector):
                 pre_vertex_slice, n)
             for m in range(0, len(pre_neurons)):
                 pre_neurons_in_slice.append(pre_neurons[m])
-                post_neurons_in_slice.append(post_vertex_array[n] - lo)
+                post_neurons_in_slice.append(post_vertex_array[n-lo])
 
         block["source"] = pre_neurons_in_slice
         block["target"] = post_neurons_in_slice

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -147,11 +147,12 @@ class FixedNumberPreConnector(AbstractConnector):
 
         # the number of max connections is either n_pre
         # or post_vertex_slice.n_atoms
-        n_connections = 0
-        if self._n_pre > post_vertex_slice.n_atoms:
-            n_connections = self._n_pre
-        else:
-            n_connections = post_vertex_slice.n_atoms
+        n_connections = self._n_pre
+#         n_connections = 0
+#         if self._n_pre > post_vertex_slice.n_atoms:
+#             n_connections = self._n_pre
+#         else:
+#             n_connections = post_vertex_slice.n_atoms
 
         if min_delay is None or max_delay is None:
             return n_connections  # self._n_pre  # post_vertex_slice.n_atoms
@@ -173,7 +174,8 @@ class FixedNumberPreConnector(AbstractConnector):
             if not self._is_connected(pre_vertex_slice, n):
                 n_not_connected += 1
 
-        if (n_not_connected == post_vertex_slice.n_atoms):            return 0
+        if (n_not_connected == post_vertex_slice.n_atoms):
+            return 0
 
         n_connections = 0
         for n in range(lo, hi + 1):

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -224,12 +224,9 @@ class FixedNumberPreConnector(AbstractConnector):
 
         # Get n_connections by adding length of each set of pre_neurons
         n_connections = 0
-        lo = post_vertex_slice.lo_atom
-        hi = post_vertex_slice.hi_atom
-        for n in range(0, self._n_post_neurons):
-            if (n >= lo and n <= hi):
-                n_connections += len(self._pre_neurons_in_slice(
-                    pre_vertex_slice, n))
+        for n in range(lo, hi + 1):
+            n_connections += len(self._pre_neurons_in_slice(
+                pre_vertex_slice, n))
 
         return self._get_weight_maximum(
             self._weights, n_connections, None)
@@ -272,10 +269,6 @@ class FixedNumberPreConnector(AbstractConnector):
 
         if (n_not_connected == post_vertex_slice.n_atoms):
             return numpy.zeros(0, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
-
-        # Get lo and hi for the post vertex
-        lo = post_vertex_slice.lo_atom
-        hi = post_vertex_slice.hi_atom
 
         # Get number of connections
         n_connections = 0

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -27,7 +27,7 @@ class FixedNumberPreConnector(AbstractConnector):
         AbstractConnector.__init__(self, safe, verbose)
         self._n_pre = n
         self._allow_self_connections = allow_self_connections
-        self._pre_neurons = None
+        self._pre_neurons_set = False
 
     def get_delay_maximum(self):
         return self._get_delay_maximum(
@@ -36,32 +36,45 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_delay_variance(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return 0.0
         return self._get_delay_variance(self._delays, None)
 
     def _get_pre_neurons(self):
-        if self._pre_neurons is None:
-            self._pre_neurons = numpy.random.choice(
-                self._n_pre_neurons, self._n_pre, False)
-            self._pre_neurons.sort()
+        # if we haven't set the array up yet, do it now
+        if not self._pre_neurons_set:
+            self._pre_neurons = [None] * self._n_post_neurons
+            self._pre_neurons_set = True
+
+        # loop over all the post neurons
+        for n in range(0, self._n_post_neurons):
+            if self._pre_neurons[n] is None:
+                #print 'pre_neurons is None!'
+                self._pre_neurons[n] = numpy.random.choice(
+                    self._n_pre_neurons, self._n_pre, False)
+                self._pre_neurons[n].sort()
         return self._pre_neurons
 
-    def _pre_neurons_in_slice(self, pre_vertex_slice):
+    def _pre_neurons_in_slice(self, pre_vertex_slice, n):
         pre_neurons = self._get_pre_neurons()
-        return pre_neurons[
-            (pre_neurons >= pre_vertex_slice.lo_atom) &
-            (pre_neurons <= pre_vertex_slice.hi_atom)]
 
-    def _is_connected(self, pre_vertex_slice):
-        return self._pre_neurons_in_slice(pre_vertex_slice).size > 0
+        # Take the nth array and get the bits from it we need
+        # for this pre-vertex slice
+        this_pre_neuron_array = pre_neurons[n]
+
+        return this_pre_neuron_array[
+            (this_pre_neuron_array >= pre_vertex_slice.lo_atom) &
+            (this_pre_neuron_array <= pre_vertex_slice.hi_atom)]
+
+    def _is_connected(self, pre_vertex_slice, n):
+        return self._pre_neurons_in_slice(pre_vertex_slice, n).size > 0
 
     def get_n_connections_from_pre_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             min_delay=None, max_delay=None):
 
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return 0
 
         if min_delay is None or max_delay is None:
@@ -74,31 +87,38 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_n_connections_to_post_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return 0
         return self._n_pre
 
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return 0.0
         return self._get_weight_mean(self._weights, None)
 
     def get_weight_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return 0.0
-        pre_neurons = self._pre_neurons_in_slice(pre_vertex_slice)
-        n_connections = len(pre_neurons) * post_vertex_slice.n_atoms
+
+        # Get n_connections by adding length of each set of pre_neurons
+        n_connections = 0
+        for n in range(0, self._n_post_neurons):
+            if (n >= post_vertex_slice.lo_atom and
+                n <= post_vertex_slice.hi_atom):
+                n_connections += len(self._pre_neurons_in_slice(
+                    pre_vertex_slice, n))
+
         return self._get_weight_maximum(
             self._weights, n_connections, None)
 
     def get_weight_variance(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return 0.0
         return self._get_weight_variance(self._weights, None)
 
@@ -111,35 +131,76 @@ class FixedNumberPreConnector(AbstractConnector):
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             synapse_type):
-        if not self._is_connected(pre_vertex_slice):
+        if not self._is_connected(pre_vertex_slice, 0):
             return numpy.zeros(0, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
-        pre_neurons_in_slice = self._pre_neurons_in_slice(pre_vertex_slice)
 
-        n_connections = len(pre_neurons_in_slice) * post_vertex_slice.n_atoms
+        # Get number of connections
+        n_connections = 0
+        for n in range(0, self._n_post_neurons):
+            if (n >= post_vertex_slice.lo_atom and
+                n <= post_vertex_slice.hi_atom):
+                n_connections += len(self._pre_neurons_in_slice(
+                    pre_vertex_slice, n))
+
+        # If self connections are not allowed then subtract those connections
         if (not self._allow_self_connections and
                 pre_vertex_slice is post_vertex_slice):
-            n_connections -= len(pre_neurons_in_slice)
+            n_self_connections = 0
+            for n in range(0, self._n_post_neurons):
+                if (n >= post_vertex_slice.lo_atom and
+                    n <= post_vertex_slice.hi_atom):
+                    pre_neurons = self._pre_neurons_in_slice(
+                        pre_vertex_slice, n)
+                    for m in range(0, len(pre_neurons)):
+                        if (n == pre_neurons[m]):
+                            n_connections -= 1
+
+        # Set up the block
         block = numpy.zeros(
             n_connections, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
 
+        # If self connections not allowed set up source and target accordingly
         if (not self._allow_self_connections and
                 pre_vertex_slice is post_vertex_slice):
-            block["source"] = [
-                pre_index for pre_index in pre_neurons_in_slice
-                for post_index in range(
-                    post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1)
-                if pre_index != post_index]
-            block["target"] = [
-                post_index for pre_index in pre_neurons_in_slice
-                for post_index in range(
-                    post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1)
-                if pre_index != post_index]
+            pre_neurons_in_slice = []
+            post_neurons_in_slice = []
+            post_vertex_array = numpy.arange(
+                post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1)
+            for n in range(0, self._n_post_neurons):
+                if (n >= post_vertex_slice.lo_atom and
+                    n <= post_vertex_slice.hi_atom):
+                    pre_neurons = self._pre_neurons_in_slice(
+                        pre_vertex_slice, n)
+                    print 'pre_neurons size: ', len(pre_neurons)
+                    for m in range (0, len(pre_neurons)):
+                        if (n != pre_neurons[m]):
+                            pre_neurons_in_slice.append(pre_neurons[m])
+                            post_neurons_in_slice.append(
+                                post_vertex_array[n-post_vertex_slice.lo_atom])
+
+            block["source"] = pre_neurons_in_slice
+            block["target"] = post_neurons_in_slice
         else:
-            block["source"] = numpy.repeat(
-                pre_neurons_in_slice, post_vertex_slice.n_atoms)
-            block["target"] = numpy.tile(numpy.arange(
-                post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1),
-                len(pre_neurons_in_slice))
+            # self connections are allowed, loop over everything and add
+            # to source and target
+            pre_neurons_in_slice = []
+            post_neurons_in_slice = []
+            post_vertex_array = numpy.arange(
+                post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1)
+            for n in range(0, self._n_post_neurons):
+                if (n >= post_vertex_slice.lo_atom and
+                    n <= post_vertex_slice.hi_atom):
+                    pre_neurons = self._pre_neurons_in_slice(
+                        pre_vertex_slice, n)
+                    print 'pre_neurons size: ', len(pre_neurons)
+                    for m in range (0, len(pre_neurons)):
+                        pre_neurons_in_slice.append(pre_neurons[m])
+                        post_neurons_in_slice.append(
+                            post_vertex_array[n-post_vertex_slice.lo_atom])
+
+            block["source"] = pre_neurons_in_slice
+            block["target"] = post_neurons_in_slice
+
         block["weight"] = self._generate_weights(
             self._weights, n_connections, None)
         block["delay"] = self._generate_delays(

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -35,7 +35,17 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_delay_variance(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice, 0):
+        # Get lo and hi for the post vertex
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):
             return 0.0
         return self._get_delay_variance(self._delays, None)
 
@@ -122,7 +132,17 @@ class FixedNumberPreConnector(AbstractConnector):
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             min_delay=None, max_delay=None):
 
-        if not self._is_connected(pre_vertex_slice, 0):
+        # Get lo and hi for the post vertex
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):
             return 0
 
         # the number of max connections is either n_pre
@@ -159,14 +179,34 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice, 0):
+        # Get lo and hi for the post vertex
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):
             return 0.0
         return self._get_weight_mean(self._weights, None)
 
     def get_weight_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice, 0):
+        # Get lo and hi for the post vertex
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):
             return 0.0
 
         # Get n_connections by adding length of each set of pre_neurons
@@ -184,7 +224,17 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_weight_variance(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice, 0):
+        # Get lo and hi for the post vertex
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):
             return 0.0
         return self._get_weight_variance(self._weights, None)
 
@@ -197,7 +247,17 @@ class FixedNumberPreConnector(AbstractConnector):
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             synapse_type):
-        if not self._is_connected(pre_vertex_slice, 0):
+        # Get lo and hi for the post vertex
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):
             return numpy.zeros(0, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
 
         # Get lo and hi for the post vertex

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -169,8 +169,7 @@ class FixedNumberPreConnector(AbstractConnector):
                 if (n >= lo and n <= hi):
                     pre_neurons = self._pre_neurons_in_slice(
                         pre_vertex_slice, n)
-                    print 'pre_neurons size: ', len(pre_neurons)
-                    for m in range (0, len(pre_neurons)):
+                    for m in range(0, len(pre_neurons)):
                         if (n != pre_neurons[m]):
                             pre_neurons_in_slice.append(pre_neurons[m])
                             post_neurons_in_slice.append(
@@ -189,8 +188,7 @@ class FixedNumberPreConnector(AbstractConnector):
                 if (n >= lo and n <= hi):
                     pre_neurons = self._pre_neurons_in_slice(
                         pre_vertex_slice, n)
-                    print 'pre_neurons size: ', len(pre_neurons)
-                    for m in range (0, len(pre_neurons)):
+                    for m in range(0, len(pre_neurons)):
                         pre_neurons_in_slice.append(pre_neurons[m])
                         post_neurons_in_slice.append(
                             post_vertex_array[n-post_vertex_slice.lo_atom])

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -49,34 +49,43 @@ class FixedNumberPreConnector(AbstractConnector):
         # Loop over all the post neurons
         for m in range(0, self._n_post_neurons):
             if self._pre_neurons[m] is None:
-                if self.with_replacement:
-                    self._pre_neurons[m] = numpy.random.choice(
-                        self._n_pre_neurons, self._n_pre,
-                        self.with_replacement)
-                elif self._n_pre > self._n_pre_neurons:
+                if not self.with_replacement and self._n_pre > self._n_pre_neurons:
                     # Throw an exception
                     raise SpynnakerException(
                         "FixedNumberPreConnector will not work when "
                         "with_replacement=False and n > n_pre_neurons")
-                else:
-                    # We can't use numpy.random.choice, so we
-                    # use a different method of selection
-                    n = 0
-                    while (n < self._n_pre):
-                        permutation = numpy.arange(self._n_pre_neurons)
-                        for i in range(0, self._n_pre_neurons - 1):
-                            j = int(self._rng.next(
-                                n=1, distribution="uniform",
-                                parameters=self._rng_parameters))
-                            (permutation[i], permutation[j]) = (
-                                permutation[j], permutation[i])
-                        n += self._n_pre_neurons
-                        if self._pre_neurons[m] is None:
-                            self._pre_neurons[m] = permutation
-                        else:
-                            self._pre_neurons[m] = numpy.append(
-                                self._post_neurons, permutation)
-                    self._pre_neurons[m] = self._pre_neurons[m][:self._n_pre]
+
+                self._pre_neurons[m] = numpy.random.choice(
+                    self._n_pre_neurons, self._n_pre, self.with_replacement)
+
+#                 if self.with_replacement:
+#                     self._pre_neurons[m] = numpy.random.choice(
+#                         self._n_pre_neurons, self._n_pre,
+#                         self.with_replacement)
+#                 elif self._n_pre > self._n_pre_neurons:
+#                     # Throw an exception
+#                     raise SpynnakerException(
+#                         "FixedNumberPreConnector will not work when "
+#                         "with_replacement=False and n > n_pre_neurons")
+#                 else:
+#                     # We can't use numpy.random.choice, so we
+#                     # use a different method of selection
+#                     n = 0
+#                     while (n < self._n_pre):
+#                         permutation = numpy.arange(self._n_pre_neurons)
+#                         for i in range(0, self._n_pre_neurons - 1):
+#                             j = int(self._rng.next(
+#                                 n=1, distribution="uniform",
+#                                 parameters=self._rng_parameters))
+#                             (permutation[i], permutation[j]) = (
+#                                 permutation[j], permutation[i])
+#                         n += self._n_pre_neurons
+#                         if self._pre_neurons[m] is None:
+#                             self._pre_neurons[m] = permutation
+#                         else:
+#                             self._pre_neurons[m] = numpy.append(
+#                                 self._pre_neurons, permutation)
+#                     self._pre_neurons[m] = self._pre_neurons[m][:self._n_pre]
 
                 # Sort the neurons now that we have them
                 self._pre_neurons[m].sort()
@@ -102,21 +111,58 @@ class FixedNumberPreConnector(AbstractConnector):
             min_delay=None, max_delay=None):
 
         if not self._is_connected(pre_vertex_slice, 0):
+            print 'returning 0 from get_n_connections pre_vertex'
             return 0
 
+#         # Need to edit this
+#         n_connections = 0
+#         lo = pre_vertex_slice.lo_atom
+#         hi = pre_vertex_slice.hi_atom
+#         for n in range(0, self._n_pre_neurons):
+#             if (n >= lo and n <= hi):
+#                 n_connections += post_vertex_slice.n_atoms
+#                 #len(self._pre_neurons_in_slice(
+#                  #   pre_vertex_slice, n))
+
+
+        # the number of max connections is either n_pre
+        # or post_vertex_slice.n_atoms
+        n_connections = 0
+        if self._n_pre > post_vertex_slice.n_atoms:
+            n_connections = self._n_pre
+        else:
+            n_connections = post_vertex_slice.n_atoms
+
+        print 'pre_vertex maximum, n_connections: ', n_connections
+
         if min_delay is None or max_delay is None:
-            return post_vertex_slice.n_atoms
+            return n_connections  # self._n_pre  # post_vertex_slice.n_atoms
 
         return self._get_n_connections_from_pre_vertex_with_delay_maximum(
             self._delays, self._n_pre * self._n_post_neurons,
-            post_vertex_slice.n_atoms, None, min_delay, max_delay)
+            n_connections, None, min_delay, max_delay)
+            # self._n_pre, None, min_delay, max_delay)
+            # post_vertex_slice.n_atoms, None, min_delay, max_delay)
 
     def get_n_connections_to_post_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
         if not self._is_connected(pre_vertex_slice, 0):
+            print 'returning 0 from get_n_connections post_vertex'
             return 0
-        return self._n_pre
+
+        n_connections = 0
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
+        for n in range(0, self._n_post_neurons):
+            if (n >= lo and n <= hi):
+                # n_connections += # max(n_connections,
+                n_connections += len(self._pre_neurons_in_slice(
+                    pre_vertex_slice, n))
+
+        print 'post vertex maximum n_connections is: ', n_connections
+
+        return n_connections  # self._n_pre
 
     def get_weight_mean(
             self, pre_slices, pre_slice_index, post_slices,
@@ -139,6 +185,8 @@ class FixedNumberPreConnector(AbstractConnector):
             if (n >= lo and n <= hi):
                 n_connections += len(self._pre_neurons_in_slice(
                     pre_vertex_slice, n))
+
+        print 'get_weight_maximum, n_connections is ', n_connections
 
         return self._get_weight_maximum(
             self._weights, n_connections, None)
@@ -184,6 +232,8 @@ class FixedNumberPreConnector(AbstractConnector):
                         if (n == pre_neurons[m]):
                             n_connections -= 1
 
+        print 'n_connections is ', n_connections
+
         # Set up the block
         block = numpy.zeros(
             n_connections, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
@@ -222,6 +272,9 @@ class FixedNumberPreConnector(AbstractConnector):
                         pre_neurons_in_slice.append(pre_neurons[m])
                         post_neurons_in_slice.append(
                             post_vertex_array[n-post_vertex_slice.lo_atom])
+
+            print 'pre_neurons slice: ', len(pre_neurons_in_slice)
+            print 'post_neurons slice: ', len(post_neurons_in_slice)
 
             block["source"] = pre_neurons_in_slice
             block["target"] = post_neurons_in_slice

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -123,9 +123,9 @@ class FixedNumberPreConnector(AbstractConnector):
             (this_pre_neuron_array >= pre_vertex_slice.lo_atom) &
             (this_pre_neuron_array <= pre_vertex_slice.hi_atom)]
 
-    def _get_n_connections(self, out_of, n_pre):
+    def _get_n_connections(self, out_of):
         return utility_calls.get_probable_maximum_selected(
-                self._n_post_neurons, self._n_pre * self._n_post_neurons,
+                self._n_post_neurons, self._n_pre * out_of,
                 1.0 / self._n_pre_neurons, chance=(1.0 / 100000.0))
 
     def get_n_connections_from_pre_vertex_maximum(
@@ -134,8 +134,7 @@ class FixedNumberPreConnector(AbstractConnector):
             min_delay=None, max_delay=None):
 
         # Get the probable max number of connections
-        n_connections = self._get_n_connections(
-            post_vertex_slice.n_atoms, pre_vertex_slice.n_atoms)
+        n_connections = self._get_n_connections(post_vertex_slice.n_atoms)
 
         if min_delay is None or max_delay is None:
             return int(math.ceil(n_connections))
@@ -158,8 +157,7 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_weight_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        n_connections = self._get_n_connections(
-            post_vertex_slice.n_atoms, pre_vertex_slice.n_atoms)
+        n_connections = self._get_n_connections(post_vertex_slice.n_atoms)
         return self._get_weight_maximum(self._weights, n_connections, None)
 
     def get_weight_variance(

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -13,7 +13,8 @@ class FixedNumberPreConnector(AbstractConnector):
     """
 
     def __init__(
-            self, n, allow_self_connections=True, safe=True, verbose=False):
+            self, n, allow_self_connections=True, with_replacement=False,
+            safe=True, verbose=False):
         """
         :param `int` n:
             number of random pre-synaptic neurons connected to output
@@ -22,10 +23,18 @@ class FixedNumberPreConnector(AbstractConnector):
             Population to itself, this flag determines whether a neuron is
             allowed to connect to itself, or only to other neurons in the
             Population.
+        :param `bool` with_replacement:
+            this flag determines how the random selection of pre-synaptic
+            neurons is performed; if true, then every pre-synaptic neuron
+            can be chosen on each occasion, and so multiple connections
+            between neuron pairs are possible; if false, then once a pre-
+            synaptic neuron has been connected to a post-neuron, it can't be
+            connected again
         """
         AbstractConnector.__init__(self, safe, verbose)
         self._n_pre = n
         self._allow_self_connections = allow_self_connections
+        self._with_replacement = with_replacement
         self._verbose = verbose
         self._pre_neurons_set = False
         self._p_connect = 1.0  # for setting maxima later
@@ -70,14 +79,14 @@ class FixedNumberPreConnector(AbstractConnector):
         # Loop over all the post neurons
         for m in range(0, self._n_post_neurons):
             if self._pre_neurons[m] is None:
-                if (not self.with_replacement and
+                if (not self._with_replacement and
                         self._n_pre > self._n_pre_neurons):
                     # Throw an exception
                     raise SpynnakerException(
                         "FixedNumberPreConnector will not work when "
                         "with_replacement=False and n > n_pre_neurons")
 
-                if (not self.with_replacement and
+                if (not self._with_replacement and
                         not self._allow_self_connections and
                         self._n_pre == self._n_pre_neurons):
                     raise SpynnakerException(
@@ -98,11 +107,11 @@ class FixedNumberPreConnector(AbstractConnector):
                     # Now use this list in the random choice
                     self._pre_neurons[m] = numpy.random.choice(
                         no_self_pre_neurons, self._n_pre,
-                        self.with_replacement)
+                        self._with_replacement)
                 else:
                     self._pre_neurons[m] = numpy.random.choice(
                         self._n_pre_neurons, self._n_pre,
-                        self.with_replacement)
+                        self._with_replacement)
 
                 # Sort the neurons now that we have them
                 self._pre_neurons[m].sort()

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -163,16 +163,22 @@ class FixedNumberPreConnector(AbstractConnector):
     def get_n_connections_to_post_vertex_maximum(
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice):
-        if not self._is_connected(pre_vertex_slice, 0):
-            return 0
-
-        n_connections = 0
+        # Get lo and hi for the post vertex
         lo = post_vertex_slice.lo_atom
         hi = post_vertex_slice.hi_atom
-        for n in range(0, self._n_post_neurons):
-            if (n >= lo and n <= hi):
-                n_connections += len(self._pre_neurons_in_slice(
-                    pre_vertex_slice, n))
+
+        # Only return zero here if *every* neuron is not connected
+        n_not_connected = 0
+        for n in range(lo, hi + 1):
+            if not self._is_connected(pre_vertex_slice, n):
+                n_not_connected += 1
+
+        if (n_not_connected == post_vertex_slice.n_atoms):            return 0
+
+        n_connections = 0
+        for n in range(lo, hi + 1):
+            n_connections += len(self._pre_neurons_in_slice(
+                pre_vertex_slice, n))
 
         return n_connections
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -25,6 +25,7 @@ class FixedNumberPreConnector(AbstractConnector):
         AbstractConnector.__init__(self, safe, verbose)
         self._n_pre = n
         self._allow_self_connections = allow_self_connections
+        self._verbose = verbose
         self._pre_neurons_set = False
 
     def get_delay_maximum(self):
@@ -94,6 +95,12 @@ class FixedNumberPreConnector(AbstractConnector):
 
                 # Sort the neurons now that we have them
                 self._pre_neurons[m].sort()
+
+                # If verbose then output the list connected to this post-neuron
+                if self._verbose:
+                    print 'post-neuron ', m, ' connects to pre-neurons '
+                    print self._pre_neurons[m]
+
         return self._pre_neurons
 
     def _pre_neurons_in_slice(self, pre_vertex_slice, n):

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -46,6 +46,15 @@ class FixedNumberPreConnector(AbstractConnector):
             self._pre_neurons_set = True
             self._rng_parameters = self.get_rng_parameters(
                 self._n_pre_neurons)
+            # if verbose open a file to output the connectivity
+            if self._verbose:
+                filename = self._pre_population.label+'_to_'+\
+                    self._post_population.label+'_fixednumberpre-conn.csv'
+                file_handle = file(filename, 'w')
+                numpy.savetxt(file_handle,
+                              [(self._n_pre_neurons, self._n_post_neurons,
+                                self._n_pre)],
+                              fmt="%u,%u,%u")
 
         # Loop over all the post neurons
         for m in range(0, self._n_post_neurons):
@@ -100,6 +109,9 @@ class FixedNumberPreConnector(AbstractConnector):
                 if self._verbose:
                     print 'post-neuron ', m, ' connects to pre-neurons '
                     print self._pre_neurons[m]
+                    numpy.savetxt(file_handle,
+                                  self._pre_neurons[m][None, :],
+                                  fmt=("%u,"*(self._n_pre-1)+"%u"))
 
         return self._pre_neurons
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -49,7 +49,6 @@ class FixedNumberPreConnector(AbstractConnector):
         # loop over all the post neurons
         for n in range(0, self._n_post_neurons):
             if self._pre_neurons[n] is None:
-                #print 'pre_neurons is None!'
                 self._pre_neurons[n] = numpy.random.choice(
                     self._n_pre_neurons, self._n_pre, False)
                 self._pre_neurons[n].sort()
@@ -106,9 +105,10 @@ class FixedNumberPreConnector(AbstractConnector):
 
         # Get n_connections by adding length of each set of pre_neurons
         n_connections = 0
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
         for n in range(0, self._n_post_neurons):
-            if (n >= post_vertex_slice.lo_atom and
-                n <= post_vertex_slice.hi_atom):
+            if (n >= lo and n <= hi):
                 n_connections += len(self._pre_neurons_in_slice(
                     pre_vertex_slice, n))
 
@@ -136,19 +136,18 @@ class FixedNumberPreConnector(AbstractConnector):
 
         # Get number of connections
         n_connections = 0
+        lo = post_vertex_slice.lo_atom
+        hi = post_vertex_slice.hi_atom
         for n in range(0, self._n_post_neurons):
-            if (n >= post_vertex_slice.lo_atom and
-                n <= post_vertex_slice.hi_atom):
+            if (n >= lo and n <= hi):
                 n_connections += len(self._pre_neurons_in_slice(
                     pre_vertex_slice, n))
 
         # If self connections are not allowed then subtract those connections
         if (not self._allow_self_connections and
                 pre_vertex_slice is post_vertex_slice):
-            n_self_connections = 0
             for n in range(0, self._n_post_neurons):
-                if (n >= post_vertex_slice.lo_atom and
-                    n <= post_vertex_slice.hi_atom):
+                if (n >= lo and n <= hi):
                     pre_neurons = self._pre_neurons_in_slice(
                         pre_vertex_slice, n)
                     for m in range(0, len(pre_neurons)):
@@ -167,8 +166,7 @@ class FixedNumberPreConnector(AbstractConnector):
             post_vertex_array = numpy.arange(
                 post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1)
             for n in range(0, self._n_post_neurons):
-                if (n >= post_vertex_slice.lo_atom and
-                    n <= post_vertex_slice.hi_atom):
+                if (n >= lo and n <= hi):
                     pre_neurons = self._pre_neurons_in_slice(
                         pre_vertex_slice, n)
                     print 'pre_neurons size: ', len(pre_neurons)
@@ -188,8 +186,7 @@ class FixedNumberPreConnector(AbstractConnector):
             post_vertex_array = numpy.arange(
                 post_vertex_slice.lo_atom, post_vertex_slice.hi_atom + 1)
             for n in range(0, self._n_post_neurons):
-                if (n >= post_vertex_slice.lo_atom and
-                    n <= post_vertex_slice.hi_atom):
+                if (n >= lo and n <= hi):
                     pre_neurons = self._pre_neurons_in_slice(
                         pre_vertex_slice, n)
                     print 'pre_neurons size: ', len(pre_neurons)

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -66,8 +66,8 @@ class FixedNumberPreConnector(AbstractConnector):
                         "with_replacement=False and n > n_pre_neurons")
 
                 if (not self.with_replacement and
-                    not self._allow_self_connections and
-                    self._n_pre == self._n_pre_neurons):
+                        not self._allow_self_connections and
+                        self._n_pre == self._n_pre_neurons):
                     raise SpynnakerException(
                         "FixedNumberPreConnector will not work when "
                         "with_replacement=False, allow_self_connections=False "
@@ -76,8 +76,8 @@ class FixedNumberPreConnector(AbstractConnector):
                 # If the pre and post populations are the same
                 # then deal with allow_self_connections=False
                 if (self._pre_population is self._post_population and
-                    not self.with_replacement and
-                    not self._allow_self_connections):
+                        not self.with_replacement and
+                        not self._allow_self_connections):
                     # Exclude the current pre-neuron from the post-neuron list
                     no_self_pre_neurons = []
                     for n in range(0, self._n_pre_neurons):

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -166,5 +166,5 @@ def test_connectors(
             print max_weight, matrix_max_weight, synaptic_block["weight"]
             print max_delay, matrix_max_delay, synaptic_block["delay"]
             raise
-    print connector.__class__.__name__, max_row_length, max_source, max_col_length, max_target
-
+    print (connector.__class__.__name__, max_row_length, max_source,
+           max_col_length, max_target)

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -154,6 +154,23 @@ def test_connectors(
         max_source = max((max(source_histogram), max_source))
         max_target = max((max(target_histogram), max_target))
 
+        if len(post_slices) > post_slice_index + 1:
+            test_post_slice = post_slices[post_slice_index + 1]
+            test_synaptic_block = connector.create_synaptic_block(
+                pre_slices, pre_slice_index, post_slices, post_slice_index + 1,
+                pre_vertex_slice, test_post_slice, synapse_type)
+            if len(test_synaptic_block) > 0:
+                assert not numpy.array_equal(
+                    test_synaptic_block, synaptic_block)
+        if len(pre_slices) > pre_slice_index + 1:
+            test_pre_slice = pre_slices[pre_slice_index + 1]
+            test_synaptic_block = connector.create_synaptic_block(
+                pre_slices, pre_slice_index + 1, post_slices, post_slice_index,
+                test_pre_slice, post_vertex_slice, synapse_type)
+            if len(test_synaptic_block) > 0:
+                assert not numpy.array_equal(
+                    test_synaptic_block, synaptic_block)
+
         try:
             assert max(source_histogram) <= max_row_length
             assert max(target_histogram) <= max_col_length

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -104,6 +104,8 @@ def test_connectors(
     globals_variables.set_failed_state(SpynnakerFailedState())
     globals_variables.set_simulator(simulator)
 
+    max_target = 0
+    max_source = 0
     for seed in range(1000):
         numpy.random.seed(seed)
         connector = create_connector()
@@ -148,6 +150,10 @@ def test_connectors(
             max(synaptic_block["weight"]) if len(synaptic_block) > 0 else 0)
         matrix_max_delay = (
             max(synaptic_block["delay"]) if len(synaptic_block) > 0 else 0)
+
+        max_source = max((max(source_histogram), max_source))
+        max_target = max((max(target_histogram), max_target))
+
         try:
             assert max(source_histogram) <= max_row_length
             assert max(target_histogram) <= max_col_length
@@ -160,3 +166,5 @@ def test_connectors(
             print max_weight, matrix_max_weight, synaptic_block["weight"]
             print max_delay, matrix_max_delay, synaptic_block["delay"]
             raise
+    print connector.__class__.__name__, max_row_length, max_source, max_col_length, max_target
+

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -1,0 +1,162 @@
+from spinn_front_end_common.utilities import globals_variables
+from pacman.model.graphs.common.slice import Slice
+import numpy
+import pytest
+import functools
+from spynnaker.pyNN.utilities.spynnaker_failed_state \
+    import SpynnakerFailedState
+from spynnaker.pyNN.models.neural_projections.connectors \
+    import FixedNumberPreConnector, FixedNumberPostConnector, \
+    FixedProbabilityConnector
+
+
+class MockPopulation(object):
+
+    def __init__(self, size, label):
+        self._size = size
+        self._label = label
+
+    @property
+    def size(self):
+        return self._size
+
+    @property
+    def label(self):
+        return self.label
+
+    def __repr__(self):
+        return "Population {}".format(self._label)
+
+
+class MockRNG(object):
+
+    def next(self, n):
+        return numpy.random.uniform(size=n)
+
+
+class MockSimulator(object):
+
+    def is_a_pynn_random(self, values):
+        return isinstance(values, MockRNG)
+
+    def get_pynn_NumpyRNG(self):
+        return MockRNG()
+
+
+@pytest.fixture(scope="module", params=[10, 100])
+def n_pre(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[10, 100])
+def n_post(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[10])
+def n_in_slice(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        functools.partial(FixedNumberPreConnector, 1),
+        functools.partial(FixedNumberPostConnector, 1),
+        functools.partial(FixedNumberPreConnector, 2),
+        functools.partial(FixedNumberPostConnector, 2),
+        functools.partial(FixedNumberPreConnector, 5, with_replacement=True),
+        functools.partial(FixedNumberPostConnector, 5, with_replacement=True),
+        functools.partial(FixedNumberPreConnector, 20, with_replacement=True),
+        functools.partial(FixedNumberPostConnector, 20, with_replacement=True),
+        functools.partial(FixedProbabilityConnector, 0.1),
+        functools.partial(FixedProbabilityConnector, 0.5)],
+    ids=[
+        "FixedNumberPreConnector1-",
+        "FixedNumberPostConnector1-",
+        "FixedNumberPreConnector2-",
+        "FixedNumberPreConnector2-",
+        "FixedNumberPreConnector5Replace-",
+        "FixedNumberPreConnector5Replace-",
+        "FixedNumberPreConnector20Replace-",
+        "FixedNumberPreConnector20Replace-",
+        "FixedProbabilityConnector0.1-",
+        "FixedProbabilityConnector0.5-"]
+    )
+def create_connector(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[5])
+def weight(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=[5])
+def delay(request):
+    return request.param
+
+
+def test_connectors(
+        n_pre, n_post, n_in_slice, create_connector, weight, delay):
+
+    simulator = MockSimulator()
+    globals_variables.set_failed_state(SpynnakerFailedState())
+    globals_variables.set_simulator(simulator)
+
+    for seed in range(1000):
+        numpy.random.seed(seed)
+        connector = create_connector()
+        connector.set_projection_information(
+            pre_population=MockPopulation(n_pre, "Pre"),
+            post_population=MockPopulation(n_post, "Post"),
+            rng=None, machine_time_step=1000)
+        connector.set_weights_and_delays(weight, delay)
+
+        pre_slices = [
+            Slice(i, i + n_in_slice - 1) for i in range(0, n_pre, n_in_slice)]
+        post_slices = [
+            Slice(i, i + n_in_slice - 1) for i in range(0, n_post, n_in_slice)]
+        pre_slice_index = 0
+        post_slice_index = 0
+        pre_vertex_slice = pre_slices[pre_slice_index]
+        post_vertex_slice = post_slices[post_slice_index]
+        synapse_type = 0
+        pre_slice = pre_slices[pre_slice_index]
+        post_slice = post_slices[post_slice_index]
+        pre_range = numpy.arange(pre_slice.lo_atom, pre_slice.hi_atom + 2)
+        post_range = numpy.arange(post_slice.lo_atom, post_slice.hi_atom + 2)
+
+        max_delay = connector.get_delay_maximum()
+        max_weight = connector.get_weight_maximum(
+            pre_slices, pre_slice_index, post_slices, post_slice_index,
+            pre_vertex_slice, post_vertex_slice)
+        max_row_length = connector.get_n_connections_from_pre_vertex_maximum(
+            pre_slices, pre_slice_index, post_slices, post_slice_index,
+            pre_vertex_slice, post_vertex_slice)
+        max_col_length = connector.get_n_connections_to_post_vertex_maximum(
+            pre_slices, pre_slice_index, post_slices, post_slice_index,
+            pre_vertex_slice, post_vertex_slice)
+        synaptic_block = connector.create_synaptic_block(
+            pre_slices, pre_slice_index, post_slices, post_slice_index,
+            pre_vertex_slice, post_vertex_slice, synapse_type)
+        source_histogram = numpy.histogram(
+            synaptic_block["source"], pre_range)[0]
+        target_histogram = numpy.histogram(
+            synaptic_block["target"], post_range)[0]
+        matrix_max_weight = (
+            max(synaptic_block["weight"]) if len(synaptic_block) > 0 else 0)
+        matrix_max_delay = (
+            max(synaptic_block["delay"]) if len(synaptic_block) > 0 else 0)
+        try:
+            assert max(source_histogram) <= max_row_length
+            assert max(target_histogram) <= max_col_length
+            assert matrix_max_weight <= max_weight
+            assert matrix_max_delay <= max_delay
+        except Exception:
+            print connector.__class__.__name__
+            print max_row_length, max(source_histogram), source_histogram
+            print max_col_length, max(target_histogram), target_histogram
+            print max_weight, matrix_max_weight, synaptic_block["weight"]
+            print max_delay, matrix_max_delay, synaptic_block["delay"]
+            raise


### PR DESCRIPTION
Fix of issue https://github.com/SpiNNakerManchester/sPyNNaker/issues/435

Associated pull requests for sPyNNaker7 and sPyNNaker8 should be done at the same time.

A few observations:

- the code which existed to do a random permutation does not seem to work as I expected it to, so I have left the randomness up to the numpy.random.choice function; if preferred, I can look at this code (commented out in e.g. the fixed number pre-connector lines 62-93) again?
- I have added some tests in sPyNNaker7 and sPyNNaker8; I noted while playing with population size on these (to check this still works when a population is divided between multiple cores) that increasing the population size leads to more timer tick and weight saturation warnings.  Is this normal or expected behaviour?
- please check my logic in the get_n_connections... functions, I think I have it right but it's definitely worth someone else checking this out as it confused me for a while.