### PR TITLE
Shorten some module names.

### DIFF
--- a/spynnaker/pyNN/models/abstract_models/abstract_population_settable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_population_settable.py
@@ -2,8 +2,7 @@ from six import add_metaclass
 
 from spinn_utilities.abstract_base import AbstractBase, abstractproperty
 from spinn_utilities.ranged.abstract_list import AbstractList
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_list import \
-    SpynakkerRangedList
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangedList
 
 from .abstract_settable import AbstractSettable
 

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -41,8 +41,7 @@ from spynnaker.pyNN.models.common import AbstractSpikeRecordable
 from spynnaker.pyNN.models.common import AbstractNeuronRecordable
 from spynnaker.pyNN.models.common import NeuronRecorder
 from spynnaker.pyNN.utilities import constants
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_list import \
-    SpynakkerRangedList
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangedList
 from spynnaker.pyNN.models.neuron.population_machine_vertex \
     import PopulationMachineVertex
 from spynnaker.pyNN.models.abstract_models \

--- a/spynnaker/pyNN/models/neuron/additional_inputs/additional_input_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/additional_inputs/additional_input_ca2_adaptive.py
@@ -3,8 +3,7 @@ from spynnaker.pyNN.models.neural_properties import NeuronParameter
 from data_specification.enums import DataType
 from spynnaker.pyNN.models.neuron.additional_inputs \
     import AbstractAdditionalInput
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 
 import numpy
 from enum import Enum

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
@@ -2,8 +2,7 @@ from data_specification.enums import DataType
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 
 from .abstract_input_type import AbstractInputType
 

--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
@@ -2,8 +2,7 @@ from spinn_utilities.overrides import overrides
 from pacman.executor.injection_decorator import inject_items
 from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 from .abstract_neuron_model import AbstractNeuronModel
 from data_specification.enums import DataType
 

--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate.py
@@ -2,8 +2,7 @@ from spinn_utilities.overrides import overrides
 from pacman.executor.injection_decorator import inject_items
 from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 from .abstract_neuron_model import AbstractNeuronModel
 
 from data_specification.enums import DataType

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
@@ -1,7 +1,6 @@
 from spinn_utilities.overrides import overrides
 from pacman.executor.injection_decorator import inject_items
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict \
-    import SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 from spynnaker.pyNN.models.neuron.synapse_types.synapse_type_exponential \
     import get_exponential_decay_and_init
 

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_delta.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_delta.py
@@ -2,8 +2,7 @@ from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
 from spynnaker.pyNN.models.neuron.synapse_types import AbstractSynapseType
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 
 INITIAL_INPUT_EXC = "initial_input_exc"
 INITIAL_INPUT_INH = "initial_input_inh"

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_dual_exponential.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_dual_exponential.py
@@ -4,8 +4,7 @@ from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
 from spynnaker.pyNN.models.neuron.synapse_types.synapse_type_exponential \
     import get_exponential_decay_and_init
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 from .abstract_synapse_type import AbstractSynapseType
 from data_specification.enums import DataType
 

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_exponential.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_exponential.py
@@ -3,8 +3,8 @@ from spinn_utilities.ranged.abstract_list import AbstractList
 from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
 from pacman.executor.injection_decorator import inject_items
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary as SpynnakerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary \
+    as SpynnakerRangeDictionary
 from .abstract_synapse_type import AbstractSynapseType
 from data_specification.enums import DataType
 

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
@@ -2,8 +2,7 @@ from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
 from spynnaker.pyNN.models.neuron.threshold_types import AbstractThresholdType
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 
 from enum import Enum
 

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_static.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_static.py
@@ -2,8 +2,7 @@ from spinn_utilities.overrides import overrides
 
 from spynnaker.pyNN.models.abstract_models import AbstractContainsUnits
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_dict import \
-    SpynakkerRangeDictionary
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangeDictionary
 from .abstract_threshold_type import AbstractThresholdType
 
 from data_specification.enums import DataType

--- a/spynnaker/pyNN/utilities/ranged/__init__.py
+++ b/spynnaker/pyNN/utilities/ranged/__init__.py
@@ -1,0 +1,3 @@
+from .spynakker_ranged_dict import SpynakkerRangeDictionary
+from .spynakker_ranged_list import SpynakkerRangedList
+__all__ = ["SpynakkerRangeDictionary", "SpynakkerRangedList"]

--- a/spynnaker/pyNN/utilities/ranged/spynakker_ranged_dict.py
+++ b/spynnaker/pyNN/utilities/ranged/spynakker_ranged_dict.py
@@ -1,6 +1,5 @@
 from spinn_utilities.ranged.range_dictionary import RangeDictionary
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_list import \
-    SpynakkerRangedList
+from .spynakker_ranged_list import SpynakkerRangedList
 
 
 class SpynakkerRangeDictionary(RangeDictionary):

--- a/unittests/model_tests/neuron/test_neural_parameter.py
+++ b/unittests/model_tests/neuron/test_neural_parameter.py
@@ -1,8 +1,7 @@
 from spynnaker.pyNN.models.neural_properties import NeuronParameter
 from spynnaker.pyNN.models.neural_properties.neural_parameter \
     import _Range_Iterator, _Get_Iterator, _SingleValue_Iterator
-from spynnaker.pyNN.utilities.ranged.spynakker_ranged_list \
-    import SpynakkerRangedList
+from spynnaker.pyNN.utilities.ranged import SpynakkerRangedList
 from data_specification.enums import DataType
 from data_specification import DataSpecificationGenerator
 from spinn_storage_handlers.file_data_writer import FileDataWriter


### PR DESCRIPTION
Let the classes in spynnaker.pyNN.utilities.ranged be found easily. (Provide a non-empty `__init__.py` and load through that elsewhere.)