### PR TITLE
Updates to make the code use n_neurons for ring buffer sizing

### DIFF
--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -12,6 +12,13 @@
 #include "timing_dependence/timing.h"
 #include <string.h>
 #include <debug.h>
+#include <utils.h>
+
+static uint32_t synapse_type_index_bits;
+static uint32_t synapse_index_bits;
+static uint32_t synapse_index_mask;
+static uint32_t synapse_type_index_mask;
+static uint32_t synapse_delay_index_type_bits;
 
 uint32_t num_plastic_pre_synaptic_events = 0;
 
@@ -42,13 +49,6 @@ uint32_t num_plastic_pre_synaptic_events = 0;
 #endif
 
 #define SYNAPSE_AXONAL_DELAY_MASK ((1 << SYNAPSE_AXONAL_DELAY_BITS) - 1)
-
-#define SYNAPSE_DELAY_TYPE_INDEX_BITS \
-    (SYNAPSE_DELAY_BITS + SYNAPSE_TYPE_INDEX_BITS)
-
-#if (SYNAPSE_DELAY_TYPE_INDEX_BITS + SYNAPSE_AXONAL_DELAY_BITS) > 16
-#error "Not enough bits for axonal synaptic delay bits"
-#endif
 
 //---------------------------------------
 // Structures
