### PR TITLE
Minor import improvements

### DIFF
--- a/spynnaker/gsyn_tools.py
+++ b/spynnaker/gsyn_tools.py
@@ -1,5 +1,4 @@
 import os
-
 import spynnaker.pyNN.utilities.utility_calls as utility_calls
 
 

--- a/spynnaker/plot_utils.py
+++ b/spynnaker/plot_utils.py
@@ -1,13 +1,12 @@
 # Imports
-import numpy as np
 import sys
-# pylint: disable=consider-using-enumerate
-
+import numpy as np
 try:
     import matplotlib.pyplot as plt
     matplotlib_missing = False
 except ImportError:
     matplotlib_missing = True
+# pylint: disable=consider-using-enumerate
 
 
 def _precheck(data, title):

--- a/spynnaker/pyNN/abstract_spinnaker_common.py
+++ b/spynnaker/pyNN/abstract_spinnaker_common.py
@@ -1,32 +1,22 @@
-# utils imports
+import logging
+import math
+import os
+from six import add_metaclass
 from spinn_utilities.abstract_base import AbstractBase
 from spinn_utilities.log import FormatAdapter
-from spynnaker.pyNN.models.utility_models import synapse_expander
-
-# common front end imports
-from spinn_front_end_common.interface.abstract_spinnaker_base \
-    import AbstractSpinnakerBase
+from spinn_front_end_common.interface.abstract_spinnaker_base import (
+    AbstractSpinnakerBase)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utility_models import CommandSender
 from spinn_front_end_common.utilities.utility_objs import ExecutableFinder
 from spinn_front_end_common.utilities import globals_variables
-
-# local front end imports
-from spynnaker.pyNN import overridden_pacman_functions
-from spynnaker.pyNN import model_binaries
+from spynnaker.pyNN.models.utility_models import synapse_expander
+from spynnaker.pyNN import overridden_pacman_functions, model_binaries
 from spynnaker.pyNN.utilities import constants
-from spynnaker.pyNN.spynnaker_simulator_interface \
-    import SpynnakerSimulatorInterface
-from spynnaker import __version__ as version
-
-# general imports
-from six import add_metaclass
-import logging
-import math
-import os
-
-# global objects
+from spynnaker.pyNN.spynnaker_simulator_interface import (
+    SpynnakerSimulatorInterface)
 from spynnaker.pyNN.utilities.extracted_data import ExtractedData
+from spynnaker import __version__ as version
 
 logger = FormatAdapter(logging.getLogger(__name__))
 

--- a/spynnaker/pyNN/connections/__init__.py
+++ b/spynnaker/pyNN/connections/__init__.py
@@ -1,8 +1,8 @@
 from .ethernet_command_connection import EthernetCommandConnection
 from .ethernet_control_connection import EthernetControlConnection
 from .spynnaker_live_spikes_connection import SpynnakerLiveSpikesConnection
