### PR TITLE
Clever trick does not work

### DIFF
--- a/neural_modelling/src/delay_extension/delay_extension.c
+++ b/neural_modelling/src/delay_extension/delay_extension.c
@@ -73,10 +73,8 @@ static uint32_t n_delays = 0;
 static inline void zero_spike_counters(void *location, uint32_t num_items)
 {
     uint32_t i;
-    for (i = 0 ; i < num_items - 3 ; i += 4) {
-        ((uint32_t *) location)[i] = 0;
-    }
-    for (; i < num_items ; i++) {
+
+    for (i = 0 ; i < num_items ; i++) {
         ((uint8_t *) location)[i] = 0;
     }
 }


### PR DESCRIPTION
We can't work out precisely why this trick makes jobs that use the delay_extension code fall over, but it does.  

Note: I tried to deal with the case where num_items < 3 (e.g. where there's a single-neuron injection population) but that only helped with simple cases where I was connecting single-neuron populations; anything more than that (e.g. PyNN8Examples/examples/synfire_if_curr_exp.py) fell over with dropped/blocked packets aplenty...