@@ -170,17 +170,19 @@ void synapse_dynamics_print_plastic_synapses(
         synapses_print_weight(
             weight, ring_buffer_to_input_buffer_left_shifts[synapse_type]);
         log_debug("nA) d: %2u, %s, n = %3u)] - {%08x %08x}\n",
-                  synapse_row_sparse_delay(control_word),
-                  synapse_types_get_type_char(synapse_row_sparse_type(control_word)),
-                  synapse_row_sparse_index(control_word), SYNAPSE_DELAY_MASK,
-                  SYNAPSE_TYPE_INDEX_BITS);
+                  synapse_row_sparse_delay(
+                      control_word, synapse_type_index_bits),
+                  synapse_types_get_type_char(synapse_row_sparse_type(
+                      control_word, synapse_index_bits)),
+                  synapse_row_sparse_index(control_word, synapse_index_mask),
+                  SYNAPSE_DELAY_MASK, synapse_type_index_bits);
     }
 #endif // LOG_LEVEL >= LOG_DEBUG
 }
 
 //---------------------------------------
 static inline index_t _sparse_axonal_delay(uint32_t x) {
-    return ((x >> SYNAPSE_DELAY_TYPE_INDEX_BITS) & SYNAPSE_AXONAL_DELAY_MASK);
+    return ((x >> synapse_delay_index_type_bits) & SYNAPSE_AXONAL_DELAY_MASK);
 }
 
 bool synapse_dynamics_initialise(
@@ -204,6 +206,19 @@ bool synapse_dynamics_initialise(
     if (post_event_history == NULL) {
         return false;
     }
+
+    uint32_t n_neurons_power_2 = n_neurons;
+    if (!is_power_of_2(n_neurons)) {
+        n_neurons_power_2 = next_power_of_2(n_neurons);
+    }
+    uint32_t log_n_neurons = log_2(n_neurons_power_2);
+
+    synapse_type_index_bits = log_n_neurons + SYNAPSE_TYPE_BITS;
+    synapse_type_index_mask = (1 << synapse_type_index_bits) - 1;
+    synapse_index_bits = log_n_neurons;
+    synapse_index_mask = (1 << synapse_index_bits) - 1;
+    synapse_delay_index_type_bits =
+        SYNAPSE_DELAY_BITS + synapse_type_index_bits;
 
     return true;
 }
@@ -247,10 +262,14 @@ bool synapse_dynamics_process_plastic_synapses(
         // **NOTE** cunningly, control word is just the same as lower
         // 16-bits of 32-bit fixed synapse so same functions can be used
         uint32_t delay_axonal = 0;    //_sparse_axonal_delay(control_word);
-        uint32_t delay_dendritic = synapse_row_sparse_delay(control_word);
-        uint32_t type = synapse_row_sparse_type(control_word);
-        uint32_t index = synapse_row_sparse_index(control_word);
-        uint32_t type_index = synapse_row_sparse_type_index(control_word);
+        uint32_t delay_dendritic = synapse_row_sparse_delay(
+            control_word, synapse_type_index_bits);
+        uint32_t type = synapse_row_sparse_type(
+            control_word, synapse_index_bits);
+        uint32_t index = synapse_row_sparse_index(
+            control_word, synapse_index_mask);
+        uint32_t type_index = synapse_row_sparse_type_index(
+            control_word, synapse_type_index_mask);
 
         // Create update state from the plastic synaptic word
         update_state_t current_state = synapse_structure_get_update_state(
@@ -264,7 +283,8 @@ bool synapse_dynamics_process_plastic_synapses(
 
         // Convert into ring buffer offset
         uint32_t ring_buffer_index = synapses_get_ring_buffer_index_combined(
-                delay_axonal + delay_dendritic + time, type_index);
+                delay_axonal + delay_dendritic + time, type_index,
+                synapse_type_index_bits);
 
         // Add weight to ring-buffer entry
         // **NOTE** Dave suspects that this could be a

--- a/neural_modelling/src/neuron/synapse_row.h
+++ b/neural_modelling/src/neuron/synapse_row.h
@@ -53,23 +53,11 @@
        shaping include
 #endif
 
-//! how many bits the synapse can support to represent the neuron id.
-#ifndef SYNAPSE_INDEX_BITS
-#define SYNAPSE_INDEX_BITS 8
-#endif
-
-//! how many bits the synapse type will need (includes the neuron id size)
-#define SYNAPSE_TYPE_INDEX_BITS (SYNAPSE_TYPE_BITS + SYNAPSE_INDEX_BITS)
-
 // Create some masks based on the number of bits
 //! the mask for the synapse delay in the row
 #define SYNAPSE_DELAY_MASK      ((1 << SYNAPSE_DELAY_BITS) - 1)
 //! the mask for the synapse type in the row
 #define SYNAPSE_TYPE_MASK       ((1 << SYNAPSE_TYPE_BITS) - 1)
-//! the mask for the synapse index in the row
-#define SYNAPSE_INDEX_MASK      ((1 << SYNAPSE_INDEX_BITS) - 1)
-//! the mask for the synapse type index in the row
-#define SYNAPSE_TYPE_INDEX_MASK ((1 << SYNAPSE_TYPE_INDEX_BITS) - 1)
 
 // Define the type of the weights
 #ifdef SYNAPSE_WEIGHTS_SIGNED
@@ -147,20 +135,24 @@ static inline uint32_t *synapse_row_fixed_weight_controls(address_t fixed) {
 }
 
 // The following are offset calculations into the ring buffers
-static inline index_t synapse_row_sparse_index(uint32_t x) {
-    return (x & SYNAPSE_INDEX_MASK);
+static inline index_t synapse_row_sparse_index(
+        uint32_t x, uint32_t synapse_index_mask) {
+    return (x & synapse_index_mask);
 }
 
-static inline index_t synapse_row_sparse_type(uint32_t x) {
-    return ((x >> SYNAPSE_INDEX_BITS) & SYNAPSE_TYPE_MASK);
+static inline index_t synapse_row_sparse_type(
+        uint32_t x, uint32_t synapse_index_bits) {
+    return ((x >> synapse_index_bits) & SYNAPSE_TYPE_MASK);
 }
 
-static inline index_t synapse_row_sparse_type_index(uint32_t x) {
-    return (x & SYNAPSE_TYPE_INDEX_MASK);
+static inline index_t synapse_row_sparse_type_index(
+        uint32_t x, uint32_t synapse_type_index_mask) {
+    return (x & synapse_type_index_mask);
 }
 
-static inline index_t synapse_row_sparse_delay(uint32_t x) {
-    return ((x >> SYNAPSE_TYPE_INDEX_BITS) & SYNAPSE_DELAY_MASK);
+static inline index_t synapse_row_sparse_delay(
+        uint32_t x, uint32_t synapse_type_index_bits) {
+    return ((x >> synapse_type_index_bits) & SYNAPSE_DELAY_MASK);
 }
 
 static inline weight_t synapse_row_sparse_weight(uint32_t x) {

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -6,15 +6,12 @@
 #include <debug.h>
 #include <spin1_api.h>
 #include <string.h>
+#include <utils.h>
 
 //! if using profiler import profiler tags
 #ifdef PROFILER_ENABLED
     #include "profile_tags.h"
 #endif
-
-// Compute the size of the input buffers and ring buffers
-#define RING_BUFFER_SIZE (1 << (SYNAPSE_DELAY_BITS + SYNAPSE_TYPE_BITS\
-                                + SYNAPSE_INDEX_BITS))
 
 // Globals required for synapse benchmarking to work.
 uint32_t  num_fixed_pre_synaptic_events = 0;
@@ -23,7 +20,7 @@ uint32_t  num_fixed_pre_synaptic_events = 0;
 static uint32_t n_neurons;
 
 // Ring buffers to handle delays between synapses and neurons
-static weight_t ring_buffers[RING_BUFFER_SIZE];
+static weight_t *ring_buffers;
 
 // Amount to left shift the ring buffer by to make it an input
 static uint32_t ring_buffer_to_input_left_shifts[SYNAPSE_TYPE_COUNT];
@@ -33,6 +30,11 @@ static synapse_param_t *neuron_synapse_shaping_params;
 
 // Count of the number of times the ring buffers have saturated
 static uint32_t saturation_count = 0;
+
+static uint32_t synapse_type_index_bits;
+static uint32_t synapse_index_bits;
+static uint32_t synapse_index_mask;
+static uint32_t synapse_type_index_mask;
 
 
 /* PRIVATE FUNCTIONS */
@@ -66,10 +68,11 @@ static inline void _print_synaptic_row(synaptic_row_t synaptic_row) {
                               ring_buffer_to_input_left_shifts[synapse_type]);
         log_debug(
             "nA) d: %2u, %s, n = %3u)] - {%08x %08x}\n",
-            synapse_row_sparse_delay(synapse),
-            synapse_types_get_type_char(synapse_row_sparse_type(synapse)),
-            synapse_row_sparse_index(synapse),
-            SYNAPSE_DELAY_MASK, SYNAPSE_TYPE_INDEX_BITS);
+            synapse_row_sparse_delay(synapse, synapse_type_index_bits),
+            synapse_types_get_type_char(
+                synapse_row_sparse_type(synapse, synapse_index_bits)),
+            synapse_row_sparse_index(synapse, synapse_index_mask),
+            SYNAPSE_DELAY_MASK, synapse_type_index_bits);
     }
 
     // If there's a plastic region
@@ -173,14 +176,16 @@ static inline void _process_fixed_synapses(
         uint32_t synaptic_word = *synaptic_words++;
 
         // Extract components from this word
-        uint32_t delay = synapse_row_sparse_delay(synaptic_word);
+        uint32_t delay = synapse_row_sparse_delay(synaptic_word,
+            synapse_type_index_bits);
         uint32_t combined_synapse_neuron_index = synapse_row_sparse_type_index(
-                synaptic_word);
+                synaptic_word, synapse_type_index_mask);
         uint32_t weight = synapse_row_sparse_weight(synaptic_word);
 
         // Convert into ring buffer offset
         uint32_t ring_buffer_index = synapses_get_ring_buffer_index_combined(
-            delay + time, combined_synapse_neuron_index);
+            delay + time, combined_synapse_neuron_index,
+            synapse_type_index_bits);
 
         // Add weight to current ring buffer value
         uint32_t accumulation = ring_buffers[ring_buffer_index] + weight;
@@ -294,9 +299,29 @@ bool synapses_initialise(
 
     *neuron_synapse_shaping_params_value = neuron_synapse_shaping_params;
 
-    for (uint32_t i = 0; i < RING_BUFFER_SIZE; i++) {
+    uint32_t n_neurons_power_2 = n_neurons;
+    if (!is_power_of_2(n_neurons)) {
+        n_neurons_power_2 = next_power_of_2(n_neurons);
+    }
+    uint32_t log_n_neurons = log_2(n_neurons_power_2);
+    uint32_t n_ring_buffer_bits =
+        log_n_neurons + SYNAPSE_TYPE_BITS + SYNAPSE_DELAY_BITS;
+    uint32_t ring_buffer_size = 1 << (n_ring_buffer_bits);
+
+    ring_buffers = (weight_t *) spin1_malloc(
+        ring_buffer_size * sizeof(weight_t));
+    if (ring_buffers == NULL) {
+        log_error(
+            "Could not allocate %u entries for ring buffers", ring_buffer_size);
+    }
+    for (uint32_t i = 0; i < ring_buffer_size; i++) {
         ring_buffers[i] = 0;
     }
+
+    synapse_type_index_bits = log_n_neurons + SYNAPSE_TYPE_BITS;
+    synapse_type_index_mask = (1 << synapse_type_index_bits) - 1;
+    synapse_index_bits = log_n_neurons;
+    synapse_index_mask = (1 << synapse_index_bits) - 1;
 
     return true;
 }
@@ -324,7 +349,8 @@ void synapses_do_timestep_update(timer_t time) {
             // Get index in the ring buffers for the current time slot for
             // this synapse type and neuron
             uint32_t ring_buffer_index = synapses_get_ring_buffer_index(
-                time, synapse_type_index, neuron_index);
+                time, synapse_type_index, neuron_index, synapse_type_index_bits,
+                synapse_index_bits);
 
             // Convert ring-buffer entry to input and add on to correct
             // input for this synapse type and neuron

--- a/neural_modelling/src/neuron/synapses.h
+++ b/neural_modelling/src/neuron/synapses.h
@@ -8,10 +8,11 @@
 // neuron index
 static inline index_t synapses_get_ring_buffer_index(
         uint32_t simuation_timestep, uint32_t synapse_type_index,
-        uint32_t neuron_index){
+        uint32_t neuron_index, uint32_t synapse_type_index_bits,
+        uint32_t synapse_index_bits){
     return (((simuation_timestep & SYNAPSE_DELAY_MASK)
-             << SYNAPSE_TYPE_INDEX_BITS)
-            | (synapse_type_index << SYNAPSE_INDEX_BITS)
+             << synapse_type_index_bits)
+            | (synapse_type_index << synapse_index_bits)
             | neuron_index);
 }
 
@@ -19,9 +20,10 @@ static inline index_t synapses_get_ring_buffer_index(
 // synapse type and neuron index (as stored in a synapse row)
 static inline index_t synapses_get_ring_buffer_index_combined(
         uint32_t simulation_timestep,
-        uint32_t combined_synapse_neuron_index) {
+        uint32_t combined_synapse_neuron_index,
+        uint32_t synapse_type_index_bits) {
     return (((simulation_timestep & SYNAPSE_DELAY_MASK)
-             << SYNAPSE_TYPE_INDEX_BITS)
+             << synapse_type_index_bits)
             | combined_synapse_neuron_index);
 }
 

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -113,8 +113,7 @@ class AbstractPopulationVertex(
             self, n_neurons, binary, label, max_atoms_per_core,
             spikes_per_second, ring_buffer_sigma, incoming_spike_buffer_size,
             model_name, neuron_model, input_type, synapse_type, threshold_type,
-            additional_input=None, constraints=None,
-            max_feasible_atoms_per_core=255):
+            additional_input=None, constraints=None):
 
         ApplicationVertex.__init__(
             self, label, constraints, max_atoms_per_core)
@@ -137,7 +136,6 @@ class AbstractPopulationVertex(
 
         self._binary = binary
         self._n_atoms = n_neurons
-        self._max_feasible_atoms_per_core = max_feasible_atoms_per_core
 
         # buffer data
         self._incoming_spike_buffer_size = incoming_spike_buffer_size
@@ -580,8 +578,7 @@ class AbstractPopulationVertex(
         self._synapse_manager.write_data_spec(
             spec, self, vertex_slice, vertex, placement, machine_graph,
             application_graph, routing_info, graph_mapper,
-            self._input_type, machine_time_step,
-            self._max_feasible_atoms_per_core)
+            self._input_type, machine_time_step)
 
         # End the writing of this specification:
         spec.end_specification()
@@ -786,8 +783,8 @@ class AbstractPopulationVertex(
         return self._synapse_manager.get_connections_from_machine(
             transceiver, placement, edge, graph_mapper,
             routing_infos, synapse_information, machine_time_step,
-            self._max_feasible_atoms_per_core, using_extra_monitor_cores,
-            placements, data_receiver, sender_extra_monitor_core_placement,
+            using_extra_monitor_cores, placements, data_receiver,
+            sender_extra_monitor_core_placement,
             extra_monitor_cores_for_router_timeout,
             handle_time_out_configuration)
 

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_exp_base.py
@@ -65,8 +65,7 @@ class IFCondExpBase(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IF_cond_exp", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE)
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def set_model_max_atoms_per_core(new_value=DEFAULT_MAX_ATOMS_PER_CORE):

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_exp_stoc.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_exp_stoc.py
@@ -69,9 +69,7 @@ class IFCondExpStoc(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IF_cond_exp_stoc", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def get_max_atoms_per_core():

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
@@ -83,9 +83,7 @@ class IFCurrAlpha(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IF_curr_alpha", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def get_max_atoms_per_core():

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_delta.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_delta.py
@@ -62,8 +62,7 @@ class IFCurrDelta(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IF_curr_delta", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE)
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def get_max_atoms_per_core():

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_dual_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_dual_exp_base.py
@@ -69,9 +69,7 @@ class IFCurrDualExpBase(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IF_curr_dual_exp", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def set_model_max_atoms_per_core(new_value=DEFAULT_MAX_ATOMS_PER_CORE):

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_base.py
@@ -63,9 +63,7 @@ class IFCurrExpBase(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IF_curr_exp", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def set_model_max_atoms_per_core(new_value=DEFAULT_MAX_ATOMS_PER_CORE):

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_ca2_adaptive.py
@@ -77,9 +77,7 @@ class IFCurrExpCa2Adaptive(AbstractPopulationVertex):
             model_name="IF_curr_exp_ca2_adaptive", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
             threshold_type=threshold_type, additional_input=additional_input,
-            constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            constraints=constraints)
 
     @staticmethod
     def get_max_atoms_per_core():

--- a/spynnaker/pyNN/models/neuron/builds/izk_cond_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/izk_cond_exp_base.py
@@ -58,9 +58,7 @@ class IzkCondExpBase(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IZK_cond_exp", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def set_model_max_atoms_per_core(new_value=DEFAULT_MAX_ATOMS_PER_CORE):

--- a/spynnaker/pyNN/models/neuron/builds/izk_curr_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/izk_curr_exp_base.py
@@ -56,9 +56,7 @@ class IzkCurrExpBase(AbstractPopulationVertex):
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             model_name="IZK_curr_exp", neuron_model=neuron_model,
             input_type=input_type, synapse_type=synapse_type,
-            threshold_type=threshold_type, constraints=constraints,
-            max_feasible_atoms_per_core=DEFAULT_MAX_ATOMS_PER_CORE
-            )
+            threshold_type=threshold_type, constraints=constraints)
 
     @staticmethod
     def set_model_max_atoms_per_core(new_value=DEFAULT_MAX_ATOMS_PER_CORE):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -38,10 +38,10 @@ class SynapseDynamicsStatic(
 
     def get_static_synaptic_data(
             self, connections, connection_row_indices, n_rows,
-            post_vertex_slice, n_synapse_types, max_feasible_atoms_per_core):
+            post_vertex_slice, n_synapse_types):
 
         n_neuron_id_bits = int(
-            math.ceil(math.log(max_feasible_atoms_per_core, 2)))
+            math.ceil(math.log(post_vertex_slice.n_atoms, 2)))
         n_synapse_type_bits = int(math.ceil(math.log(n_synapse_types, 2)))
 
         fixed_fixed = (
@@ -71,12 +71,11 @@ class SynapseDynamicsStatic(
         return ff_size
 
     def read_static_synaptic_data(
-            self, post_vertex_slice, n_synapse_types, ff_size, ff_data,
-            max_feasible_atoms_per_core):
+            self, post_vertex_slice, n_synapse_types, ff_size, ff_data):
 
         n_synapse_type_bits = int(math.ceil(math.log(n_synapse_types, 2)))
         n_neuron_id_bits = int(
-            math.ceil(math.log(max_feasible_atoms_per_core, 2)))
+            math.ceil(math.log(post_vertex_slice.n_atoms, 2)))
 
         data = numpy.concatenate(ff_data)
         connections = numpy.zeros(data.size, dtype=self.NUMPY_CONNECTORS_DTYPE)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -168,11 +168,11 @@ class SynapseDynamicsSTDP(
 
     def get_plastic_synaptic_data(
             self, connections, connection_row_indices, n_rows,
-            post_vertex_slice, n_synapse_types, max_feasible_atoms_per_core):
+            post_vertex_slice, n_synapse_types):
 
         n_synapse_type_bits = int(math.ceil(math.log(n_synapse_types, 2)))
         n_neuron_id_bits = int(
-            math.ceil(math.log(max_feasible_atoms_per_core, 2)))
+            math.ceil(math.log(post_vertex_slice.n_atoms, 2)))
 
         dendritic_delays = (
             connections["delay"] * self._dendritic_delay_fraction)
@@ -229,12 +229,12 @@ class SynapseDynamicsSTDP(
 
     def read_plastic_synaptic_data(
             self, post_vertex_slice, n_synapse_types, pp_size, pp_data,
-            fp_size, fp_data, max_feasible_atoms_per_core):
+            fp_size, fp_data):
         n_rows = len(fp_size)
 
         n_synapse_type_bits = int(math.ceil(math.log(n_synapse_types, 2)))
         n_neuron_id_bits = int(
-            math.ceil(math.log(max_feasible_atoms_per_core, 2)))
+            math.ceil(math.log(post_vertex_slice.n_atoms, 2)))
 
         data_fixed = numpy.concatenate([
             fp_data[i].view(dtype="uint16")[0:fp_size[i]]

--- a/spynnaker/pyNN/models/neuron/synapse_io/synapse_io_row_based.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io/synapse_io_row_based.py
@@ -119,8 +119,7 @@ class SynapseIORowBased(AbstractSynapseIO):
     @staticmethod
     def _get_max_row_length_and_row_data(
             connections, row_indices, n_rows, post_vertex_slice,
-            n_synapse_types, population_table, synapse_dynamics,
-            max_feasible_atoms_per_core):
+            n_synapse_types, population_table, synapse_dynamics):
 
         ff_data, ff_size = None, None
         fp_data, pp_data, fp_size, pp_size = None, None, None, None
@@ -129,7 +128,7 @@ class SynapseIORowBased(AbstractSynapseIO):
             # Get the static data
             ff_data, ff_size = synapse_dynamics.get_static_synaptic_data(
                 connections, row_indices, n_rows, post_vertex_slice,
-                n_synapse_types, max_feasible_atoms_per_core)
+                n_synapse_types)
 
             # Blank the plastic data
             fp_data = [numpy.zeros(0, dtype="uint32") for _ in range(n_rows)]
@@ -146,7 +145,7 @@ class SynapseIORowBased(AbstractSynapseIO):
             fp_data, pp_data, fp_size, pp_size = \
                 synapse_dynamics.get_plastic_synaptic_data(
                     connections, row_indices, n_rows, post_vertex_slice,
-                    n_synapse_types, max_feasible_atoms_per_core)
+                    n_synapse_types)
 
         # Add some padding
         row_lengths = [
@@ -173,8 +172,7 @@ class SynapseIORowBased(AbstractSynapseIO):
             self, synapse_info, pre_slices, pre_slice_index,
             post_slices, post_slice_index, pre_vertex_slice,
             post_vertex_slice, n_delay_stages, population_table,
-            n_synapse_types, weight_scales, machine_time_step,
-            max_feasible_atoms_per_core):
+            n_synapse_types, weight_scales, machine_time_step):
 
         # Get delays in timesteps
         max_delay = self.get_maximum_delay_supported_in_ms(machine_time_step)
@@ -221,8 +219,7 @@ class SynapseIORowBased(AbstractSynapseIO):
             max_row_length, row_data = self._get_max_row_length_and_row_data(
                 undelayed_connections, undelayed_row_indices,
                 pre_vertex_slice.n_atoms, post_vertex_slice, n_synapse_types,
-                population_table, synapse_info.synapse_dynamics,
-                max_feasible_atoms_per_core)
+                population_table, synapse_info.synapse_dynamics)
 
             del undelayed_row_indices
         del undelayed_connections
@@ -252,7 +249,7 @@ class SynapseIORowBased(AbstractSynapseIO):
                     delayed_connections, delayed_row_indices,
                     pre_vertex_slice.n_atoms * n_delay_stages,
                     post_vertex_slice, n_synapse_types, population_table,
-                    synapse_info.synapse_dynamics, max_feasible_atoms_per_core)
+                    synapse_info.synapse_dynamics)
             del delayed_row_indices
         del delayed_connections
 
