### PR TITLE
Update ArrayConnector to work with all arrays

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
@@ -40,7 +40,21 @@ class ArrayConnector(AbstractConnector):
         return self._get_delay_variance(self._delays, None)
 
     def _get_n_connections(self, pre_vertex_slice, post_vertex_slice):
-        n_connections = pre_vertex_slice.n_atoms
+        pre_neurons = self._array[0]
+        post_neurons = self._array[1]
+        self._pre_neurons_slice = numpy.empty(0, numpy.uint32)
+        self._post_neurons_slice = numpy.empty(0, numpy.uint32)
+        for i in range(pre_neurons.size):
+            if ((pre_neurons[i] >= pre_vertex_slice.lo_atom) and
+                (pre_neurons[i] <= pre_vertex_slice.hi_atom) and
+                (post_neurons[i] >= post_vertex_slice.lo_atom) and
+                (post_neurons[i] <= post_vertex_slice.hi_atom)):
+                self._pre_neurons_slice = numpy.append(
+                    self._pre_neurons_slice, pre_neurons[i])
+                self._post_neurons_slice = numpy.append(
+                    self._post_neurons_slice, post_neurons[i])
+
+        n_connections = self._pre_neurons_slice.size
         return n_connections
 
     @overrides(AbstractConnector.get_n_connections_from_pre_vertex_maximum)
@@ -96,12 +110,10 @@ class ArrayConnector(AbstractConnector):
                                                 post_vertex_slice)
 
         # The array already exists: just feed it into the block structure
-        source = self._array[
-            0, pre_vertex_slice.lo_atom:(pre_vertex_slice.hi_atom+1)]
+        source = self._pre_neurons_slice
         # This might look strange, but it's correct: the 2D array needs
         # the same set of indices on each row for this to work
-        target = self._array[
-            1, pre_vertex_slice.lo_atom:(pre_vertex_slice.hi_atom+1)]
+        target = self._post_neurons_slice
 
         block = numpy.zeros(
             n_connections, dtype=AbstractConnector.NUMPY_SYNAPSES_DTYPE)
@@ -116,4 +128,4 @@ class ArrayConnector(AbstractConnector):
 
     def __repr__(self):
         return "ArrayConnector({})".format(
-            self._index_expression)
+            self._array)

--- a/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
@@ -45,13 +45,13 @@ class ArrayConnector(AbstractConnector):
         self._post_neurons_slice = numpy.empty(0, numpy.uint32)
         for i in range(pre_neurons.size):
             if ((pre_neurons[i] >= pre_vertex_slice.lo_atom) and
-                (pre_neurons[i] <= pre_vertex_slice.hi_atom) and
-                (post_neurons[i] >= post_vertex_slice.lo_atom) and
-                (post_neurons[i] <= post_vertex_slice.hi_atom)):
-                    self._pre_neurons_slice = numpy.append(
-                        self._pre_neurons_slice, pre_neurons[i])
-                    self._post_neurons_slice = numpy.append(
-                        self._post_neurons_slice, post_neurons[i])
+                    (pre_neurons[i] <= pre_vertex_slice.hi_atom) and
+                    (post_neurons[i] >= post_vertex_slice.lo_atom) and
+                    (post_neurons[i] <= post_vertex_slice.hi_atom)):
+                self._pre_neurons_slice = numpy.append(
+                    self._pre_neurons_slice, pre_neurons[i])
+                self._post_neurons_slice = numpy.append(
+                    self._post_neurons_slice, post_neurons[i])
 
         n_connections = self._pre_neurons_slice.size
         return n_connections

--- a/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
@@ -29,7 +29,6 @@ class ArrayConnector(AbstractConnector):
     @overrides(AbstractConnector.get_delay_maximum)
     def get_delay_maximum(self):
         n_connections_max = self._n_pre_neurons * self._n_post_neurons
-        # we can probably look at the array and do better than this?
         return self._get_delay_maximum(
             self._delays, n_connections_max)
 
@@ -49,10 +48,10 @@ class ArrayConnector(AbstractConnector):
                 (pre_neurons[i] <= pre_vertex_slice.hi_atom) and
                 (post_neurons[i] >= post_vertex_slice.lo_atom) and
                 (post_neurons[i] <= post_vertex_slice.hi_atom)):
-                self._pre_neurons_slice = numpy.append(
-                    self._pre_neurons_slice, pre_neurons[i])
-                self._post_neurons_slice = numpy.append(
-                    self._post_neurons_slice, post_neurons[i])
+                    self._pre_neurons_slice = numpy.append(
+                        self._pre_neurons_slice, pre_neurons[i])
+                    self._post_neurons_slice = numpy.append(
+                        self._post_neurons_slice, post_neurons[i])
 
         n_connections = self._pre_neurons_slice.size
         return n_connections
@@ -109,10 +108,8 @@ class ArrayConnector(AbstractConnector):
         n_connections = self._get_n_connections(pre_vertex_slice,
                                                 post_vertex_slice)
 
-        # The array already exists: just feed it into the block structure
+        # Feed the arrays calculated above into the block structure
         source = self._pre_neurons_slice
-        # This might look strange, but it's correct: the 2D array needs
-        # the same set of indices on each row for this to work
         target = self._post_neurons_slice
 
         block = numpy.zeros(


### PR DESCRIPTION
This should now work for all arrays, not just arrays that are the same size as the number of neurons.  I've updated the integration test in sPyNNaker8 to test one array that is not the same size, but we perhaps should bullet-proof this a bit more by testing it with all sorts of different arrays...