-from .spynnaker_poisson_control_connection \
-    import SpynnakerPoissonControlConnection
+from .spynnaker_poisson_control_connection import (
+    SpynnakerPoissonControlConnection)
 
 __all__ = [
     "EthernetCommandConnection", "EthernetControlConnection",

--- a/spynnaker/pyNN/connections/ethernet_command_connection.py
+++ b/spynnaker/pyNN/connections/ethernet_command_connection.py
@@ -1,5 +1,5 @@
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
 from spinn_front_end_common.utilities.constants import NOTIFY_PORT
 from spinn_front_end_common.utilities.database import DatabaseConnection
 

--- a/spynnaker/pyNN/connections/ethernet_control_connection.py
+++ b/spynnaker/pyNN/connections/ethernet_control_connection.py
@@ -1,11 +1,9 @@
-from spinn_front_end_common.utility_models import MultiCastCommand
-
-from spinnman.connections.udp_packet_connections import EIEIOConnection
-from spinnman.messages.eieio.data_messages \
-    import EIEIODataMessage, KeyDataElement, KeyPayloadDataElement
-
 import logging
 from threading import Thread
+from spinn_front_end_common.utility_models import MultiCastCommand
+from spinnman.connections.udp_packet_connections import EIEIOConnection
+from spinnman.messages.eieio.data_messages import (
+    EIEIODataMessage, KeyDataElement, KeyPayloadDataElement)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/connections/spynnaker_live_spikes_connection.py
+++ b/spynnaker/pyNN/connections/spynnaker_live_spikes_connection.py
@@ -1,10 +1,8 @@
 from spinn_front_end_common.utilities.connections import LiveEventConnection
 from spinn_front_end_common.utilities.constants import NOTIFY_PORT
 
-
 # The maximum number of 32-bit keys that will fit in a packet
 _MAX_FULL_KEYS_PER_PACKET = 63
-
 # The maximum number of 16-bit keys that will fit in a packet
 _MAX_HALF_KEYS_PER_PACKET = 127
 

--- a/spynnaker/pyNN/connections/spynnaker_poisson_control_connection.py
+++ b/spynnaker/pyNN/connections/spynnaker_poisson_control_connection.py
@@ -1,10 +1,7 @@
 from spinn_utilities.overrides import overrides
-
 from spinnman.messages.eieio import EIEIOType
 from spinnman.messages.eieio.data_messages import EIEIODataMessage
-
 from data_specification.enums import DataType
-
 from spinn_front_end_common.utilities.connections import LiveEventConnection
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.constants import NOTIFY_PORT

--- a/spynnaker/pyNN/external_devices_models/__init__.py
+++ b/spynnaker/pyNN/external_devices_models/__init__.py
@@ -1,17 +1,17 @@
 from .abstract_ethernet_controller import AbstractEthernetController
 from .abstract_ethernet_sensor import AbstractEthernetSensor
 from .abstract_ethernet_translator import AbstractEthernetTranslator
-from .abstract_multicast_controllable_device \
-    import AbstractMulticastControllableDevice
+from .abstract_multicast_controllable_device import (
+    AbstractMulticastControllableDevice)
 from .arbitrary_fpga_device import ArbitraryFPGADevice
 from .external_device_lif_control import ExternalDeviceLifControl
 from .external_spinnaker_link_cochlea_device import ExternalCochleaDevice
-from .external_spinnaker_link_fpga_retina_device \
-    import ExternalFPGARetinaDevice
+from .external_spinnaker_link_fpga_retina_device import (
+    ExternalFPGARetinaDevice)
 from .munich_spinnaker_link_motor_device import MunichMotorDevice
 from .munich_spinnaker_link_retina_device import MunichRetinaDevice
-from .threshold_type_multicast_device_control \
-    import ThresholdTypeMulticastDeviceControl
+from .threshold_type_multicast_device_control import (
+    ThresholdTypeMulticastDeviceControl)
 
 __all__ = ["AbstractEthernetController", "AbstractEthernetSensor",
            "AbstractEthernetTranslator", "ArbitraryFPGADevice",

--- a/spynnaker/pyNN/external_devices_models/abstract_ethernet_controller.py
+++ b/spynnaker/pyNN/external_devices_models/abstract_ethernet_controller.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/external_devices_models/abstract_ethernet_sensor.py
+++ b/spynnaker/pyNN/external_devices_models/abstract_ethernet_sensor.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/external_devices_models/abstract_ethernet_translator.py
+++ b/spynnaker/pyNN/external_devices_models/abstract_ethernet_translator.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/external_devices_models/abstract_multicast_controllable_device.py
+++ b/spynnaker/pyNN/external_devices_models/abstract_multicast_controllable_device.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractproperty
 
 

--- a/spynnaker/pyNN/external_devices_models/arbitrary_fpga_device.py
+++ b/spynnaker/pyNN/external_devices_models/arbitrary_fpga_device.py
@@ -1,7 +1,6 @@
-# pacman imports
 from pacman.model.graphs.application import ApplicationFPGAVertex
-from spinn_front_end_common.abstract_models.impl\
-    import ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 
 
 class ArbitraryFPGADevice(

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
@@ -1,21 +1,15 @@
-from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.external_devices_models\
-    .external_device_lif_control_vertex import ExternalDeviceLifControlVertex
-from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
-from spynnaker.pyNN.models.defaults \
-    import default_initial_values
-
-from .threshold_type_multicast_device_control \
-    import ThresholdTypeMulticastDeviceControl
-
-from spinn_front_end_common.utilities.exceptions import ConfigurationException
-
-from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
-from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
-
 import logging
+from spinn_utilities.overrides import overrides
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
+from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
+from spynnaker.pyNN.models.defaults import default_initial_values
+from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
+from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
+from .external_device_lif_control_vertex import ExternalDeviceLifControlVertex
+from .threshold_type_multicast_device_control import (
+    ThresholdTypeMulticastDeviceControl)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
@@ -1,21 +1,15 @@
-from spinn_utilities.overrides import overrides
-
-from .abstract_ethernet_controller import AbstractEthernetController
-
-from pacman.model.constraints.key_allocator_constraints import \
-    FixedKeyAndMaskConstraint
-from pacman.model.routing_info import BaseKeyAndMask
-
-from spinn_front_end_common.abstract_models import \
-    AbstractProvidesOutgoingPartitionConstraints
-from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.abstract_models \
-    import AbstractVertexWithEdgeToDependentVertices
-
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
-
-import logging
 from collections import OrderedDict
+import logging
+from spinn_utilities.overrides import overrides
+from pacman.model.constraints.key_allocator_constraints import (
+    FixedKeyAndMaskConstraint)
+from pacman.model.routing_info import BaseKeyAndMask
+from spinn_front_end_common.abstract_models import (
+    AbstractProvidesOutgoingPartitionConstraints,
+    AbstractVertexWithEdgeToDependentVertices)
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
+from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from .abstract_ethernet_controller import AbstractEthernetController
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/external_devices_models/external_spinnaker_link_cochlea_device.py
+++ b/spynnaker/pyNN/external_devices_models/external_spinnaker_link_cochlea_device.py
@@ -1,6 +1,6 @@
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
-from spinn_front_end_common.abstract_models.impl import \
-    ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 
 
 class ExternalCochleaDevice(

--- a/spynnaker/pyNN/external_devices_models/external_spinnaker_link_fpga_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/external_spinnaker_link_fpga_retina_device.py
@@ -1,16 +1,15 @@
 import logging
-
 from spinn_utilities.overrides import overrides
-from pacman.model.constraints.key_allocator_constraints \
-    import FixedKeyAndMaskConstraint
+from pacman.model.constraints.key_allocator_constraints import (
+    FixedKeyAndMaskConstraint)
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
 from pacman.model.routing_info import BaseKeyAndMask
-from spinn_front_end_common.abstract_models import \
-    AbstractProvidesOutgoingPartitionConstraints
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
-from spinn_front_end_common.abstract_models.impl\
-    import ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models import (
+    AbstractProvidesOutgoingPartitionConstraints)
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utility_models import MultiCastCommand
 from spynnaker.pyNN.exceptions import SpynnakerException
 

--- a/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
@@ -1,31 +1,26 @@
-# spynnaker imports
 import logging
-
 from spinn_utilities.overrides import overrides
 from pacman.executor.injection_decorator import inject_items
-from pacman.model.constraints.key_allocator_constraints \
-    import FixedMaskConstraint
+from pacman.model.constraints.key_allocator_constraints import (
+    FixedMaskConstraint)
 from pacman.model.graphs.machine import SimpleMachineVertex
-from pacman.model.graphs.application \
-    import ApplicationSpiNNakerLinkVertex, ApplicationVertex
-from pacman.model.resources import CPUCyclesPerTickResource, DTCMResource
-from pacman.model.resources import ResourceContainer, SDRAMResource
-from spinn_front_end_common.abstract_models import\
-    AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary
-from spinn_front_end_common.abstract_models\
-    import AbstractProvidesOutgoingPartitionConstraints
-from spinn_front_end_common.abstract_models.impl import \
-    ProvidesKeyToAtomMappingImpl
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
-from spinn_front_end_common.abstract_models \
-    import AbstractVertexWithEdgeToDependentVertices
+from pacman.model.graphs.application import (
+    ApplicationSpiNNakerLinkVertex, ApplicationVertex)
+from pacman.model.resources import (
+    CPUCyclesPerTickResource, DTCMResource, ResourceContainer, SDRAMResource)
+from spinn_front_end_common.abstract_models import (
+    AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary,
+    AbstractProvidesOutgoingPartitionConstraints,
+    AbstractVertexWithEdgeToDependentVertices)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.interface.simulation import simulation_utilities
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.constants import SYSTEM_BYTES_REQUIREMENT
 from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.models.defaults import defaults
 
 logger = logging.getLogger(__name__)
-
 MOTOR_PARTITION_ID = "MOTOR"
 
 

--- a/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_retina_device.py
@@ -1,20 +1,18 @@
 from spinn_utilities.overrides import overrides
-from pacman.model.constraints.key_allocator_constraints \
-    import FixedKeyAndMaskConstraint
+from pacman.model.constraints.key_allocator_constraints import (
+    FixedKeyAndMaskConstraint)
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
 from pacman.model.routing_info import BaseKeyAndMask
-# front end common imports
-from spinn_front_end_common.abstract_models import \
-    AbstractProvidesOutgoingPartitionConstraints
-from spinn_front_end_common.abstract_models.impl\
-    import ProvidesKeyToAtomMappingImpl
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
+from spinn_front_end_common.abstract_models import (
+    AbstractProvidesOutgoingPartitionConstraints,
+    AbstractSendMeMulticastCommandsVertex)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utility_models import MultiCastCommand
 from spynnaker.pyNN.exceptions import SpynnakerException
 
-
 # robot with 7 7 1
+
 
 def get_x_from_robot_retina(key):
     return (key >> 7) & 0x7f

--- a/spynnaker/pyNN/external_devices_models/push_bot/abstract_push_bot_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/abstract_push_bot_retina_device.py
@@ -1,9 +1,8 @@
-from spinn_front_end_common.abstract_models.impl \
-    import ProvidesKeyToAtomMappingImpl
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
-
 from spinn_utilities.overrides import overrides
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
 
 
 class AbstractPushBotRetinaDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_control_modules/push_bot_lif_ethernet.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_control_modules/push_bot_lif_ethernet.py
@@ -1,10 +1,11 @@
-from spynnaker.pyNN.models.defaults \
-    import default_initial_values
+from spynnaker.pyNN.models.defaults import default_initial_values
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet \
-    import PushBotTranslator
+    import (
+        PushBotTranslator)
 from spynnaker.pyNN.external_devices_models import ExternalDeviceLifControl
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet \
-    import get_pushbot_wifi_connection
+    import (
+        get_pushbot_wifi_connection)
 
 
 class PushBotLifEthernet(ExternalDeviceLifControl):

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_control_modules/push_bot_lif_spinnaker_link.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_control_modules/push_bot_lif_spinnaker_link.py
@@ -1,9 +1,7 @@
+import logging
 from spynnaker.pyNN.external_devices_models import ExternalDeviceLifControl
 from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
-from spynnaker.pyNN.models.defaults \
-    import default_initial_values
-
-import logging
+from spynnaker.pyNN.models.defaults import default_initial_values
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_device.py
@@ -1,10 +1,8 @@
-from spynnaker.pyNN.external_devices_models \
-    import AbstractMulticastControllableDevice
-
 from six import add_metaclass
-
 from spinn_utilities.overrides import overrides
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from spynnaker.pyNN.external_devices_models import (
+    AbstractMulticastControllableDevice)
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_laser_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_laser_device.py
@@ -1,12 +1,13 @@
 from spinn_utilities.overrides import overrides
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
-from spinn_front_end_common.abstract_models.impl import \
-    ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from .push_bot_ethernet_device import PushBotEthernetDevice
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotLaser
+    import (
+        PushBotLaser)
 
 
 class PushBotEthernetLaserDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_led_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_led_device.py
@@ -1,12 +1,13 @@
 from spinn_utilities.overrides import overrides
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
-from spinn_front_end_common.abstract_models.impl import \
-    ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from .push_bot_ethernet_device import PushBotEthernetDevice
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotLED
+    import (
+        PushBotLED)
 
 
 class PushBotEthernetLEDDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_motor_device.py
@@ -1,12 +1,13 @@
 from spinn_utilities.overrides import overrides
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
-from spinn_front_end_common.abstract_models.impl import \
-    ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from .push_bot_ethernet_device import PushBotEthernetDevice
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotMotor
+    import (
+        PushBotMotor)
 
 
 class PushBotEthernetMotorDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_retina_device.py
@@ -1,11 +1,10 @@
 from spinn_utilities.overrides import overrides
-
 from spynnaker.pyNN.external_devices_models import AbstractEthernetSensor
 from .push_bot_translator import PushBotTranslator
 from .push_bot_wifi_connection import get_pushbot_wifi_connection
 from .push_bot_retina_connection import PushBotRetinaConnection
-from spynnaker.pyNN.external_devices_models.push_bot \
-    import AbstractPushBotRetinaDevice
+from spynnaker.pyNN.external_devices_models.push_bot import (
+    AbstractPushBotRetinaDevice)
 
 
 class PushBotEthernetRetinaDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_speaker_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_ethernet_speaker_device.py
@@ -1,12 +1,13 @@
 from spinn_utilities.overrides import overrides
-from spinn_front_end_common.abstract_models \
-    import AbstractSendMeMulticastCommandsVertex
-from spinn_front_end_common.abstract_models.impl import \
-    ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models import (
+    AbstractSendMeMulticastCommandsVertex)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from .push_bot_ethernet_device import PushBotEthernetDevice
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotSpeaker
+    import (
+        PushBotSpeaker)
 
 
 class PushBotEthernetSpeakerDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_retina_connection.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_retina_connection.py
@@ -1,15 +1,13 @@
 import logging
 from threading import RLock
-
 import numpy
-
 from spinnman.connections import ConnectionListener
 from spynnaker.pyNN.connections import SpynnakerLiveSpikesConnection
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotRetinaResolution
+    import (
+        PushBotRetinaResolution)
 
 logger = logging.getLogger(__name__)
-
 _RETINA_PACKET_SIZE = 2
 
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_translator.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_translator.py
@@ -1,10 +1,10 @@
+import logging
+from time import sleep
 from spinn_utilities.overrides import overrides
 from spinn_utilities.log import FormatAdapter
-from time import sleep
-import logging
 from spynnaker.pyNN.external_devices_models import AbstractEthernetTranslator
-from spynnaker.pyNN.protocols import MunichIoEthernetProtocol
-from spynnaker.pyNN.protocols import munich_io_spinnaker_link_protocol
+from spynnaker.pyNN.protocols import (
+    MunichIoEthernetProtocol, munich_io_spinnaker_link_protocol)
 
 logger = FormatAdapter(logging.getLogger(__name__))
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_wifi_connection.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_ethernet/push_bot_wifi_connection.py
@@ -1,17 +1,13 @@
-from spinnman.connections.abstract_classes import Listenable
-from spinnman.connections.abstract_classes import Connection
-from spinnman.exceptions import SpinnmanIOException
-from spinnman.exceptions import SpinnmanTimeoutException
-
-import platform
-import subprocess
-import socket
-import select
 import logging
+import platform
+import select
+import socket
+import subprocess
 from six import raise_from
+from spinnman.connections.abstract_classes import Listenable, Connection
+from spinnman.exceptions import SpinnmanIOException, SpinnmanTimeoutException
 
 logger = logging.getLogger(__name__)
-
 # A set of connections that have already been made
 _existing_connections = dict()
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_laser.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_laser.py
@@ -1,7 +1,7 @@
-from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
 from data_specification.enums import DataType
-from spynnaker.pyNN.external_devices_models.push_bot \
-    import AbstractPushBotOutputDevice
+from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
+from spynnaker.pyNN.external_devices_models.push_bot import (
+    AbstractPushBotOutputDevice)
 
 
 class PushBotLaser(AbstractPushBotOutputDevice):

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_led.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_led.py
@@ -1,7 +1,7 @@
-from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
-from spynnaker.pyNN.external_devices_models.push_bot \
-    import AbstractPushBotOutputDevice
 from data_specification.enums import DataType
+from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
+from spynnaker.pyNN.external_devices_models.push_bot import (
+    AbstractPushBotOutputDevice)
 
 
 class PushBotLED(AbstractPushBotOutputDevice):

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_motor.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_motor.py
@@ -1,6 +1,6 @@
 from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
-from spynnaker.pyNN.external_devices_models.push_bot \
-    import AbstractPushBotOutputDevice
+from spynnaker.pyNN.external_devices_models.push_bot import (
+    AbstractPushBotOutputDevice)
 
 
 class PushBotMotor(AbstractPushBotOutputDevice):

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_retina_viewer.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_retina_viewer.py
@@ -1,14 +1,12 @@
+import math
+import socket
 from threading import Thread
 import numpy
-import socket
-import math
 
 # Value of brightest pixel to show
 _DISPLAY_MAX = 33.0
-
 # How regularity to display frames
 _FRAME_TIME_MS = 10
-
 # Time constant of pixel decay
 _DECAY_TIME_CONSTANT_MS = 100
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_speaker.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_parameters/push_bot_speaker.py
@@ -1,7 +1,7 @@
-from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
-from spynnaker.pyNN.external_devices_models.push_bot \
-    import AbstractPushBotOutputDevice
 from data_specification.enums import DataType
+from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
+from spynnaker.pyNN.external_devices_models.push_bot import (
+    AbstractPushBotOutputDevice)
 
 
 class PushBotSpeaker(AbstractPushBotOutputDevice):

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/__init__.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/__init__.py
@@ -1,13 +1,12 @@
-from .push_bot_spinnaker_link_laser_device \
-    import PushBotSpiNNakerLinkLaserDevice
-from .push_bot_spinnaker_link_led_device \
-    import PushBotSpiNNakerLinkLEDDevice
-from .push_bot_spinnaker_link_motor_device \
-    import PushBotSpiNNakerLinkMotorDevice
-from .push_bot_spinnaker_link_retina_device \
-    import PushBotSpiNNakerLinkRetinaDevice
-from .push_bot_spinnaker_link_speaker_device \
-    import PushBotSpiNNakerLinkSpeakerDevice
+from .push_bot_spinnaker_link_laser_device import (
+    PushBotSpiNNakerLinkLaserDevice)
+from .push_bot_spinnaker_link_led_device import PushBotSpiNNakerLinkLEDDevice
+from .push_bot_spinnaker_link_motor_device import (
+    PushBotSpiNNakerLinkMotorDevice)
+from .push_bot_spinnaker_link_retina_device import (
+    PushBotSpiNNakerLinkRetinaDevice)
+from .push_bot_spinnaker_link_speaker_device import (
+    PushBotSpiNNakerLinkSpeakerDevice)
 
 __all__ = ["PushBotSpiNNakerLinkLaserDevice",
            "PushBotSpiNNakerLinkLEDDevice",

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_laser_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_laser_device.py
@@ -1,8 +1,6 @@
-
-# pynn imports
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet \
-    import PushBotEthernetLaserDevice
+from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet import (
+    PushBotEthernetLaserDevice)
 
 
 class PushBotSpiNNakerLinkLaserDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_led_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_led_device.py
@@ -1,7 +1,6 @@
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
-
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet \
-    import PushBotEthernetLEDDevice
+from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet import (
+    PushBotEthernetLEDDevice)
 
 
 class PushBotSpiNNakerLinkLEDDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_motor_device.py
@@ -1,6 +1,6 @@
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet \
-    import PushBotEthernetMotorDevice
+from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet import (
+    PushBotEthernetMotorDevice)
 
 
 class PushBotSpiNNakerLinkMotorDevice(

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_retina_device.py
@@ -1,11 +1,10 @@
+import logging
 from spinn_utilities.overrides import overrides
 from pacman.executor.injection_decorator import inject, supports_injection
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
-from spynnaker.pyNN.external_devices_models.push_bot \
-    import AbstractPushBotRetinaDevice
-
-import logging
+from spynnaker.pyNN.external_devices_models.push_bot import (
+    AbstractPushBotRetinaDevice)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_speaker_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/push_bot_spinnaker_link/push_bot_spinnaker_link_speaker_device.py
@@ -1,6 +1,6 @@
 from pacman.model.graphs.application import ApplicationSpiNNakerLinkVertex
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet \
-    import PushBotEthernetSpeakerDevice
+from spynnaker.pyNN.external_devices_models.push_bot.push_bot_ethernet import (
+    PushBotEthernetSpeakerDevice)
 
 
 class PushBotSpiNNakerLinkSpeakerDevice(

--- a/spynnaker/pyNN/models/abstract_models/__init__.py
+++ b/spynnaker/pyNN/models/abstract_models/__init__.py
@@ -3,8 +3,8 @@ from .abstract_contains_units import AbstractContainsUnits
 from .abstract_filterable_edge import AbstractFilterableEdge
 from .abstract_population_initializable import AbstractPopulationInitializable
 from .abstract_population_settable import AbstractPopulationSettable
-from .abstract_read_parameters_before_set \
-    import AbstractReadParametersBeforeSet
+from .abstract_read_parameters_before_set import (
+    AbstractReadParametersBeforeSet)
 from .abstract_settable import AbstractSettable
 from .abstract_weight_updatable import AbstractWeightUpdatable
 

--- a/spynnaker/pyNN/models/abstract_models/abstract_accepts_incoming_synapses.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_accepts_incoming_synapses.py
@@ -1,7 +1,6 @@
 from six import add_metaclass
-
-from spinn_utilities.abstract_base import AbstractBase
-from spinn_utilities.abstract_base import abstractproperty, abstractmethod
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractproperty, abstractmethod)
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/abstract_models/abstract_filterable_edge.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_filterable_edge.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/abstract_models/abstract_population_initializable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_population_initializable.py
@@ -1,7 +1,6 @@
 from six import add_metaclass
-
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod, \
-    abstractproperty
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractmethod, abstractproperty)
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/abstract_models/abstract_population_settable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_population_settable.py
@@ -1,9 +1,7 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractproperty
 from spinn_utilities.ranged.abstract_list import AbstractList
 from spynnaker.pyNN.utilities.ranged import SpynnakerRangedList
-
 from .abstract_settable import AbstractSettable
 
 

--- a/spynnaker/pyNN/models/abstract_models/abstract_settable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_settable.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/abstract_models/abstract_weight_updatable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_weight_updatable.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/abstract_pynn_model.py
+++ b/spynnaker/pyNN/models/abstract_pynn_model.py
@@ -1,9 +1,9 @@
-from six import add_metaclass
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod,\
-    abstractproperty
 from collections import defaultdict
 import sys
+from six import add_metaclass
 from spinn_utilities.classproperty import classproperty
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractmethod, abstractproperty)
 from spynnaker.pyNN.models.defaults import get_dict_from_init
 
 

--- a/spynnaker/pyNN/models/common/__init__.py
+++ b/spynnaker/pyNN/models/common/__init__.py
@@ -3,8 +3,9 @@ from .abstract_spike_recordable import AbstractSpikeRecordable
 from .eieio_spike_recorder import EIEIOSpikeRecorder
 from .neuron_recorder import NeuronRecorder
 from .multi_spike_recorder import MultiSpikeRecorder
-from .recording_utils import get_buffer_sizes, get_data, \
-    get_recording_region_size_in_bytes, needs_buffering, pull_off_cached_lists
+from .recording_utils import (
+    get_buffer_sizes, get_data, get_recording_region_size_in_bytes,
+    needs_buffering, pull_off_cached_lists)
 from .simple_population_settable import SimplePopulationSettable
 
 __all__ = ["AbstractNeuronRecordable", "AbstractSpikeRecordable",

--- a/spynnaker/pyNN/models/common/abstract_neuron_recordable.py
+++ b/spynnaker/pyNN/models/common/abstract_neuron_recordable.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/common/abstract_spike_recordable.py
+++ b/spynnaker/pyNN/models/common/abstract_spike_recordable.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/common/eieio_spike_recorder.py
+++ b/spynnaker/pyNN/models/common/eieio_spike_recorder.py
@@ -1,11 +1,10 @@
+import logging
+import struct
+import numpy
 from spinn_utilities.progress_bar import ProgressBar
 from spinn_utilities.log import FormatAdapter
 from spinnman.messages.eieio.data_messages import EIEIODataHeader
 from spynnaker.pyNN.models.common import recording_utils
-
-import numpy
-import struct
-import logging
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _ONE_WORD = struct.Struct("<I")

--- a/spynnaker/pyNN/models/common/multi_spike_recorder.py
+++ b/spynnaker/pyNN/models/common/multi_spike_recorder.py
@@ -1,12 +1,10 @@
-from spinn_utilities.progress_bar import ProgressBar
-from spinn_utilities.log import FormatAdapter
-
-from spynnaker.pyNN.models.common import recording_utils
-
 import math
-import numpy
 import logging
 import struct
+import numpy
+from spinn_utilities.progress_bar import ProgressBar
+from spinn_utilities.log import FormatAdapter
+from spynnaker.pyNN.models.common import recording_utils
 
 logger = FormatAdapter(logging.getLogger(__name__))
 _TWO_WORDS = struct.Struct("<II")

--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -5,16 +5,14 @@ import math
 import numpy
 from six import iteritems, raise_from
 from six.moves import range, xrange
-
+from spinn_utilities.index_is_value import IndexIsValue
+from spinn_utilities.progress_bar import ProgressBar
 from data_specification.enums import DataType
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities import globals_variables
-from spinn_utilities.index_is_value import IndexIsValue
-from spinn_utilities.progress_bar import ProgressBar
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
 
 logger = logging.getLogger(__name__)
-
 SPIKES = "spikes"
 
 

--- a/spynnaker/pyNN/models/common/recording_utils.py
+++ b/spynnaker/pyNN/models/common/recording_utils.py
@@ -1,10 +1,9 @@
 from __future__ import division
-import struct
 import logging
+import struct
 import numpy
-
-from spinn_front_end_common.utilities.helpful_functions \
-    import locate_memory_region_for_placement
+from spinn_front_end_common.utilities.helpful_functions import (
+    locate_memory_region_for_placement)
 from spynnaker.pyNN.exceptions import MemReadException
 
 logger = logging.getLogger(__name__)

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -1,3 +1,7 @@
+import logging
+import math
+import re
+import numpy
 from six import add_metaclass, string_types
 from spinn_utilities import logger_utils
 from spinn_utilities.safe_eval import SafeEval
@@ -5,10 +9,6 @@ from spinn_front_end_common.utilities.utility_objs import ProvenanceDataItem
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 from spynnaker.pyNN.utilities import utility_calls
-import logging
-import numpy
-import math
-import re
 
 # global objects
 logger = logging.getLogger(__name__)

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
@@ -1,13 +1,13 @@
-from spinn_utilities.abstract_base import abstractproperty, AbstractBase
-from six import add_metaclass
-import numpy
-from spinn_front_end_common.utilities.globals_variables import get_simulator
-from spynnaker.pyNN.models.neural_projections.connectors\
-    import AbstractConnector
-from data_specification.enums.data_type import DataType
+import decimal
 from distutils.version import StrictVersion
 from enum import Enum
-import decimal
+import numpy
+from six import add_metaclass
+from spinn_utilities.abstract_base import abstractproperty, AbstractBase
+from data_specification.enums.data_type import DataType
+from spinn_front_end_common.utilities.globals_variables import get_simulator
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    AbstractConnector)
 
 # Travis fix - when sPyNNaker is installed, you will likely always have
 # PyNN installed as well, but sPyNNaker itself doesn't rely on PyNN

--- a/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
@@ -1,9 +1,9 @@
+import logging
+import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
-from .abstract_generate_connector_on_machine \
-    import AbstractGenerateConnectorOnMachine, ConnectorIDs
-import numpy
-import logging
+from .abstract_generate_connector_on_machine import (
+    AbstractGenerateConnectorOnMachine, ConnectorIDs)
 
 logger = logging.getLogger(__file__)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
@@ -1,7 +1,7 @@
-from spinn_utilities.overrides import overrides
-from .abstract_connector import AbstractConnector
 import logging
 import numpy
+from spinn_utilities.overrides import overrides
+from .abstract_connector import AbstractConnector
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
@@ -1,6 +1,6 @@
 import logging
-import numpy
 import csa
+import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
@@ -1,9 +1,8 @@
-from spinn_utilities.overrides import overrides
-from .abstract_connector import AbstractConnector
-
 import logging
 import numpy
 import csa
+from spinn_utilities.overrides import overrides
+from .abstract_connector import AbstractConnector
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
@@ -1,18 +1,17 @@
-from spynnaker.pyNN.utilities import utility_calls
-from .abstract_connector import AbstractConnector
+import logging
+import math
+import numpy
+from numpy import (
+    arccos, arcsin, arctan, arctan2, ceil, cos, cosh, exp, fabs, floor, fmod,
+    hypot, ldexp, log, log10, modf, power, sin, sinh, sqrt, tan, tanh, maximum,
+    minimum, e, pi)
 from spinn_utilities.overrides import overrides
 from spinn_utilities.safe_eval import SafeEval
-import logging
-import numpy
-import math
-
-# support for arbitrary expression for the distance dependence
-from numpy import arccos, arcsin, arctan, arctan2, ceil, cos
-from numpy import cosh, exp, fabs, floor, fmod, hypot, ldexp
-from numpy import log, log10, modf, power, sin, sinh, sqrt
-from numpy import tan, tanh, maximum, minimum, e, pi
+from spynnaker.pyNN.utilities import utility_calls
+from .abstract_connector import AbstractConnector
 
 logger = logging.getLogger(__name__)
+# support for arbitrary expression for the distance dependence
 _d_expr_context = SafeEval(math, numpy, arccos, arcsin, arctan, arctan2, ceil,
                            cos, cosh, exp, fabs, floor, fmod, hypot, ldexp,
                            log, log10, modf, power, sin, sinh, sqrt, tan, tanh,

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
+import logging
+import math
+import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.exceptions import SpynnakerException
-import numpy
-import logging
-import math
 
 logger = logging.getLogger(__file__)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -1,10 +1,10 @@
+import logging
+import math
+import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.exceptions import SpynnakerException
-import numpy
-import logging
-import math
 
 logger = logging.getLogger(__file__)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -1,13 +1,13 @@
-from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.utilities import utility_calls
-from .abstract_connector import AbstractConnector
 import decimal
-from .abstract_generate_connector_on_machine \
-    import AbstractGenerateConnectorOnMachine, ConnectorIDs
-from spinn_front_end_common.utilities.exceptions import ConfigurationException
 import math
 import numpy
+from spinn_utilities.overrides import overrides
 from data_specification.enums.data_type import DataType
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
+from spynnaker.pyNN.utilities import utility_calls
+from .abstract_connector import AbstractConnector
+from .abstract_generate_connector_on_machine import (
+    AbstractGenerateConnectorOnMachine, ConnectorIDs)
 
 
 class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine):

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_file_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_file_connector.py
@@ -1,8 +1,8 @@
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod
-from .from_list_connector import FromListConnector
 import os
 import numpy
 from six import add_metaclass, string_types
+from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from .from_list_connector import FromListConnector
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -1,9 +1,9 @@
+import logging
+import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.exceptions import InvalidParameterType
 from spynnaker.pyNN.utilities.utility_calls import convert_param_to_numpy
-import logging
-import numpy
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/index_based_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/index_based_probability_connector.py
@@ -1,18 +1,17 @@
+import logging
+import math
+import numpy
+from numpy import (
+    arccos, arcsin, arctan, arctan2, ceil, cos, cosh, exp, fabs, floor, fmod,
+    hypot, ldexp, log, log10, modf, power, sin, sinh, sqrt, tan, tanh, maximum,
+    minimum, e, pi)
 from spinn_utilities.overrides import overrides
+from spinn_utilities.safe_eval import SafeEval
 from spynnaker.pyNN.utilities import utility_calls
 from .abstract_connector import AbstractConnector
-from spinn_utilities.safe_eval import SafeEval
-import logging
-import numpy
-import math
-
-# support for arbitrary expression for the indices
-from numpy import arccos, arcsin, arctan, arctan2, ceil, cos
-from numpy import cosh, exp, fabs, floor, fmod, hypot, ldexp
-from numpy import log, log10, modf, power, sin, sinh, sqrt
-from numpy import tan, tanh, maximum, minimum, e, pi
 
 logger = logging.getLogger(__name__)
+# support for arbitrary expression for the indices
 _index_expr_context = SafeEval(math, numpy, arccos, arcsin, arctan, arctan2,
                                ceil, cos, cosh, exp, fabs, floor, fmod, hypot,
                                ldexp, log, log10, modf, power, sin, sinh, sqrt,

--- a/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
@@ -1,16 +1,15 @@
+import logging
+import math
+import numpy.random
+from six import raise_from
+from spinn_utilities.abstract_base import abstractmethod
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.utilities import utility_calls
-from .abstract_connector import AbstractConnector
-from .abstract_generate_connector_on_machine \
-    import AbstractGenerateConnectorOnMachine, ConnectorIDs
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spinn_utilities.abstract_base import abstractmethod
+from .abstract_connector import AbstractConnector
+from .abstract_generate_connector_on_machine import (
+    AbstractGenerateConnectorOnMachine, ConnectorIDs)
 
-import numpy.random
-import math
-from six import raise_from
-
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -1,10 +1,10 @@
+import logging
 import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
-from .abstract_generate_connector_on_machine \
-    import AbstractGenerateConnectorOnMachine, ConnectorIDs
+from .abstract_generate_connector_on_machine import (
+    AbstractGenerateConnectorOnMachine, ConnectorIDs)
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
@@ -1,6 +1,6 @@
-from .abstract_connector import AbstractConnector
-from spinn_utilities.overrides import overrides
 import numpy
+from spinn_utilities.overrides import overrides
+from .abstract_connector import AbstractConnector
 
 
 class SmallWorldConnector(AbstractConnector):

--- a/spynnaker/pyNN/models/neural_projections/delay_afferent_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/delay_afferent_machine_edge.py
@@ -1,9 +1,9 @@
-from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractWeightUpdatable, AbstractFilterableEdge
-from pacman.model.graphs.machine import MachineEdge
-
 import logging
+from spinn_utilities.overrides import overrides
+from pacman.model.graphs.machine import MachineEdge
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractWeightUpdatable, AbstractFilterableEdge)
+
 logger = logging.getLogger(__name__)
 
 

--- a/spynnaker/pyNN/models/neural_projections/delayed_application_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/delayed_application_edge.py
@@ -1,6 +1,6 @@
 from spinn_utilities.overrides import overrides
-from .delayed_machine_edge import DelayedMachineEdge
 from pacman.model.graphs.application import ApplicationEdge
+from .delayed_machine_edge import DelayedMachineEdge
 
 
 class DelayedApplicationEdge(ApplicationEdge):

--- a/spynnaker/pyNN/models/neural_projections/delayed_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/delayed_machine_edge.py
@@ -1,8 +1,7 @@
 from spinn_utilities.overrides import overrides
 from pacman.model.graphs.machine import MachineEdge
-from spynnaker.pyNN.models.neural_projections.connectors.one_to_one_connector\
-    import (
-        OneToOneConnector)
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    OneToOneConnector)
 from spynnaker.pyNN.models.abstract_models import AbstractFilterableEdge
 
 

--- a/spynnaker/pyNN/models/neural_projections/delayed_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/delayed_machine_edge.py
@@ -1,7 +1,8 @@
 from spinn_utilities.overrides import overrides
 from pacman.model.graphs.machine import MachineEdge
 from spynnaker.pyNN.models.neural_projections.connectors.one_to_one_connector\
-    import OneToOneConnector
+    import (
+        OneToOneConnector)
 from spynnaker.pyNN.models.abstract_models import AbstractFilterableEdge
 
 

--- a/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
@@ -1,9 +1,7 @@
+import logging
 from spinn_utilities.overrides import overrides
 from pacman.model.graphs.application import ApplicationEdge
-
 from .projection_machine_edge import ProjectionMachineEdge
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
@@ -1,13 +1,14 @@
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.utilities import utility_calls
-from spinn_front_end_common.utilities import globals_variables
-from spinn_front_end_common.interface.provenance \
-    import AbstractProvidesLocalProvenanceData
-from spynnaker.pyNN.models.neural_projections.connectors.one_to_one_connector \
-    import OneToOneConnector
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractWeightUpdatable, AbstractFilterableEdge
 from pacman.model.graphs.machine import MachineEdge
+from spinn_front_end_common.utilities import globals_variables
+from spinn_front_end_common.interface.provenance import (
+    AbstractProvidesLocalProvenanceData)
+from spynnaker.pyNN.models.neural_projections.connectors.one_to_one_connector \
+    import (
+        OneToOneConnector)
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractWeightUpdatable, AbstractFilterableEdge)
 
 
 class ProjectionMachineEdge(

--- a/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
@@ -4,9 +4,8 @@ from pacman.model.graphs.machine import MachineEdge
 from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.interface.provenance import (
     AbstractProvidesLocalProvenanceData)
-from spynnaker.pyNN.models.neural_projections.connectors.one_to_one_connector \
-    import (
-        OneToOneConnector)
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    OneToOneConnector)
 from spynnaker.pyNN.models.abstract_models import (
     AbstractWeightUpdatable, AbstractFilterableEdge)
 

--- a/spynnaker/pyNN/models/neural_projections/synapse_information.py
+++ b/spynnaker/pyNN/models/neural_projections/synapse_information.py
@@ -1,4 +1,3 @@
-
 class SynapseInformation(object):
     """ Contains the synapse information including the connector, synapse type\
         and synapse dynamics

--- a/spynnaker/pyNN/models/neural_properties/neural_parameter.py
+++ b/spynnaker/pyNN/models/neural_properties/neural_parameter.py
@@ -1,7 +1,7 @@
+from six import Iterator
 from spinn_utilities.ranged.abstract_list import AbstractList
 from data_specification.enums import DataType, Commands
 from data_specification.exceptions import UnknownTypeException
-from six import Iterator
 
 
 class _Range_Iterator(Iterator):

--- a/spynnaker/pyNN/models/neuron/__init__.py
+++ b/spynnaker/pyNN/models/neuron/__init__.py
@@ -3,8 +3,8 @@ from .connection_holder import ConnectionHolder
 from .population_machine_vertex import PopulationMachineVertex
 from .synaptic_manager import SynapticManager
 from .abstract_pynn_neuron_model import AbstractPyNNNeuronModel
-from .abstract_pynn_neuron_model_standard \
-    import AbstractPyNNNeuronModelStandard
+from .abstract_pynn_neuron_model_standard import (
+    AbstractPyNNNeuronModelStandard)
 
 __all__ = ["AbstractPopulationVertex", "ConnectionHolder", "SynapticManager",
            "PopulationMachineVertex", "AbstractPyNNNeuronModel",

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -10,8 +10,8 @@ from pacman.model.resources import (
     CPUCyclesPerTickResource, DTCMResource, ResourceContainer, SDRAMResource)
 from spinn_front_end_common.abstract_models import (
     AbstractChangableAfterRun, AbstractProvidesIncomingPartitionConstraints,
-    AbstractProvidesOutgoingPartitionConstraints, AbstractRewritesDataSpecification,
-    AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary)
+    AbstractProvidesOutgoingPartitionConstraints, AbstractHasAssociatedBinary,
+    AbstractGeneratesDataSpecification, AbstractRewritesDataSpecification)
 from spinn_front_end_common.abstract_models.impl import (
     ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utilities import (

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -1,55 +1,37 @@
-from spinn_utilities.overrides import overrides
-
-# pacman imports
-from pacman.model.constraints.key_allocator_constraints \
-    import ContiguousKeyRangeContraint
-from pacman.executor.injection_decorator import inject_items
-from pacman.model.graphs.application import ApplicationVertex
-from pacman.model.resources import CPUCyclesPerTickResource, DTCMResource
-from pacman.model.resources import ResourceContainer, SDRAMResource
-
-# front end common imports
-from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
-from spinn_front_end_common.abstract_models import \
-    AbstractProvidesIncomingPartitionConstraints
-from spinn_front_end_common.abstract_models import \
-    AbstractProvidesOutgoingPartitionConstraints
-from spinn_front_end_common.abstract_models\
-    import AbstractRewritesDataSpecification
-from spinn_front_end_common.abstract_models \
-    import AbstractGeneratesDataSpecification
-from spinn_front_end_common.abstract_models import AbstractHasAssociatedBinary
-from spinn_front_end_common.abstract_models.impl\
-    import ProvidesKeyToAtomMappingImpl
-from spinn_front_end_common.utilities import constants as common_constants
-from spinn_front_end_common.utilities import helpful_functions
-from spinn_front_end_common.utilities import globals_variables
-from spinn_front_end_common.utilities.utility_objs import ExecutableType
-from spinn_front_end_common.interface.simulation import simulation_utilities
-from spinn_front_end_common.interface.buffer_management\
-    import recording_utilities
-from spinn_front_end_common.interface.profiling import profile_utils
-
-# spynnaker imports
-from spynnaker.pyNN.models.neuron.synaptic_manager import SynapticManager
-from spynnaker.pyNN.models.common import AbstractSpikeRecordable
-from spynnaker.pyNN.models.common import AbstractNeuronRecordable
-from spynnaker.pyNN.models.common import NeuronRecorder
-from spynnaker.pyNN.utilities import constants
-from spynnaker.pyNN.models.neuron.population_machine_vertex \
-    import PopulationMachineVertex
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractPopulationInitializable, AbstractAcceptsIncomingSynapses
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractPopulationSettable, AbstractReadParametersBeforeSet
-from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
-from spynnaker.pyNN.exceptions import InvalidParameterType
-from spynnaker.pyNN.utilities.ranged import SpynnakerRangeDictionary
-
-
 import logging
 import os
 import random
+from spinn_utilities.overrides import overrides
+from pacman.model.constraints.key_allocator_constraints import (
+    ContiguousKeyRangeContraint)
+from pacman.executor.injection_decorator import inject_items
+from pacman.model.graphs.application import ApplicationVertex
+from pacman.model.resources import (
+    CPUCyclesPerTickResource, DTCMResource, ResourceContainer, SDRAMResource)
+from spinn_front_end_common.abstract_models import (
+    AbstractChangableAfterRun, AbstractProvidesIncomingPartitionConstraints,
+    AbstractProvidesOutgoingPartitionConstraints, AbstractRewritesDataSpecification,
+    AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
+from spinn_front_end_common.utilities import (
+    constants as common_constants, helpful_functions, globals_variables)
+from spinn_front_end_common.utilities.utility_objs import ExecutableType
+from spinn_front_end_common.interface.simulation import simulation_utilities
+from spinn_front_end_common.interface.buffer_management import (
+    recording_utilities)
+from spinn_front_end_common.interface.profiling import profile_utils
+from .synaptic_manager import SynapticManager
+from spynnaker.pyNN.models.common import (
+    AbstractSpikeRecordable, AbstractNeuronRecordable, NeuronRecorder)
+from spynnaker.pyNN.utilities import constants
+from .population_machine_vertex import PopulationMachineVertex
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractPopulationInitializable, AbstractAcceptsIncomingSynapses,
+    AbstractPopulationSettable, AbstractReadParametersBeforeSet,
+    AbstractContainsUnits)
+from spynnaker.pyNN.exceptions import InvalidParameterType
+from spynnaker.pyNN.utilities.ranged import SpynnakerRangeDictionary
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model.py
@@ -2,7 +2,6 @@ from pacman.model.decorators.overrides import overrides
 from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 
-
 DEFAULT_MAX_ATOMS_PER_CORE = 255
 
 _population_parameters = {

--- a/spynnaker/pyNN/models/neuron/additional_inputs/abstract_additional_input.py
+++ b/spynnaker/pyNN/models/neuron/additional_inputs/abstract_additional_input.py
@@ -1,5 +1,5 @@
-from spynnaker.pyNN.models.neuron.implementations\
-    import AbstractStandardNeuronComponent
+from spynnaker.pyNN.models.neuron.implementations import (
+    AbstractStandardNeuronComponent)
 
 
 class AbstractAdditionalInput(AbstractStandardNeuronComponent):

--- a/spynnaker/pyNN/models/neuron/additional_inputs/additional_input_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/additional_inputs/additional_input_ca2_adaptive.py
@@ -1,9 +1,8 @@
-from pacman.executor.injection_decorator import inject_items
-from data_specification.enums import DataType
-from spinn_utilities.overrides import overrides
-from .abstract_additional_input import AbstractAdditionalInput
-
 import numpy
+from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
+from pacman.executor.injection_decorator import inject_items
+from .abstract_additional_input import AbstractAdditionalInput
 
 I_ALPHA = "i_alpha"
 I_CA2 = "i_ca2"

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_exp_base.py
@@ -1,7 +1,7 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron.input_types import InputTypeConductance
 from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
 from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_exp_stoc.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_exp_stoc.py
@@ -1,11 +1,11 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
 from spynnaker.pyNN.models.neuron.input_types import InputTypeConductance
-from spynnaker.pyNN.models.neuron.threshold_types \
-    import ThresholdTypeMaassStochastic
+from spynnaker.pyNN.models.neuron.threshold_types import (
+    ThresholdTypeMaassStochastic)
 
 
 class IFCondExpStoc(AbstractPyNNNeuronModelStandard):

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
@@ -1,7 +1,7 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeAlpha
 from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
 from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_delta.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_delta.py
@@ -1,7 +1,7 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
 from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic
 from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeDelta

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_dual_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_dual_exp_base.py
@@ -1,9 +1,9 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
-from spynnaker.pyNN.models.neuron.synapse_types \
-    import SynapseTypeDualExponential
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
+from spynnaker.pyNN.models.neuron.synapse_types import (
+    SynapseTypeDualExponential)
 from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
 from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic
 

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_base.py
@@ -1,7 +1,7 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
 from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
 from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_ca2_adaptive.py
@@ -1,12 +1,12 @@
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
 from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
 from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic
-from spynnaker.pyNN.models.neuron.additional_inputs \
-    import AdditionalInputCa2Adaptive
+from spynnaker.pyNN.models.neuron.additional_inputs import (
+    AdditionalInputCa2Adaptive)
 
 
 class IFCurrExpCa2Adaptive(AbstractPyNNNeuronModelStandard):

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_semd_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_semd_base.py
@@ -1,14 +1,10 @@
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.neuron_models\
-    .neuron_model_leaky_integrate_and_fire \
-    import NeuronModelLeakyIntegrateAndFire
+from spynnaker.pyNN.models.neuron.neuron_models import (
+    NeuronModelLeakyIntegrateAndFire)
 from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
-from spynnaker.pyNN.models.neuron.synapse_types.synapse_type_exponential \
-    import SynapseTypeExponential
-from spynnaker.pyNN.models.neuron.input_types.input_type_current_semd \
-    import InputTypeCurrentSEMD
-from spynnaker.pyNN.models.neuron.threshold_types.threshold_type_static \
-    import ThresholdTypeStatic
+from spynnaker.pyNN.models.neuron.synapse_types import SynapseTypeExponential
+from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrentSEMD
+from spynnaker.pyNN.models.neuron.threshold_types import ThresholdTypeStatic
 
 
 class IFCurrExpSEMDBase(AbstractPyNNNeuronModelStandard):

--- a/spynnaker/pyNN/models/neuron/generator_data.py
+++ b/spynnaker/pyNN/models/neuron/generator_data.py
@@ -1,5 +1,5 @@
-import numpy
 import decimal
+import numpy
 from data_specification.enums.data_type import DataType
 
 

--- a/spynnaker/pyNN/models/neuron/implementations/abstract_neuron_impl.py
+++ b/spynnaker/pyNN/models/neuron/implementations/abstract_neuron_impl.py
@@ -1,6 +1,6 @@
 from six import add_metaclass
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod,\
-    abstractproperty
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractmethod, abstractproperty)
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
+++ b/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
@@ -1,7 +1,7 @@
-from .abstract_neuron_impl import AbstractNeuronImpl
-from spynnaker.pyNN.models.neuron.input_types import InputTypeConductance
-from spinn_utilities.overrides import overrides
 import numpy
+from spinn_utilities.overrides import overrides
+from spynnaker.pyNN.models.neuron.input_types import InputTypeConductance
+from .abstract_neuron_impl import AbstractNeuronImpl
 
 
 class NeuronImplStandard(AbstractNeuronImpl):

--- a/spynnaker/pyNN/models/neuron/implementations/ranged_dict_vertex_slice.py
+++ b/spynnaker/pyNN/models/neuron/implementations/ranged_dict_vertex_slice.py
@@ -1,6 +1,6 @@
-from spinn_utilities.helpful_functions import is_singleton
-import numpy
 import itertools
+import numpy
+from spinn_utilities.helpful_functions import is_singleton
 
 
 class RangedDictVertexSlice(object):

--- a/spynnaker/pyNN/models/neuron/implementations/struct.py
+++ b/spynnaker/pyNN/models/neuron/implementations/struct.py
@@ -1,8 +1,8 @@
+import numpy
 from spinn_utilities.helpful_functions import is_singleton
 from spinn_utilities.ranged.ranged_list import RangedList
-from spynnaker.pyNN.utilities.utility_calls import convert_to
 from spinn_front_end_common.utilities.globals_variables import get_simulator
-import numpy
+from spynnaker.pyNN.utilities.utility_calls import convert_to
 
 
 class Struct(object):

--- a/spynnaker/pyNN/models/neuron/input_types/abstract_input_type.py
+++ b/spynnaker/pyNN/models/neuron/input_types/abstract_input_type.py
@@ -1,6 +1,6 @@
 from spinn_utilities.abstract_base import abstractmethod
-from spynnaker.pyNN.models.neuron.implementations \
-    import AbstractStandardNeuronComponent
+from spynnaker.pyNN.models.neuron.implementations import (
+    AbstractStandardNeuronComponent)
 
 
 class AbstractInputType(AbstractStandardNeuronComponent):

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
@@ -1,5 +1,5 @@
-from data_specification.enums import DataType
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from .abstract_input_type import AbstractInputType
 
 E_REV_E = "e_rev_E"

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_current_semd.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_current_semd.py
@@ -1,7 +1,6 @@
-from data_specification.enums import DataType
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from .abstract_input_type import AbstractInputType
-
 
 MULTIPLICATOR = "multiplicator"
 INH_INPUT_PREVIOUS = "inh_input_previous"

--- a/spynnaker/pyNN/models/neuron/master_pop_table_generators/abstract_master_pop_table_factory.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table_generators/abstract_master_pop_table_factory.py
@@ -1,7 +1,5 @@
-# general imports
 import logging
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 logger = logging.getLogger(__name__)

--- a/spynnaker/pyNN/models/neuron/master_pop_table_generators/master_pop_table_as_2d_array.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table_generators/master_pop_table_as_2d_array.py
@@ -1,20 +1,12 @@
 from spinn_utilities.overrides import overrides
-
-# pacman imports
-from pacman.model.constraints.key_allocator_constraints \
-    import FixedKeyFieldConstraint, FixedMaskConstraint
-from pacman.utilities.utility_objs import Field
-
-# spynnaker imports
-from .abstract_master_pop_table_factory import AbstractMasterPopTableFactory
-from spynnaker.pyNN.exceptions import SynapticBlockGenerationException,\
-    SynapseRowTooBigException
-
-# spinn front end common imports
-from spinn_front_end_common.utilities import helpful_functions
-
-# dsg imports
 from data_specification.enums import DataType
+from pacman.model.constraints.key_allocator_constraints import (
+    FixedKeyFieldConstraint, FixedMaskConstraint)
+from pacman.utilities.utility_objs import Field
+from spinn_front_end_common.utilities import helpful_functions
+from .abstract_master_pop_table_factory import AbstractMasterPopTableFactory
+from spynnaker.pyNN.exceptions import (
+    SynapticBlockGenerationException, SynapseRowTooBigException)
 
 # Fixed row sizes allowed in this table
 ROW_LEN_TABLE_ENTRIES = [0, 1, 8, 16, 32, 64, 128, 256]

--- a/spynnaker/pyNN/models/neuron/master_pop_table_generators/master_pop_table_as_binary_search.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table_generators/master_pop_table_as_binary_search.py
@@ -1,21 +1,16 @@
-
-# spynnaker imports
+import logging
+import math
 import struct
+import sys
+import numpy
+from spinn_utilities.overrides import overrides
 from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
 from pacman.model.graphs.application import ApplicationVertex
-from spinn_utilities.overrides import overrides
-
-from spynnaker.pyNN.models.neural_projections \
-    import ProjectionApplicationEdge, ProjectionMachineEdge
-from spynnaker.pyNN.exceptions import SynapseRowTooBigException,\
-    SynapticConfigurationException
+from spynnaker.pyNN.models.neural_projections import (
+    ProjectionApplicationEdge, ProjectionMachineEdge)
+from spynnaker.pyNN.exceptions import (
+    SynapseRowTooBigException, SynapticConfigurationException)
 from .abstract_master_pop_table_factory import AbstractMasterPopTableFactory
-
-# general imports
-import logging
-import numpy
-import sys
-import math
 
 logger = logging.getLogger(__name__)
 _TWO_WORDS = struct.Struct("<II")

--- a/spynnaker/pyNN/models/neuron/neuron_models/__init__.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/__init__.py
@@ -1,7 +1,7 @@
 from .abstract_neuron_model import AbstractNeuronModel
 from .neuron_model_izh import NeuronModelIzh
-from .neuron_model_leaky_integrate_and_fire \
-    import NeuronModelLeakyIntegrateAndFire
+from .neuron_model_leaky_integrate_and_fire import (
+    NeuronModelLeakyIntegrateAndFire)
 
 __all__ = ["AbstractNeuronModel", "NeuronModelIzh",
            "NeuronModelLeakyIntegrateAndFire"]

--- a/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
@@ -1,8 +1,7 @@
 import numpy
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.implementations.struct import Struct
 from spynnaker.pyNN.models.neuron.implementations import (
-    AbstractStandardNeuronComponent)
+    AbstractStandardNeuronComponent, Struct)
 
 
 class AbstractNeuronModel(AbstractStandardNeuronComponent):

--- a/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
@@ -1,8 +1,8 @@
-from spinn_utilities.overrides import overrides
 import numpy
+from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.models.neuron.implementations.struct import Struct
-from spynnaker.pyNN.models.neuron.implementations \
-    import AbstractStandardNeuronComponent
+from spynnaker.pyNN.models.neuron.implementations import (
+    AbstractStandardNeuronComponent)
 
 
 class AbstractNeuronModel(AbstractStandardNeuronComponent):

--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
@@ -1,7 +1,7 @@
 from spinn_utilities.overrides import overrides
-from .abstract_neuron_model import AbstractNeuronModel
 from data_specification.enums import DataType
 from pacman.executor.injection_decorator import inject_items
+from .abstract_neuron_model import AbstractNeuronModel
 
 A = 'a'
 B = 'b'

--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate_and_fire.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate_and_fire.py
@@ -1,9 +1,8 @@
+import numpy
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from pacman.executor.injection_decorator import inject_items
 from .abstract_neuron_model import AbstractNeuronModel
-from data_specification.enums import DataType
-
-import numpy
 
 V = "v"
 V_REST = "v_rest"

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/common/plasticity_helpers.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/common/plasticity_helpers.py
@@ -1,12 +1,9 @@
 import math
 import logging
-
 from data_specification.enums import DataType
-
 from spinn_front_end_common.utilities.utility_objs import ProvenanceDataItem
 
 logger = logging.getLogger(__name__)
-
 # Default value of fixed-point one for STDP
 STDP_FIXED_POINT_ONE = (1 << 11)
 

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/synapse_structure/__init__.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/synapse_structure/__init__.py
@@ -1,7 +1,7 @@
 from .abstract_synapse_structure import AbstractSynapseStructure
 from .synapse_structure_weight_only import SynapseStructureWeightOnly
-from .synapse_structure_weight_accumulator \
-    import SynapseStructureWeightAccumulator
+from .synapse_structure_weight_accumulator import (
+    SynapseStructureWeightAccumulator)
 
 __all__ = [
     "AbstractSynapseStructure", "SynapseStructureWeightOnly",

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/synapse_structure/abstract_synapse_structure.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/synapse_structure/abstract_synapse_structure.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_accumulator.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_accumulator.py
@@ -1,6 +1,6 @@
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure \
-    import AbstractSynapseStructure
+from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure import (
+    AbstractSynapseStructure)
 
 
 class SynapseStructureWeightAccumulator(AbstractSynapseStructure):

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/__init__.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/__init__.py
@@ -1,10 +1,10 @@
 from .abstract_timing_dependence import AbstractTimingDependence
 from .timing_dependence_spike_pair import TimingDependenceSpikePair
-from .timing_dependence_pfister_spike_triplet\
-    import TimingDependencePfisterSpikeTriplet
+from .timing_dependence_pfister_spike_triplet import (
+    TimingDependencePfisterSpikeTriplet)
 from .timing_dependence_recurrent import TimingDependenceRecurrent
-from .timing_dependence_spike_nearest_pair \
-    import TimingDependenceSpikeNearestPair
+from .timing_dependence_spike_nearest_pair import (
+    TimingDependenceSpikeNearestPair)
 from .timing_dependence_vogels_2011 import TimingDependenceVogels2011
 
 __all__ = [

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/abstract_timing_dependence.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/abstract_timing_dependence.py
@@ -1,7 +1,6 @@
 from six import add_metaclass
-
-from spinn_utilities.abstract_base import \
-    AbstractBase, abstractmethod, abstractproperty
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractmethod, abstractproperty)
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_pfister_spike_triplet.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_pfister_spike_triplet.py
@@ -1,12 +1,14 @@
-from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.plasticity.stdp.common \
-    import plasticity_helpers
-from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence\
-    import AbstractTimingDependence
-from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure\
-    import SynapseStructureWeightOnly
-
 import logging
+from spinn_utilities.overrides import overrides
+from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
+    plasticity_helpers)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence\
+    import (
+        AbstractTimingDependence)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure\
+    import (
+        SynapseStructureWeightOnly)
+
 logger = logging.getLogger(__name__)
 
 LOOKUP_TAU_PLUS_SIZE = 256

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_recurrent.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_recurrent.py
@@ -1,13 +1,11 @@
 import math
-
-from data_specification.enums import DataType
-
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from .abstract_timing_dependence import AbstractTimingDependence
-from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure \
-    import SynapseStructureWeightAccumulator
-from spynnaker.pyNN.models.neuron.plasticity.stdp.common \
-    import plasticity_helpers
+from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure import (
+    SynapseStructureWeightAccumulator)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
+    plasticity_helpers)
 
 
 class TimingDependenceRecurrent(AbstractTimingDependence):

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_spike_nearest_pair.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_spike_nearest_pair.py
@@ -1,12 +1,11 @@
+import logging
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.plasticity.stdp.common \
-    import plasticity_helpers
-from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure \
-    import SynapseStructureWeightOnly
+from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
+    plasticity_helpers)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure import (
+    SynapseStructureWeightOnly)
 from .abstract_timing_dependence import AbstractTimingDependence
 from .timing_dependence_spike_pair import TimingDependenceSpikePair
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_spike_pair.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_spike_pair.py
@@ -1,12 +1,11 @@
-from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.plasticity.stdp.common \
-    import plasticity_helpers
-from .abstract_timing_dependence import AbstractTimingDependence
-from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure\
-    import SynapseStructureWeightOnly
-
-
 import logging
+from spinn_utilities.overrides import overrides
+from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
+    plasticity_helpers)
+from .abstract_timing_dependence import AbstractTimingDependence
+from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure import (
+    SynapseStructureWeightOnly)
+
 logger = logging.getLogger(__name__)
 
 LOOKUP_TAU_PLUS_SIZE = 256

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_vogels_2011.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_vogels_2011.py
@@ -1,14 +1,13 @@
-from data_specification.enums import DataType
-
-from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence\
-    import AbstractTimingDependence
-from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure\
-    import SynapseStructureWeightOnly
-from spynnaker.pyNN.models.neuron.plasticity.stdp.common \
-    import plasticity_helpers
-
 import logging
+from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
+from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence import (
+    AbstractTimingDependence)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.synapse_structure import (
+    SynapseStructureWeightOnly)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
+    plasticity_helpers)
+
 logger = logging.getLogger(__name__)
 
 # Constants

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/abstract_has_a_plus_a_minus.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/abstract_has_a_plus_a_minus.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase
 
 

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/abstract_weight_dependence.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/abstract_weight_dependence.py
@@ -1,7 +1,6 @@
 from six import add_metaclass
-
-from spinn_utilities.abstract_base import \
-    AbstractBase, abstractmethod, abstractproperty
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractmethod, abstractproperty)
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_additive.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_additive.py
@@ -1,5 +1,5 @@
-from data_specification.enums import DataType
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from .abstract_has_a_plus_a_minus import AbstractHasAPlusAMinus
 from .abstract_weight_dependence import AbstractWeightDependence
 

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_multiplicative.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_multiplicative.py
@@ -1,5 +1,5 @@
-from data_specification.enums import DataType
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from .abstract_has_a_plus_a_minus import AbstractHasAPlusAMinus
 from .abstract_weight_dependence import AbstractWeightDependence
 

--- a/spynnaker/pyNN/models/neuron/population_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_vertex.py
@@ -1,27 +1,20 @@
+from enum import Enum
 from spinn_utilities.overrides import overrides
-
-# pacman imports
 from pacman.model.graphs.machine import MachineVertex
-
-# spinn front end common imports
 from spinn_front_end_common.utilities.utility_objs import ProvenanceDataItem
-from spinn_front_end_common.interface.provenance \
-    import ProvidesProvenanceDataFromMachineImpl
-from spinn_front_end_common.interface.buffer_management.buffer_models \
-    import AbstractReceiveBuffersToHost
-from spinn_front_end_common.interface.buffer_management\
-    import recording_utilities
-from spinn_front_end_common.utilities.helpful_functions \
-    import locate_memory_region_for_placement
+from spinn_front_end_common.interface.provenance import (
+    ProvidesProvenanceDataFromMachineImpl)
+from spinn_front_end_common.interface.buffer_management.buffer_models import (
+    AbstractReceiveBuffersToHost)
+from spinn_front_end_common.interface.buffer_management import (
+    recording_utilities)
+from spinn_front_end_common.utilities.helpful_functions import (
+    locate_memory_region_for_placement)
 from spinn_front_end_common.abstract_models import AbstractRecordable
 from spinn_front_end_common.interface.profiling import AbstractHasProfileData
-from spinn_front_end_common.interface.profiling.profile_utils \
-    import get_profiling_data
-
-# spynnaker imports
+from spinn_front_end_common.interface.profiling.profile_utils import (
+    get_profiling_data)
 from spynnaker.pyNN.utilities.constants import POPULATION_BASED_REGIONS
-
-from enum import Enum
 
 
 class PopulationMachineVertex(

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
@@ -1,7 +1,7 @@
 from .abstract_synapse_dynamics import AbstractSynapseDynamics
 from .abstract_generate_on_machine import AbstractGenerateOnMachine
-from .abstract_synapse_dynamics_structural \
-    import AbstractSynapseDynamicsStructural
+from .abstract_synapse_dynamics_structural import (
+    AbstractSynapseDynamicsStructural)
 from .abstract_static_synapse_dynamics import AbstractStaticSynapseDynamics
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .pynn_synapse_dynamics import PyNNSynapseDynamics

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_generate_on_machine.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_generate_on_machine.py
@@ -1,7 +1,7 @@
-from six import add_metaclass
 from enum import Enum
-from spinn_utilities.abstract_base import AbstractBase, abstractproperty
 import numpy
+from six import add_metaclass
+from spinn_utilities.abstract_base import AbstractBase, abstractproperty
 
 
 class MatrixGeneratorID(Enum):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_plastic_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_plastic_synapse_dynamics.py
@@ -1,8 +1,6 @@
-from .abstract_synapse_dynamics import AbstractSynapseDynamics
-
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from .abstract_synapse_dynamics import AbstractSynapseDynamics
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_static_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_static_synapse_dynamics.py
@@ -1,8 +1,6 @@
-from .abstract_synapse_dynamics import AbstractSynapseDynamics
-
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+from .abstract_synapse_dynamics import AbstractSynapseDynamics
 
 
 @add_metaclass(AbstractBase)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -1,7 +1,6 @@
-from six import add_metaclass
-import numpy
 import math
-
+import numpy
+from six import add_metaclass
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -1,11 +1,10 @@
 import numpy
-
-from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
 from spinn_utilities.overrides import overrides
+from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
 from spynnaker.pyNN.models.abstract_models import AbstractSettable
 from .abstract_static_synapse_dynamics import AbstractStaticSynapseDynamics
-from .abstract_generate_on_machine import AbstractGenerateOnMachine, \
-    MatrixGeneratorID
+from .abstract_generate_on_machine import (
+    AbstractGenerateOnMachine, MatrixGeneratorID)
 from spynnaker.pyNN.exceptions import InvalidParameterType
 from .abstract_synapse_dynamics import AbstractSynapseDynamics
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -1,18 +1,16 @@
 import math
 import numpy
-
-from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
 from spinn_utilities.overrides import overrides
+from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
 from spynnaker.pyNN.models.abstract_models import AbstractSettable
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
-from .abstract_generate_on_machine import AbstractGenerateOnMachine, \
-    MatrixGeneratorID
+from .abstract_generate_on_machine import (
+    AbstractGenerateOnMachine, MatrixGeneratorID)
 from spynnaker.pyNN.exceptions import InvalidParameterType
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 
 # How large are the time-stamps stored with each event
 TIME_STAMP_BYTES = 4
-
 # When not using the MAD scheme, how many pre-synaptic events are buffered
 NUM_PRE_SYNAPTIC_EVENTS = 4
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -1,12 +1,11 @@
-from six import itervalues
-import numpy as np
 import collections
-
+import numpy as np
+from six import itervalues
 from data_specification.enums.data_type import DataType
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 from spynnaker.pyNN.models.neural_projections import ProjectionMachineEdge
-from .abstract_synapse_dynamics_structural import \
-    AbstractSynapseDynamicsStructural
+from .abstract_synapse_dynamics_structural import (
+    AbstractSynapseDynamicsStructural)
 from spynnaker.pyNN.utilities import constants
 
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -1,9 +1,9 @@
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.synapse_dynamics import \
-    AbstractSynapseDynamicsStructural
-from spynnaker.pyNN.models.neuron.synapse_dynamics. \
-    synapse_dynamics_structural_common import \
-    SynapseDynamicsStructuralCommon as CommonSP
+from .abstract_synapse_dynamics_structural import (
+    AbstractSynapseDynamicsStructural)
+from .synapse_dynamics_structural_common import (
+    SynapseDynamicsStructuralCommon as
+    CommonSP)
 from .synapse_dynamics_static import SynapseDynamicsStatic
 
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -1,9 +1,9 @@
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron.synapse_dynamics import \
-    AbstractSynapseDynamicsStructural, SynapseDynamicsSTDP
-from spynnaker.pyNN.models.neuron.synapse_dynamics. \
-    synapse_dynamics_structural_common import \
-    SynapseDynamicsStructuralCommon as CommonSP
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    AbstractSynapseDynamicsStructural, SynapseDynamicsSTDP)
+from .synapse_dynamics_structural_common import (
+    SynapseDynamicsStructuralCommon as
+    CommonSP)
 
 
 class SynapseDynamicsStructuralSTDP(AbstractSynapseDynamicsStructural,

--- a/spynnaker/pyNN/models/neuron/synapse_io/abstract_synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io/abstract_synapse_io.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/models/neuron/synapse_io/synapse_io_row_based.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io/synapse_io_row_based.py
@@ -1,21 +1,16 @@
-import numpy
 import math
+import numpy
 from six import raise_from
 from spinn_utilities.overrides import overrides
-
-from spynnaker.pyNN.models.neural_projections.connectors \
-    import AbstractConnector
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    AbstractConnector)
 from spynnaker.pyNN.exceptions import SynapseRowTooBigException
-from spynnaker.pyNN.models.neuron.synapse_dynamics import \
-    SynapseDynamicsStructuralStatic, SynapseDynamicsStructuralSTDP
 from .abstract_synapse_io import AbstractSynapseIO
 from .max_row_info import MaxRowInfo
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import AbstractStaticSynapseDynamics, AbstractSynapseDynamicsStructural
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import SynapseDynamicsSTDP
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import AbstractSynapseDynamics
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    SynapseDynamicsStructuralStatic, SynapseDynamicsStructuralSTDP,
+    AbstractStaticSynapseDynamics, AbstractSynapseDynamicsStructural,
+    SynapseDynamicsSTDP, AbstractSynapseDynamics)
 
 _N_HEADER_WORDS = 3
 

--- a/spynnaker/pyNN/models/neuron/synapse_types/abstract_synapse_type.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/abstract_synapse_type.py
@@ -1,6 +1,6 @@
 from spinn_utilities.abstract_base import abstractmethod
-from spynnaker.pyNN.models.neuron.implementations \
-    import AbstractStandardNeuronComponent
+from spynnaker.pyNN.models.neuron.implementations import (
+    AbstractStandardNeuronComponent)
 
 
 class AbstractSynapseType(AbstractStandardNeuronComponent):

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
@@ -1,8 +1,8 @@
+import numpy
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
-from data_specification.enums import DataType
-import numpy
 
 EXC_RESPONSE = "exc_response"
 EXC_EXP_RESPONSE = "exc_exp_response"

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_dual_exponential.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_dual_exponential.py
@@ -1,8 +1,8 @@
+import numpy
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
-from data_specification.enums import DataType
-import numpy
 
 TAU_SYN_E = 'tau_syn_E'
 TAU_SYN_E2 = 'tau_syn_E2'

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_exponential.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_exponential.py
@@ -1,8 +1,8 @@
+import numpy
 from spinn_utilities.overrides import overrides
+from data_specification.enums import DataType
 from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
-from data_specification.enums import DataType
-import numpy
 
 TAU_SYN_E = 'tau_syn_E'
 TAU_SYN_I = 'tau_syn_I'

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -1,45 +1,34 @@
+from collections import defaultdict
 import math
-import scipy.stats  # @UnresolvedImport
 import struct
 import sys
-from collections import defaultdict
-from scipy import special  # @UnresolvedImport
 import numpy
-
-# PACMAN imports
-from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
-
-# spinn utilities
+import scipy.stats  # @UnresolvedImport
+from scipy import special  # @UnresolvedImport
 from spinn_utilities.helpful_functions import get_valid_components
-from spynnaker.pyNN.models.neuron.generator_data import GeneratorData
-
-# front-end common
-from spinn_front_end_common.utilities.helpful_functions \
-    import locate_memory_region_for_placement
-from spinn_front_end_common.utilities.globals_variables import get_simulator
-
-# dsg
+from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
 from data_specification.enums import DataType
-
-# spynnaker
+from spinn_front_end_common.utilities.helpful_functions import (
+    locate_memory_region_for_placement)
+from spinn_front_end_common.utilities.globals_variables import get_simulator
+from spynnaker.pyNN.models.neuron.generator_data import GeneratorData
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
-from spynnaker.pyNN.models.neural_projections.connectors \
-    import OneToOneConnector, AbstractGenerateConnectorOnMachine
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    OneToOneConnector, AbstractGenerateConnectorOnMachine)
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 from spynnaker.pyNN.models.neuron import master_pop_table_generators
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import SynapseDynamicsStatic, AbstractSynapseDynamicsStructural, \
-    AbstractGenerateOnMachine
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    SynapseDynamicsStatic, AbstractSynapseDynamicsStructural,
+    AbstractGenerateOnMachine)
 from spynnaker.pyNN.models.neuron.synapse_io import SynapseIORowBased
-from spynnaker.pyNN.models.spike_source.spike_source_poisson_vertex \
-    import SpikeSourcePoissonVertex
+from spynnaker.pyNN.models.spike_source.spike_source_poisson_vertex import (
+    SpikeSourcePoissonVertex)
 from spynnaker.pyNN.models.utility_models import DelayExtensionVertex
-from spynnaker.pyNN.utilities.constants \
-    import POPULATION_BASED_REGIONS, POSSION_SIGMA_SUMMATION_LIMIT
-from spynnaker.pyNN.utilities.utility_calls \
-    import get_maximum_probable_value, get_n_bits
+from spynnaker.pyNN.utilities.constants import (
+    POPULATION_BASED_REGIONS, POSSION_SIGMA_SUMMATION_LIMIT)
+from spynnaker.pyNN.utilities.utility_calls import (
+    get_maximum_probable_value, get_n_bits)
 from spynnaker.pyNN.utilities.running_stats import RunningStats
-
 
 TIME_STAMP_BYTES = 4
 

--- a/spynnaker/pyNN/models/neuron/threshold_types/abstract_threshold_type.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/abstract_threshold_type.py
@@ -1,5 +1,5 @@
-from spynnaker.pyNN.models.neuron.implementations \
-    import AbstractStandardNeuronComponent
+from spynnaker.pyNN.models.neuron.implementations import (
+    AbstractStandardNeuronComponent)
 
 
 class AbstractThresholdType(AbstractStandardNeuronComponent):

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
@@ -1,7 +1,7 @@
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from .abstract_threshold_type import AbstractThresholdType
 from pacman.executor.injection_decorator import inject_items
+from .abstract_threshold_type import AbstractThresholdType
 
 DU_TH = "du_th"
 TAU_TH = "tau_th"

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_static.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_static.py
@@ -1,6 +1,6 @@
 from spinn_utilities.overrides import overrides
-from .abstract_threshold_type import AbstractThresholdType
 from data_specification.enums import DataType
+from .abstract_threshold_type import AbstractThresholdType
 
 V_THRESH = "v_thresh"
 

--- a/spynnaker/pyNN/models/pynn_population_common.py
+++ b/spynnaker/pyNN/models/pynn_population_common.py
@@ -1,26 +1,20 @@
+import logging
+import numpy
+from six import string_types, iteritems
+from spinn_utilities.log import FormatAdapter
 from pacman.model.constraints import AbstractConstraint
-from pacman.model.constraints.placer_constraints\
-    import ChipAndCoreConstraint
-from pacman.model.constraints.partitioner_constraints\
-    import MaxVertexAtomsConstraint
-from pacman.model.graphs.application.application_vertex \
-    import ApplicationVertex
-
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractReadParametersBeforeSet, AbstractContainsUnits
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractPopulationInitializable, AbstractPopulationSettable
-from .abstract_pynn_model import AbstractPyNNModel
-
+from pacman.model.constraints.placer_constraints import ChipAndCoreConstraint
+from pacman.model.constraints.partitioner_constraints import (
+    MaxVertexAtomsConstraint)
+from pacman.model.graphs.application.application_vertex import (
+    ApplicationVertex)
 from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
-
-from spinn_utilities.log import FormatAdapter
-
-import numpy
-import logging
-from six import string_types, iteritems
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractReadParametersBeforeSet, AbstractContainsUnits,
+    AbstractPopulationInitializable, AbstractPopulationSettable)
+from .abstract_pynn_model import AbstractPyNNModel
 
 logger = FormatAdapter(logging.getLogger(__file__))
 

--- a/spynnaker/pyNN/models/pynn_projection_common.py
+++ b/spynnaker/pyNN/models/pynn_projection_common.py
@@ -1,23 +1,18 @@
-from pacman.model.constraints.partitioner_constraints \
-    import SameAtomsAsVertexConstraint
+import logging
+import math
+from spinn_utilities.progress_bar import ProgressBar
+from pacman.model.constraints.partitioner_constraints import (
+    SameAtomsAsVertexConstraint)
 from spinn_front_end_common.utilities import helpful_functions
-
-from spynnaker.pyNN.models.abstract_models \
-    import AbstractAcceptsIncomingSynapses
-from spynnaker.pyNN.models.neural_projections \
-    import DelayedApplicationEdge, SynapseInformation
-from spynnaker.pyNN.models.neural_projections \
-    import ProjectionApplicationEdge, DelayAfferentApplicationEdge
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractAcceptsIncomingSynapses)
+from spynnaker.pyNN.models.neural_projections import (
+    DelayedApplicationEdge, SynapseInformation,
+    ProjectionApplicationEdge, DelayAfferentApplicationEdge)
 from spynnaker.pyNN.models.utility_models import DelayExtensionVertex
 from spynnaker.pyNN.utilities import constants
 from spynnaker.pyNN.models.neuron import ConnectionHolder
-
-from spinn_front_end_common.utilities.exceptions import ConfigurationException
-
-from spinn_utilities.progress_bar import ProgressBar
-
-import logging
-import math
 # pylint: disable=protected-access
 
 logger = logging.getLogger(__name__)

--- a/spynnaker/pyNN/models/recording_common.py
+++ b/spynnaker/pyNN/models/recording_common.py
@@ -1,16 +1,14 @@
+from collections import defaultdict
+import logging
+import numpy
+from six.moves import xrange
 from spinn_utilities import logger_utils
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.timer import Timer
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.globals_variables import get_simulator
-
-from spynnaker.pyNN.models.common import AbstractSpikeRecordable
-from spynnaker.pyNN.models.common import AbstractNeuronRecordable
-
-from collections import defaultdict
-import numpy
-import logging
-from six.moves import xrange
+from spynnaker.pyNN.models.common import (
+    AbstractSpikeRecordable, AbstractNeuronRecordable)
 # pylint: disable=protected-access
 
 logger = FormatAdapter(logging.getLogger(__name__))

--- a/spynnaker/pyNN/models/spike_source/spike_source_array.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array.py
@@ -1,5 +1,5 @@
-from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spinn_utilities.overrides import overrides
+from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spynnaker.pyNN.utilities import constants
 from .spike_source_array_vertex import SpikeSourceArrayVertex
 

--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -1,20 +1,16 @@
 import logging
 import sys
-
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.utility_models import ReverseIpTagMultiCastSource
-from spinn_front_end_common.utilities.constants \
-    import MAX_SIZE_OF_BUFFERED_REGION_ON_CHIP
-from spinn_front_end_common.utilities import exceptions
-from spinn_front_end_common.utilities import helpful_functions
+from spinn_front_end_common.utilities.constants import (
+    MAX_SIZE_OF_BUFFERED_REGION_ON_CHIP)
+from spinn_front_end_common.utilities import exceptions, helpful_functions
 from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
-from spinn_front_end_common.abstract_models.impl\
-    import ProvidesKeyToAtomMappingImpl
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.utilities import globals_variables
-
-from spynnaker.pyNN.models.common import AbstractSpikeRecordable
-from spynnaker.pyNN.models.common import EIEIOSpikeRecorder
-from spynnaker.pyNN.models.common import SimplePopulationSettable
+from spynnaker.pyNN.models.common import (
+    AbstractSpikeRecordable, EIEIOSpikeRecorder, SimplePopulationSettable)
 from spynnaker.pyNN.utilities import constants
 
 logger = logging.getLogger(__name__)

--- a/spynnaker/pyNN/models/spike_source/spike_source_from_file.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_from_file.py
@@ -1,9 +1,6 @@
-# spynnaker imports
+import numpy
 from .spike_source_array import SpikeSourceArray
 from spynnaker.pyNN.utilities import utility_calls
-
-# general imports
-import numpy
 
 
 class SpikeSourceFromFile(SpikeSourceArray):

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -1,23 +1,20 @@
+from enum import Enum
 from spinn_utilities.overrides import overrides
 from pacman.executor.injection_decorator import inject_items
-from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.abstract_models \
-    import AbstractSupportsDatabaseInjection
-from spinn_front_end_common.utilities.helpful_functions \
-    import locate_memory_region_for_placement
 from pacman.model.graphs.machine import MachineVertex
-from spinn_front_end_common.abstract_models import AbstractRecordable
-from spinn_front_end_common.interface.provenance \
-    import ProvidesProvenanceDataFromMachineImpl
-from spinn_front_end_common.interface.buffer_management.buffer_models \
-    import AbstractReceiveBuffersToHost
-from spinn_front_end_common.interface.buffer_management \
-    import recording_utilities
-
-from spynnaker.pyNN.utilities.constants \
-    import LIVE_POISSON_CONTROL_PARTITION_ID
-
-from enum import Enum
+from spinn_front_end_common.abstract_models import (
+    AbstractSupportsDatabaseInjection, AbstractRecordable)
+from spinn_front_end_common.interface.provenance import (
+    ProvidesProvenanceDataFromMachineImpl)
+from spinn_front_end_common.interface.buffer_management.buffer_models import (
+    AbstractReceiveBuffersToHost)
+from spinn_front_end_common.interface.buffer_management import (
+    recording_utilities)
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
+from spinn_front_end_common.utilities.helpful_functions import (
+    locate_memory_region_for_placement)
+from spynnaker.pyNN.utilities.constants import (
+    LIVE_POISSON_CONTROL_PARTITION_ID)
 
 
 class SpikeSourcePoissonMachineVertex(

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
@@ -27,12 +27,10 @@ from spinn_front_end_common.utilities.constants import (
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spynnaker.pyNN.models.common import (
-    AbstractSpikeRecordable, MultiSpikeRecorder)
+    AbstractSpikeRecordable, MultiSpikeRecorder, SimplePopulationSettable)
 from spynnaker.pyNN.utilities import constants, utility_calls
 from spynnaker.pyNN.models.abstract_models import (
     AbstractReadParametersBeforeSet)
-from spynnaker.pyNN.models.common.simple_population_settable import (
-    SimplePopulationSettable)
 from spynnaker.pyNN.models.neuron.implementations import Struct
 from .spike_source_poisson_machine_vertex import (
     SpikeSourcePoissonMachineVertex)

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
@@ -1,49 +1,41 @@
-import scipy.stats
 import logging
 import math
 import random
 import numpy
-
+import scipy.stats
 from spinn_utilities.overrides import overrides
-
 from data_specification.enums import DataType
-
 from pacman.executor.injection_decorator import inject_items
-from pacman.model.constraints.key_allocator_constraints \
-    import ContiguousKeyRangeContraint
+from pacman.model.constraints.key_allocator_constraints import (
+    ContiguousKeyRangeContraint)
 from pacman.model.graphs.application import ApplicationVertex
-from pacman.model.resources import CPUCyclesPerTickResource, DTCMResource
-from pacman.model.resources import ResourceContainer, SDRAMResource
-
-from spinn_front_end_common.abstract_models import \
-    AbstractChangableAfterRun, AbstractProvidesOutgoingPartitionConstraints
+from pacman.model.resources import (
+    CPUCyclesPerTickResource, DTCMResource, ResourceContainer, SDRAMResource)
+from spinn_front_end_common.abstract_models import (
+    AbstractChangableAfterRun, AbstractProvidesOutgoingPartitionConstraints,
+    AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary,
+    AbstractRewritesDataSpecification)
+from spinn_front_end_common.abstract_models.impl import (
+    ProvidesKeyToAtomMappingImpl)
 from spinn_front_end_common.interface.simulation import simulation_utilities
-from spinn_front_end_common.abstract_models \
-    import AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary
-from spinn_front_end_common.utilities import helpful_functions
-from spinn_front_end_common.interface.buffer_management \
-    import recording_utilities
-from spinn_front_end_common.utilities.constants \
-    import SYSTEM_BYTES_REQUIREMENT, SARK_PER_MALLOC_SDRAM_USAGE
-from spinn_front_end_common.abstract_models \
-    import AbstractRewritesDataSpecification
-from spinn_front_end_common.abstract_models.impl\
-    import ProvidesKeyToAtomMappingImpl
-from spinn_front_end_common.utilities import globals_variables
+from spinn_front_end_common.interface.buffer_management import (
+    recording_utilities)
+from spinn_front_end_common.utilities import (
+    helpful_functions, globals_variables)
+from spinn_front_end_common.utilities.constants import (
+    SYSTEM_BYTES_REQUIREMENT, SARK_PER_MALLOC_SDRAM_USAGE)
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-
-from spynnaker.pyNN.models.common import AbstractSpikeRecordable
-from spynnaker.pyNN.models.common import MultiSpikeRecorder
-from spynnaker.pyNN.utilities import constants
-from spynnaker.pyNN.utilities import utility_calls
-from spynnaker.pyNN.models.abstract_models\
-    import AbstractReadParametersBeforeSet
-from spynnaker.pyNN.models.common.simple_population_settable \
-    import SimplePopulationSettable
+from spynnaker.pyNN.models.common import (
+    AbstractSpikeRecordable, MultiSpikeRecorder)
+from spynnaker.pyNN.utilities import constants, utility_calls
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractReadParametersBeforeSet)
+from spynnaker.pyNN.models.common.simple_population_settable import (
+    SimplePopulationSettable)
 from spynnaker.pyNN.models.neuron.implementations import Struct
-from .spike_source_poisson_machine_vertex \
-    import SpikeSourcePoissonMachineVertex
+from .spike_source_poisson_machine_vertex import (
+    SpikeSourcePoissonMachineVertex)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/utility_models/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delay_extension_machine_vertex.py
@@ -1,13 +1,9 @@
+from enum import Enum
 from spinn_utilities.overrides import overrides
 from pacman.model.graphs.machine import MachineVertex
-
-# front end common imports
-from spinn_front_end_common.interface.provenance \
-    import ProvidesProvenanceDataFromMachineImpl
+from spinn_front_end_common.interface.provenance import (
+    ProvidesProvenanceDataFromMachineImpl)
 from spinn_front_end_common.utilities.utility_objs import ProvenanceDataItem
-
-# general imports
-from enum import Enum
 
 
 class DelayExtensionMachineVertex(

--- a/spynnaker/pyNN/models/utility_models/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delay_extension_vertex.py
@@ -1,44 +1,34 @@
+from collections import defaultdict
 import logging
 import math
 import random
 import sys
-from collections import defaultdict
-
 from spinn_utilities.overrides import overrides
-
-from spinn_front_end_common.utilities.constants import \
-    SARK_PER_MALLOC_SDRAM_USAGE, SYSTEM_BYTES_REQUIREMENT
-
 from pacman.executor.injection_decorator import inject_items
 from pacman.model.abstract_classes import AbstractHasGlobalMaxAtoms
-from pacman.model.constraints.key_allocator_constraints \
-    import ContiguousKeyRangeContraint
-from pacman.model.constraints.partitioner_constraints \
-    import SameAtomsAsVertexConstraint
+from pacman.model.constraints.key_allocator_constraints import (
+    ContiguousKeyRangeContraint)
+from pacman.model.constraints.partitioner_constraints import (
+    SameAtomsAsVertexConstraint)
 from pacman.model.graphs.application import ApplicationVertex
-from pacman.model.resources import CPUCyclesPerTickResource, DTCMResource
-from pacman.model.resources import ResourceContainer, SDRAMResource
-
-from spinn_front_end_common.abstract_models \
-    import AbstractProvidesNKeysForPartition
-from spinn_front_end_common.abstract_models import \
-    AbstractProvidesOutgoingPartitionConstraints
+from pacman.model.resources import (
+    CPUCyclesPerTickResource, DTCMResource, ResourceContainer, SDRAMResource)
+from spinn_front_end_common.utilities.constants import (
+    SARK_PER_MALLOC_SDRAM_USAGE, SYSTEM_BYTES_REQUIREMENT)
+from spinn_front_end_common.abstract_models import (
+    AbstractProvidesNKeysForPartition, AbstractGeneratesDataSpecification,
+    AbstractProvidesOutgoingPartitionConstraints, AbstractHasAssociatedBinary)
 from spinn_front_end_common.interface.simulation import simulation_utilities
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
-
-from spinn_front_end_common.abstract_models \
-    import AbstractGeneratesDataSpecification, AbstractHasAssociatedBinary
 from .delay_block import DelayBlock
 from .delay_extension_machine_vertex import DelayExtensionMachineVertex
 from .delay_generator_data import DelayGeneratorData
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
-from spynnaker.pyNN.models.neural_projections \
-    import DelayedApplicationEdge
-from spynnaker.pyNN.models.neural_projections.connectors\
-    import AbstractGenerateConnectorOnMachine
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import AbstractGenerateOnMachine
-
+from spynnaker.pyNN.models.neural_projections import DelayedApplicationEdge
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    AbstractGenerateConnectorOnMachine)
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    AbstractGenerateOnMachine)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/utility_models/delay_generator_data.py
+++ b/spynnaker/pyNN/models/utility_models/delay_generator_data.py
@@ -1,5 +1,5 @@
-import numpy
 import decimal
+import numpy
 from data_specification.enums.data_type import DataType
 
 

--- a/spynnaker/pyNN/models/utility_models/spike_injector_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector_vertex.py
@@ -1,17 +1,13 @@
 import logging
-
 from spinn_utilities.overrides import overrides
-from pacman.model.constraints.key_allocator_constraints \
-    import ContiguousKeyRangeContraint
-
-from spinn_front_end_common.abstract_models \
-    import AbstractProvidesOutgoingPartitionConstraints
+from pacman.model.constraints.key_allocator_constraints import (
+    ContiguousKeyRangeContraint)
+from spinn_front_end_common.abstract_models import (
+    AbstractProvidesOutgoingPartitionConstraints)
 from spinn_front_end_common.utility_models import ReverseIpTagMultiCastSource
 from spinn_front_end_common.utilities.globals_variables import get_simulator
-
-from spynnaker.pyNN.models.common \
-    import AbstractSpikeRecordable, EIEIOSpikeRecorder, \
-    SimplePopulationSettable
+from spynnaker.pyNN.models.common import (
+    AbstractSpikeRecordable, EIEIOSpikeRecorder, SimplePopulationSettable)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/models/utility_models/synapse_expander/synapse_expander.py
+++ b/spynnaker/pyNN/models/utility_models/synapse_expander/synapse_expander.py
@@ -1,11 +1,11 @@
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
-from spynnaker.pyNN.models.utility_models import DelayExtensionVertex
+import logging
+import os
+from spinn_utilities.progress_bar import ProgressBar
 from spinnman.model import ExecutableTargets
 from spinnman.model.enums import CPUState
-import logging
+from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.utility_models import DelayExtensionVertex
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spinn_utilities.progress_bar import ProgressBar
-import os
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/overridden_pacman_functions/graph_edge_filter.py
+++ b/spynnaker/pyNN/overridden_pacman_functions/graph_edge_filter.py
@@ -1,19 +1,13 @@
+import logging
 from spinn_utilities.progress_bar import ProgressBar
-
-# pacman imports
 from pacman.model.graphs.application import ApplicationEdge
 from pacman.model.graphs.machine import MachineGraph
 from pacman.model.graphs.common import GraphMapper
-
-# spynnaker imports
 from spynnaker.pyNN.exceptions import FilterableException
 from spynnaker.pyNN.models.abstract_models import AbstractFilterableEdge
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
-from spynnaker.pyNN.models.neuron.synapse_dynamics import \
-    AbstractSynapseDynamicsStructural
-
-# import logging
-import logging
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    AbstractSynapseDynamicsStructural)
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/overridden_pacman_functions/graph_edge_weight_updater.py
+++ b/spynnaker/pyNN/overridden_pacman_functions/graph_edge_weight_updater.py
@@ -1,7 +1,7 @@
+import logging
 from spinn_utilities.progress_bar import ProgressBar
 from spynnaker.pyNN.models.abstract_models import AbstractWeightUpdatable
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/spynnaker/pyNN/overridden_pacman_functions/spynnaker_data_specification_writer.py
+++ b/spynnaker/pyNN/overridden_pacman_functions/spynnaker_data_specification_writer.py
@@ -1,6 +1,5 @@
-from spinn_front_end_common.interface.interface_functions import \
-    GraphDataSpecificationWriter
-
+from spinn_front_end_common.interface.interface_functions import (
+    GraphDataSpecificationWriter)
 from spynnaker.pyNN.models.utility_models import DelayExtensionVertex
 
 

--- a/spynnaker/pyNN/protocols/__init__.py
+++ b/spynnaker/pyNN/protocols/__init__.py
@@ -1,6 +1,6 @@
 from .munich_io_ethernet_protocol import MunichIoEthernetProtocol
-from .munich_io_spinnaker_link_protocol \
-    import MunichIoSpiNNakerLinkProtocol, RetinaKey, RetinaPayload
+from .munich_io_spinnaker_link_protocol import (
+    MunichIoSpiNNakerLinkProtocol, RetinaKey, RetinaPayload)
 
 __all__ = ["MunichIoEthernetProtocol", "MunichIoSpiNNakerLinkProtocol",
            "RetinaKey", "RetinaPayload"]

--- a/spynnaker/pyNN/protocols/munich_io_spinnaker_link_protocol.py
+++ b/spynnaker/pyNN/protocols/munich_io_spinnaker_link_protocol.py
@@ -1,8 +1,7 @@
 from enum import Enum
+import logging
 from spinn_front_end_common.utility_models import MultiCastCommand
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
+++ b/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
@@ -1,15 +1,15 @@
 from pacman.model.graphs.application import ApplicationEdge
 from spinnman.messages.eieio import EIEIOType
-from spinn_front_end_common.utilities.globals_variables import get_simulator
-from spynnaker.pyNN.utilities import constants
 from spinn_front_end_common.utilities import helpful_functions
+from spinn_front_end_common.utilities.globals_variables import get_simulator
+from spinn_front_end_common.utility_models import (
+    ReverseIpTagMultiCastSource)
+from spinn_front_end_common.utilities.notification_protocol import (
+    SocketAddress)
+from spinn_front_end_common.utilities.utility_objs import (
+    LivePacketGatherParameters)
+from spynnaker.pyNN.utilities import constants
 from spynnaker.pyNN.models.pynn_population_common import PyNNPopulationCommon
-from spinn_front_end_common.utility_models \
-    import ReverseIpTagMultiCastSource
-from spinn_front_end_common.utilities.notification_protocol \
-    import SocketAddress
-from spinn_front_end_common.utilities.utility_objs \
-    import LivePacketGatherParameters
 
 
 class SpynnakerExternalDevicePluginManager(object):

--- a/spynnaker/pyNN/spynnaker_simulator_interface.py
+++ b/spynnaker/pyNN/spynnaker_simulator_interface.py
@@ -1,9 +1,6 @@
 from six import add_metaclass
-
-from spinn_utilities.abstract_base import AbstractBase
-from spinn_utilities.abstract_base import abstractproperty
-from spinn_utilities.abstract_base import abstractmethod
-
+from spinn_utilities.abstract_base import (
+    AbstractBase, abstractproperty, abstractmethod)
 from spinn_front_end_common.utilities import SimulatorInterface
 
 

--- a/spynnaker/pyNN/utilities/random_stats/abstract_random_stats.py
+++ b/spynnaker/pyNN/utilities/random_stats/abstract_random_stats.py
@@ -1,5 +1,4 @@
 from six import add_metaclass
-
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 

--- a/spynnaker/pyNN/utilities/spynnaker_failed_state.py
+++ b/spynnaker/pyNN/utilities/spynnaker_failed_state.py
@@ -1,8 +1,8 @@
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.utilities.failed_state import FailedState, \
-    FAILED_STATE_MSG
-from spynnaker.pyNN.spynnaker_simulator_interface \
-    import SpynnakerSimulatorInterface
+from spinn_front_end_common.utilities.failed_state import (
+    FailedState, FAILED_STATE_MSG)
+from spynnaker.pyNN.spynnaker_simulator_interface import (
+    SpynnakerSimulatorInterface)
 
 
 class SpynnakerFailedState(SpynnakerSimulatorInterface, FailedState, object):

--- a/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_neuron_network_specification_report.py
@@ -1,6 +1,5 @@
 import logging
 import os
-
 from spinn_utilities.progress_bar import ProgressBar
 from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge

--- a/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
+++ b/spynnaker/pyNN/utilities/spynnaker_synaptic_matrix_report.py
@@ -1,8 +1,7 @@
 import logging
-import numpy
 import os
+import numpy
 from spinn_utilities.progress_bar import ProgressBar
-
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -1,17 +1,15 @@
 """
 utility class containing simple helper methods
 """
-import numpy
+from decimal import Decimal
 import os
 import logging
 import math
-
-from spinn_utilities.safe_eval import SafeEval
-
+import numpy
 from scipy.stats import binom
+from spinn_utilities.safe_eval import SafeEval
 from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from decimal import Decimal
 
 MAX_RATE = 2 ** 32 - 1  # To allow a unit32_t to be used to store the rate
 

--- a/unittests/external_device_model_tests/test_live_spike_recorder.py
+++ b/unittests/external_device_model_tests/test_live_spike_recorder.py
@@ -1,6 +1,4 @@
-
 import unittest
-
 from spinn_front_end_common.utility_models import LivePacketGather
 
 

--- a/unittests/mocks.py
+++ b/unittests/mocks.py
@@ -1,8 +1,8 @@
 import configparser
 import numpy
 from spinn_front_end_common.utilities import globals_variables
-from spynnaker.pyNN.utilities.spynnaker_failed_state \
-    import SpynnakerFailedState
+from spynnaker.pyNN.utilities.spynnaker_failed_state import (
+    SpynnakerFailedState)
 
 
 class MockPopulation(object):

--- a/unittests/model_tests/neuron/test_abstract_neuron_impl.py
+++ b/unittests/model_tests/neuron/test_abstract_neuron_impl.py
@@ -1,7 +1,7 @@
-from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
-from spynnaker.pyNN.models.neuron.abstract_pynn_neuron_model \
-    import DEFAULT_MAX_ATOMS_PER_CORE, AbstractPyNNNeuronModel
 import sys
+from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
+from spynnaker.pyNN.models.neuron.abstract_pynn_neuron_model import (
+    DEFAULT_MAX_ATOMS_PER_CORE, AbstractPyNNNeuronModel)
 
 
 class _MyPyNNModelImpl(AbstractPyNNModel):

--- a/unittests/model_tests/neuron/test_connection_holder.py
+++ b/unittests/model_tests/neuron/test_connection_holder.py
@@ -1,7 +1,7 @@
 import math
 import pytest
 import numpy
-from spynnaker.pyNN.models.neuron.connection_holder import ConnectionHolder
+from spynnaker.pyNN.models.neuron import ConnectionHolder
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     AbstractSynapseDynamics)
 

--- a/unittests/model_tests/neuron/test_connection_holder.py
+++ b/unittests/model_tests/neuron/test_connection_holder.py
@@ -1,10 +1,9 @@
-import numpy
 import math
 import pytest
-
+import numpy
 from spynnaker.pyNN.models.neuron.connection_holder import ConnectionHolder
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import AbstractSynapseDynamics
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    AbstractSynapseDynamics)
 
 
 @pytest.fixture(

--- a/unittests/model_tests/neuron/test_defaults.py
+++ b/unittests/model_tests/neuron/test_defaults.py
@@ -1,7 +1,7 @@
 from six import add_metaclass
 from spinn_utilities.abstract_base import AbstractBase, abstractproperty
-from spynnaker.pyNN.models.defaults import defaults, default_parameters, \
-    default_initial_values
+from spynnaker.pyNN.models.defaults import (
+    defaults, default_parameters, default_initial_values)
 
 
 def test_nothing():

--- a/unittests/model_tests/neuron/test_neural_parameter.py
+++ b/unittests/model_tests/neuron/test_neural_parameter.py
@@ -1,14 +1,14 @@
 import os
 import struct
-from unittests.mocks import MockSimulator
 from six.moves import xrange
-from spinn_storage_handlers.file_data_writer import FileDataWriter
+from spinn_storage_handlers import FileDataWriter
 from data_specification.enums import DataType
 from data_specification import DataSpecificationGenerator
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
 from spynnaker.pyNN.models.neural_properties.neural_parameter import (
     _Range_Iterator, _Get_Iterator, _SingleValue_Iterator)
 from spynnaker.pyNN.utilities.ranged import SpynnakerRangedList
+from unittests.mocks import MockSimulator
 
 
 def _iterate_parameter_values(iterator, data_type):

--- a/unittests/model_tests/neuron/test_neural_parameter.py
+++ b/unittests/model_tests/neuron/test_neural_parameter.py
@@ -1,16 +1,14 @@
-from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.models.neural_properties.neural_parameter \
-    import _Range_Iterator, _Get_Iterator, _SingleValue_Iterator
-from spynnaker.pyNN.utilities.ranged import SpynnakerRangedList
-from data_specification.enums import DataType
-from data_specification import DataSpecificationGenerator
-from spinn_storage_handlers.file_data_writer import FileDataWriter
-
-from unittests.mocks import MockSimulator
-
 import os
 import struct
+from unittests.mocks import MockSimulator
 from six.moves import xrange
+from spinn_storage_handlers.file_data_writer import FileDataWriter
+from data_specification.enums import DataType
+from data_specification import DataSpecificationGenerator
+from spynnaker.pyNN.models.neural_properties import NeuronParameter
+from spynnaker.pyNN.models.neural_properties.neural_parameter import (
+    _Range_Iterator, _Get_Iterator, _SingleValue_Iterator)
+from spynnaker.pyNN.utilities.ranged import SpynnakerRangedList
 
 
 def _iterate_parameter_values(iterator, data_type):

--- a/unittests/model_tests/neuron/test_neuron_recorder.py
+++ b/unittests/model_tests/neuron/test_neuron_recorder.py
@@ -1,8 +1,8 @@
 from pacman.model.graphs.common import Slice
 from spinn_front_end_common.utilities import globals_variables
 from spynnaker.pyNN.models.common import NeuronRecorder
-from spynnaker.pyNN.utilities.spynnaker_failed_state \
-    import SpynnakerFailedState
+from spynnaker.pyNN.utilities.spynnaker_failed_state import (
+    SpynnakerFailedState)
 
 
 class MockSimulator(object):

--- a/unittests/model_tests/neuron/test_neuron_recorder.py
+++ b/unittests/model_tests/neuron/test_neuron_recorder.py
@@ -5,14 +5,14 @@ from spynnaker.pyNN.utilities.spynnaker_failed_state import (
     SpynnakerFailedState)
 
 
-class MockSimulator(object):
+class _MockBasicSimulator(object):
     @property
     def machine_time_step(self):
         return 1000
 
 
 def test_simple_record():
-    simulator = MockSimulator()
+    simulator = _MockBasicSimulator()
     globals_variables.set_failed_state(SpynnakerFailedState())
     globals_variables.set_simulator(simulator)
 

--- a/unittests/model_tests/neuron/test_synapse_io_row_based.py
+++ b/unittests/model_tests/neuron/test_synapse_io_row_based.py
@@ -1,17 +1,16 @@
 import pytest
-from spynnaker.pyNN.models.neuron.synapse_dynamics import SynapseDynamicsStatic
+from spynnaker.pyNN.exceptions import SynapseRowTooBigException
+from spynnaker.pyNN.models.neural_projections import (
+    ProjectionApplicationEdge, SynapseInformation)
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    SynapseDynamicsStatic, SynapseDynamicsSTDP)
 from spynnaker.pyNN.models.neuron.master_pop_table_generators import (
     MasterPopTableAsBinarySearch)
-from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 from spynnaker.pyNN.models.neuron.synapse_io import SynapseIORowBased
-from spynnaker.pyNN.exceptions import SynapseRowTooBigException
 from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence import (
     WeightDependenceAdditive)
 from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence import (
     TimingDependenceSpikePair)
-from spynnaker.pyNN.models.neuron.synapse_dynamics import SynapseDynamicsSTDP
-from spynnaker.pyNN.models.neural_projections.synapse_information import (
-    SynapseInformation)
 
 
 @pytest.mark.parametrize(

--- a/unittests/model_tests/neuron/test_synapse_io_row_based.py
+++ b/unittests/model_tests/neuron/test_synapse_io_row_based.py
@@ -1,18 +1,17 @@
+import pytest
 from spynnaker.pyNN.models.neuron.synapse_dynamics import SynapseDynamicsStatic
-from spynnaker.pyNN.models.neuron.master_pop_table_generators\
-    import MasterPopTableAsBinarySearch
+from spynnaker.pyNN.models.neuron.master_pop_table_generators import (
+    MasterPopTableAsBinarySearch)
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 from spynnaker.pyNN.models.neuron.synapse_io import SynapseIORowBased
 from spynnaker.pyNN.exceptions import SynapseRowTooBigException
-from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence \
-    import WeightDependenceAdditive
-from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence \
-    import TimingDependenceSpikePair
+from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence import (
+    WeightDependenceAdditive)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence import (
+    TimingDependenceSpikePair)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import SynapseDynamicsSTDP
-from spynnaker.pyNN.models.neural_projections.synapse_information \
-    import SynapseInformation
-
-import pytest
+from spynnaker.pyNN.models.neural_projections.synapse_information import (
+    SynapseInformation)
 
 
 @pytest.mark.parametrize(

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -1,39 +1,28 @@
-import unittest
-import struct
 import os
+import struct
 import tempfile
-
+import unittest
 import spinn_utilities.conf_loader as conf_loader
 from spinn_utilities.overrides import overrides
-
 from pacman.model.placements import Placement
 from pacman.model.resources import ResourceContainer
-from pacman.model.graphs.common import GraphMapper
-from pacman.model.graphs.common import Slice
-from pacman.model.graphs.machine import MachineGraph
-from pacman.model.routing_info import RoutingInfo
-from pacman.model.routing_info import PartitionRoutingInfo
-from pacman.model.routing_info import BaseKeyAndMask
-from pacman.model.graphs.machine import SimpleMachineVertex
+from pacman.model.graphs.common import GraphMapper, Slice
+from pacman.model.graphs.machine import MachineGraph, SimpleMachineVertex
+from pacman.model.routing_info import (
+    RoutingInfo, PartitionRoutingInfo, BaseKeyAndMask)
 from pacman.model.graphs.application import ApplicationVertex
-
-from data_specification \
-    import DataSpecificationGenerator, DataSpecificationExecutor
-
 from spinn_storage_handlers import FileDataWriter, FileDataReader
-
+from data_specification import (
+    DataSpecificationGenerator, DataSpecificationExecutor)
 from spynnaker.pyNN.models.neuron.synaptic_manager import SynapticManager
 from spynnaker.pyNN.abstract_spinnaker_common import AbstractSpiNNakerCommon
 import spynnaker.pyNN.abstract_spinnaker_common as abstract_spinnaker_common
-from spynnaker.pyNN.models.neural_projections \
-    import ProjectionApplicationEdge, ProjectionMachineEdge
-from spynnaker.pyNN.models.neural_projections \
-    import SynapseInformation
-from spynnaker.pyNN.models.neural_projections.connectors \
-    import OneToOneConnector, AllToAllConnector
-from spynnaker.pyNN.models.neuron.synapse_dynamics \
-    import SynapseDynamicsStatic
-
+from spynnaker.pyNN.models.neural_projections import (
+    ProjectionApplicationEdge, ProjectionMachineEdge, SynapseInformation)
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    OneToOneConnector, AllToAllConnector)
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    SynapseDynamicsStatic)
 from unittests.mocks import MockSimulator
 
 

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -14,7 +14,7 @@ from pacman.model.graphs.application import ApplicationVertex
 from spinn_storage_handlers import FileDataWriter, FileDataReader
 from data_specification import (
     DataSpecificationGenerator, DataSpecificationExecutor)
-from spynnaker.pyNN.models.neuron.synaptic_manager import SynapticManager
+from spynnaker.pyNN.models.neuron import SynapticManager
 from spynnaker.pyNN.abstract_spinnaker_common import AbstractSpiNNakerCommon
 import spynnaker.pyNN.abstract_spinnaker_common as abstract_spinnaker_common
 from spynnaker.pyNN.models.neural_projections import (

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import functools
 import numpy
 import pytest
-from pacman.model.graphs.common.slice import Slice
+from pacman.model.graphs.common import Slice
 from spynnaker.pyNN.models.neural_projections.connectors import (
     FixedNumberPreConnector, FixedNumberPostConnector,
     FixedProbabilityConnector, IndexBasedProbabilityConnector)

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
-from pacman.model.graphs.common.slice import Slice
+import functools
 import numpy
 import pytest
-import functools
-from spynnaker.pyNN.models.neural_projections.connectors \
-    import FixedNumberPreConnector, FixedNumberPostConnector, \
-    FixedProbabilityConnector, IndexBasedProbabilityConnector
+from pacman.model.graphs.common.slice import Slice
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    FixedNumberPreConnector, FixedNumberPostConnector,
+    FixedProbabilityConnector, IndexBasedProbabilityConnector)
 from unittests.mocks import MockSimulator, MockPopulation
 
 

--- a/unittests/test_import_all.py
+++ b/unittests/test_import_all.py
@@ -1,5 +1,5 @@
-import unittest
 import os
+import unittest
 import spinn_utilities.package_loader as package_loader
 
 

--- a/unittests/test_munich_io_spinnaker_link_protocol.py
+++ b/unittests/test_munich_io_spinnaker_link_protocol.py
@@ -1,6 +1,6 @@
 import unittest
-from spynnaker.pyNN.protocols import MunichIoSpiNNakerLinkProtocol
-from spynnaker.pyNN.protocols import RetinaKey
+from spynnaker.pyNN.protocols import (
+    MunichIoSpiNNakerLinkProtocol, RetinaKey)
 
 
 class TestMunichIOSpinnakerLinkProtocol(unittest.TestCase):

--- a/unittests/test_populations/test_population.py
+++ b/unittests/test_populations/test_population.py
@@ -1,6 +1,6 @@
-from unittests.mocks import MockSimulator
+from spynnaker.pyNN.models.neuron.builds import IFCurrExpBase
 from spynnaker.pyNN.models.pynn_population_common import PyNNPopulationCommon
-from spynnaker.pyNN.models.neuron.builds.if_curr_exp_base import IFCurrExpBase
+from unittests.mocks import MockSimulator
 
 
 def test_selector():

--- a/unittests/test_populations/test_vertex.py
+++ b/unittests/test_populations/test_vertex.py
@@ -1,14 +1,13 @@
 import pytest
-
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
-from unittests.mocks import MockSimulator
-from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModelStandard
 import numpy
+from spynnaker.pyNN.models.neuron import (
+    AbstractPopulationVertex, AbstractPyNNNeuronModelStandard)
 from spynnaker.pyNN.models.neuron.synapse_types import AbstractSynapseType
 from spynnaker.pyNN.models.neuron.neuron_models import AbstractNeuronModel
 from spynnaker.pyNN.models.defaults import default_initial_values
-from spynnaker.pyNN.models.neuron.implementations \
-    import AbstractStandardNeuronComponent
+from spynnaker.pyNN.models.neuron.implementations import (
+    AbstractStandardNeuronComponent)
+from unittests.mocks import MockSimulator
 
 
 class EmptyNeuronComponent(AbstractStandardNeuronComponent):

--- a/unittests/test_push_bot_devices.py
+++ b/unittests/test_push_bot_devices.py
@@ -1,13 +1,7 @@
 import unittest
-
 from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotLaser
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotMotor
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotSpeaker
-from spynnaker.pyNN.external_devices_models.push_bot.push_bot_parameters \
-    import PushBotLED
+    import (
+        PushBotLaser, PushBotMotor, PushBotSpeaker, PushBotLED)
 
 
 class Test(unittest.TestCase):

--- a/unittests/utilities_tests/test_spinnaker_main_interface.py
+++ b/unittests/utilities_tests/test_spinnaker_main_interface.py
@@ -1,16 +1,15 @@
 import os
 import sys
 import unittest
-
 import spinn_front_end_common.interface.abstract_spinnaker_base as base
-from spynnaker.pyNN.abstract_spinnaker_common import AbstractSpiNNakerCommon
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spinn_front_end_common.interface.abstract_spinnaker_base \
-    import AbstractSpinnakerBase
+from spinn_front_end_common.interface.abstract_spinnaker_base import (
+    AbstractSpinnakerBase)
 from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.utility_objs import ExecutableFinder
-from spynnaker.pyNN.utilities.spynnaker_failed_state \
-    import SpynnakerFailedState
+from spynnaker.pyNN.abstract_spinnaker_common import AbstractSpiNNakerCommon
+from spynnaker.pyNN.utilities.spynnaker_failed_state import (
+    SpynnakerFailedState)
 
 
 class Close_Once(object):

--- a/unittests/utilities_tests/test_spinnaker_main_interface.py
+++ b/unittests/utilities_tests/test_spinnaker_main_interface.py
@@ -1,11 +1,10 @@
 import os
 import sys
 import unittest
-import spinn_front_end_common.interface.abstract_spinnaker_base as base
-from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.interface.abstract_spinnaker_base import (
-    AbstractSpinnakerBase)
+    AbstractSpinnakerBase, CONFIG_FILE)
 from spinn_front_end_common.utilities import globals_variables
+from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.utilities.utility_objs import ExecutableFinder
 from spynnaker.pyNN.abstract_spinnaker_common import AbstractSpiNNakerCommon
 from spynnaker.pyNN.utilities.spynnaker_failed_state import (
@@ -50,14 +49,14 @@ class TestSpinnakerMainInterface(unittest.TestCase):
         path = os.path.dirname(os.path.abspath(class_file))
         os.chdir(path)
         print(path)
-        AbstractSpinnakerBase(base.CONFIG_FILE, ExecutableFinder())
+        AbstractSpinnakerBase(CONFIG_FILE, ExecutableFinder())
 
     def test_stop_init(self):
         class_file = sys.modules[self.__module__].__file__
         path = os.path.dirname(os.path.abspath(class_file))
         os.chdir(path)
 
-        interface = AbstractSpinnakerBase(base.CONFIG_FILE, ExecutableFinder())
+        interface = AbstractSpinnakerBase(CONFIG_FILE, ExecutableFinder())
         mock_contoller = Close_Once()
         interface._machine_allocation_controller = mock_contoller
         self.assertFalse(mock_contoller.closed)


### PR DESCRIPTION
These help my IDE hide all the imports more effectively. And I've
reordered the imports to put Python system packages first, then other
external packages, then our internal packages. Putting the system ones
first will stop one of the possible complaints from pylint (not that I'm
in a hurry to do that analysis!) and putting the rest in that order just
seems plain sensible. And I deleted a bunch of wildly inaccurate and not
very useful comments about imports too…