@@ -290,7 +287,7 @@ class SynapseIORowBased(AbstractSynapseIO):
             self, synapse_info, pre_vertex_slice, post_vertex_slice,
             max_row_length, delayed_max_row_length, n_synapse_types,
             weight_scales, data, delayed_data, n_delay_stages,
-            machine_time_step, max_feasible_atoms_per_core):
+            machine_time_step):
 
         # Translate the data into rows
         row_data = None
@@ -314,16 +311,14 @@ class SynapseIORowBased(AbstractSynapseIO):
             if row_data is not None and len(row_data) > 0:
                 ff_size, ff_data = self._get_static_data(row_data, dynamics)
                 undelayed_connections = dynamics.read_static_synaptic_data(
-                    post_vertex_slice, n_synapse_types, ff_size, ff_data,
-                    max_feasible_atoms_per_core)
+                    post_vertex_slice, n_synapse_types, ff_size, ff_data)
                 undelayed_connections["source"] += pre_vertex_slice.lo_atom
                 connections.append(undelayed_connections)
             if delayed_row_data is not None and len(delayed_row_data) > 0:
                 ff_size, ff_data = self._get_static_data(
                     delayed_row_data, dynamics)
                 delayed_connections = dynamics.read_static_synaptic_data(
-                    post_vertex_slice, n_synapse_types, ff_size, ff_data,
-                    max_feasible_atoms_per_core)
+                    post_vertex_slice, n_synapse_types, ff_size, ff_data)
 
                 # Use the row index to work out the actual delay and source
                 n_synapses = dynamics.get_n_synapses_in_rows(ff_size)
