### PR TITLE
Plasticity window printing

### DIFF
--- a/neural_modelling/src/neuron/plasticity/common/post_events.h
+++ b/neural_modelling/src/neuron/plasticity/common/post_events.h
@@ -191,4 +191,33 @@ static inline void post_events_add(uint32_t time, post_event_history_t *events,
     }
 }
 
+
+static inline print_event_history(post_event_history_t *events){
+	log_info("		##  printing entire post event history  ##");
+	for (int i = 0; i <= events->count_minus_one; i++){
+		log_info("post event: %u, time: %u, trace: %u",
+				i,
+				events->times[i],
+				events->traces[i]
+				);
+	}
+}
+
+static inline print_delayed_window_events(post_event_history_t *post_event_history,
+		uint32_t begin_time, uint32_t end_time, uint32_t delay_dendritic){
+	log_info("		##  printing post window  ##");
+    post_event_window_t post_window = post_events_get_window_delayed(
+            post_event_history, begin_time, end_time);
+
+    while (post_window.num_events > 0) {
+    	const uint32_t delayed_post_time = *post_window.next_time
+    	                                           + delay_dendritic;
+    	log_info("post spike: %u, time: %u, trace: %u",
+    			post_window.num_events, delayed_post_time,
+				*post_window.next_trace);
+
+    	post_window = post_events_next_delayed(post_window, delayed_post_time);
+    }
+}
+
 #endif  // _POST_EVENTS_H_

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -85,6 +85,10 @@ static inline final_state_t _plasticity_update_synapse(
         window_begin_time, window_end_time, post_window.prev_time,
         post_window.num_events);
 
+    print_event_history(post_event_history);
+    print_delayed_window_events(post_event_history, window_begin_time,
+    		window_end_time, delay_dendritic);
+
     // Process events in post-synaptic window
     while (post_window.num_events > 0) {
         const uint32_t delayed_post_time = *post_window.next_time

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -85,9 +85,9 @@ static inline final_state_t _plasticity_update_synapse(
         window_begin_time, window_end_time, post_window.prev_time,
         post_window.num_events);
 
-    print_event_history(post_event_history);
-    print_delayed_window_events(post_event_history, window_begin_time,
-    		window_end_time, delay_dendritic);
+    // print_event_history(post_event_history);
+    // print_delayed_window_events(post_event_history, window_begin_time,
+    //		window_end_time, delay_dendritic);
 
     // Process events in post-synaptic window
     while (post_window.num_events > 0) {


### PR DESCRIPTION
I wrote these functions today whilst debugging the post-synaptic event history data-structure. They're a useful tool for debugging, and so I think they're useful to have in the main toolchain.