### PR TITLE
add maximum weight check to poisson max weight calculation

### DIFF
--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -490,7 +490,8 @@ class SynapticManager(object):
             stats = running_totals[synapse_type]
             rates = rate_stats[synapse_type]
             if delay_running_totals[synapse_type].variance == 0.0:
-                max_weights[synapse_type] = total_weights[synapse_type]
+                max_weights[synapse_type] = max(total_weights[synapse_type],
+                                                biggest_weight[synapse_type])
             else:
                 max_weights[synapse_type] = min(
                     self._ring_buffer_expected_upper_bound(


### PR DESCRIPTION
Without this comparison to the individual biggest weight, it's possible to return zero as the max weight when using a Poisson spike source, and subsequently write a weight to SpiNNaker of zero, if it can't be represented with a single integer bit (as the shift is zero). 

It seems to make sense, as regardless of Poisson rate, the ring buffers should always be scaled to take the single biggest individual weight.