@@ -352,7 +347,7 @@ class SynapseIORowBased(AbstractSynapseIO):
                     row_data, dynamics)
                 undelayed_connections = dynamics.read_plastic_synaptic_data(
                     post_vertex_slice, n_synapse_types, pp_size, pp_data,
-                    fp_size, fp_data, max_feasible_atoms_per_core)
+                    fp_size, fp_data)
                 undelayed_connections["source"] += pre_vertex_slice.lo_atom
                 connections.append(undelayed_connections)
 
@@ -361,7 +356,7 @@ class SynapseIORowBased(AbstractSynapseIO):
                     delayed_row_data, dynamics)
                 delayed_connections = dynamics.read_plastic_synaptic_data(
                     post_vertex_slice, n_synapse_types, pp_size, pp_data,
-                    fp_size, fp_data, max_feasible_atoms_per_core)
+                    fp_size, fp_data)
 
                 # Use the row index to work out the actual delay and source
                 n_synapses = dynamics.get_n_synapses_in_rows(pp_size, fp_size)

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -570,8 +570,7 @@ class SynapticManager(object):
             self, spec, post_slices, post_slice_index, machine_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             master_pop_table_region, synaptic_matrix_region, routing_info,
-            graph_mapper, machine_graph, machine_time_step,
-            max_feasible_atoms_per_core):
+            graph_mapper, machine_graph, machine_time_step):
         """ Simultaneously generates both the master population table and
             the synaptic matrix.
         """
