### PR TITLE
Most C warnings are trivial things. Let them begone!

### DIFF
--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_accumulator_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_accumulator_impl.h
@@ -62,4 +62,4 @@ static inline plastic_synapse_t synapse_structure_get_final_synaptic_word(
     return final_state;
 }
 
-#endif _SYNAPSE_STRUCUTRE_WEIGHT_STATE_ACCUMULATOR_IMPL_H_
+#endif // _SYNAPSE_STRUCUTRE_WEIGHT_STATE_ACCUMULATOR_IMPL_H_

--- a/neural_modelling/src/spike_source/poisson/spike_source_poisson.c
+++ b/neural_modelling/src/spike_source/poisson/spike_source_poisson.c
@@ -234,7 +234,7 @@ bool read_global_parameters(address_t address) {
 //!            Poisson parameter region starts.
 //! \return a boolean which is True if the parameters were read successfully or
 //!         False otherwise
-static read_poisson_parameters(address_t address) {
+static bool read_poisson_parameters(address_t address) {
 
     // Allocate DTCM for array of spike sources and copy block of data
     if (global_parameters.n_spike_sources > 0) {
@@ -593,7 +593,7 @@ void timer_callback(uint timer_count, uint unused) {
     }
 }
 
-void set_spike_source_rate(int id, REAL rate) {
+void set_spike_source_rate(uint32_t id, REAL rate) {
     if ((id >= global_parameters.first_source_id) &&
             ((id - global_parameters.first_source_id) <
              global_parameters.n_spike_sources)) {
@@ -618,7 +618,6 @@ void sdp_packet_callback(uint mailbox, uint port) {
     uint32_t *data = (uint32_t *) &(msg->cmd_rc);
 
     uint32_t n_items = data[0];
-    REAL rate;
     data = &(data[1]);
     for (uint32_t item = 0; item < n_items; item++) {
         uint32_t id = data[(item * 2)];


### PR DESCRIPTION
These are very small bugs in the C code that produce warnings without really being meaningfully a problem. Let's get rid of these warnings instead.

1. `#endif` doesn't take any tokens after it (so comment them out.
2. Functions should have their return types specified.
3. Match argument types to what they're really passed as (avoiding a warning about signed/unsigned comparisons).
4. Remove a completely unused variable.