### PR TITLE
Use correct variable in provenance printing

### DIFF
--- a/spynnaker/pyNN/models/neuron/population_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_vertex.py
@@ -151,7 +151,7 @@ class PopulationMachineVertex(
             self._add_name(names,
                            "Times_plastic_synaptic_weights_have_saturated"),
             n_plastic_saturations,
-            report=n_saturations > 0,
+            report=n_plastic_saturations > 0,
             message=(
                 "The weights from the plastic synapses for {} on {}, {}, {} "
                 "saturated {} times. If this causes issue increase the "


### PR DESCRIPTION
Fixes minor mistake, where I'd used the static variable to decide whether or not to print the plastic saturation count