@@ -616,8 +615,7 @@ class SynapticManager(object):
                             post_slices, post_slice_index, pre_vertex_slice,
                             post_vertex_slice, app_edge.n_delay_stages,
                             self._poptable_type, n_synapse_types,
-                            weight_scales, machine_time_step,
-                            max_feasible_atoms_per_core)
+                            weight_scales, machine_time_step)
 
                     if app_edge.delay_edge is not None:
                         app_edge.delay_edge.pre_vertex.add_delays(
@@ -685,6 +683,7 @@ class SynapticManager(object):
                     if delay_key in self._delay_key_index:
                         rinfo = self._delay_key_index[delay_key]
                     if len(delayed_row_data) > 0:
+
                         if (delayed_row_length == 1 and isinstance(
                                 synapse_info.connector, OneToOneConnector) and
                                 (next_single_start_position +
@@ -740,8 +739,7 @@ class SynapticManager(object):
     def write_data_spec(
             self, spec, application_vertex, post_vertex_slice, machine_vertex,
             placement, machine_graph, application_graph, routing_info,
-            graph_mapper, input_type, machine_time_step,
-            max_feasible_atoms_per_core):
+            graph_mapper, input_type, machine_time_step):
 
         # Create an index of delay keys into this vertex
         for m_edge in machine_graph.get_edges_ending_at_vertex(machine_vertex):
@@ -775,8 +773,7 @@ class SynapticManager(object):
             post_vertex_slice, all_syn_block_sz, weight_scales,
             POPULATION_BASED_REGIONS.POPULATION_TABLE.value,
             POPULATION_BASED_REGIONS.SYNAPTIC_MATRIX.value,
-            routing_info, graph_mapper, machine_graph, machine_time_step,
-            max_feasible_atoms_per_core)
+            routing_info, graph_mapper, machine_graph, machine_time_step)
 
         self._synapse_dynamics.write_parameters(
             spec, POPULATION_BASED_REGIONS.SYNAPSE_DYNAMICS.value,
@@ -790,8 +787,7 @@ class SynapticManager(object):
     def get_connections_from_machine(
             self, transceiver, placement, machine_edge, graph_mapper,
             routing_infos, synapse_info, machine_time_step,
-            max_feasible_atoms_per_core, using_extra_monitor_cores,
-            placements=None, data_receiver=None,
+            using_extra_monitor_cores, placements=None, data_receiver=None,
             sender_extra_monitor_core_placement=None,
             extra_monitor_cores_for_router_timeout=None,
             handle_time_out_configuration=True):
@@ -856,8 +852,7 @@ class SynapticManager(object):
             synapse_info, pre_vertex_slice, post_vertex_slice,
             max_row_length, delayed_max_row_len, n_synapse_types,
             self._weight_scales[placement], data, delayed_data,
-            app_edge.n_delay_stages, machine_time_step,
-            max_feasible_atoms_per_core)
+            app_edge.n_delay_stages, machine_time_step)
 
     def _retrieve_synaptic_block(
             self, transceiver, placement, master_pop_table_address,

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -240,7 +240,6 @@ class TestSynapticManager(unittest.TestCase):
         config.set("Simulation", "one_to_one_connection_dtcm_max_bytes", 40)
 
         machine_time_step = 1000.0
-        max_feasible_atoms_per_core = 255
 
         pre_app_vertex = SimpleApplicationVertex(10)
         pre_vertex = SimpleMachineVertex(resources=None)
@@ -315,7 +314,7 @@ class TestSynapticManager(unittest.TestCase):
             spec, [post_vertex_slice], post_slice_index, post_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             master_pop_region, synapse_region, routing_info, graph_mapper,
-            graph, machine_time_step, max_feasible_atoms_per_core)
+            graph, machine_time_step)
         spec.end_specification()
         spec_writer.close()
 
