### PR TITLE
Workaround for failing Travis builds due to nonblocking stdout!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
 cache: pip
 
 before_install:
+  # Work around ludicrous Travis bug
+  - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
   # Bring pip up to date 
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy numpy scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ cache: pip
 
 before_install:
   # Work around ludicrous Travis bug
-  - python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+  - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
+  - python support/travis_blocking_stdout.py
   # Bring pip up to date 
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy numpy scipy
-  - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
   # SpiNNakerManchester internal dependencies; development mode
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNUtils.git
   - support/pipinstall.sh git://github.com/SpiNNakerManchester/SpiNNMachine.git


### PR DESCRIPTION
This is a workaround for https://github.com/travis-ci/travis-ci/issues/4704 that resets stdout so that it is in blocking mode, which is what most normal command line tools expect.

The script to actually apply the fix is [this](https://github.com/SpiNNakerManchester/SupportScripts/blob/master/travis_blocking_stdout.py).

***We should not have had to do this!*** _Seriously, ugh!_