@@ -367,8 +366,7 @@ class TestSynapticManager(unittest.TestCase):
         connections_1 = synaptic_manager._synapse_io.read_synapses(
             direct_synapse_information_1, pre_vertex_slice, post_vertex_slice,
             row_len_1, 0, 2, weight_scales, data_1, None,
-            app_edge.n_delay_stages, machine_time_step,
-            max_feasible_atoms_per_core)
+            app_edge.n_delay_stages, machine_time_step)
 
         # The first matrix is a 1-1 matrix, so row length is 1
         assert row_len_1 == 1
@@ -388,8 +386,7 @@ class TestSynapticManager(unittest.TestCase):
         connections_2 = synaptic_manager._synapse_io.read_synapses(
             direct_synapse_information_2, pre_vertex_slice, post_vertex_slice,
             row_len_2, 0, 2, weight_scales, data_2, None,
-            app_edge.n_delay_stages, machine_time_step,
-            max_feasible_atoms_per_core)
+            app_edge.n_delay_stages, machine_time_step)
 
         # The second matrix is a 1-1 matrix, so row length is 1
         assert row_len_2 == 1
@@ -409,8 +406,7 @@ class TestSynapticManager(unittest.TestCase):
         connections_3 = synaptic_manager._synapse_io.read_synapses(
             all_to_all_synapse_information, pre_vertex_slice,
             post_vertex_slice, row_len_3, 0, 2, weight_scales, data_3, None,
-            app_edge.n_delay_stages, machine_time_step,
-            max_feasible_atoms_per_core)
+            app_edge.n_delay_stages, machine_time_step)
 
         # The third matrix is an all-to-all matrix, so length is n_atoms
         assert row_len_3 == post_vertex_slice.n_atoms


### PR DESCRIPTION
This adjusts the code to use n_neurons instead of passing down the max feasible atoms per core.  This not only appears to work correctly, but it also reduces the number of instructions by 2 within that part of the code!  Not sure why this should be, but it works in any case...

This has the advantage that the ring buffer size is now related to the number of neurons per core.  This doesn't make it as small as it can be (it is sized to the next closest power of 2 of the number of neurons -
 to make it exact would require other changes to be made in the future), but the reduction is still useful.

Note that this is a pull request to pass_down_max_feasible_atoms_per_core.  As such, it currently fails due to a dependency on spinn_common branch by the same name (but different to the name of this branch ;).