### PR TITLE
Add warnings for now that values get overwritten

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -79,6 +79,16 @@ class AbstractConnector(object):
             or random number generator
         :raises NotImplementedError: when lists are not supported and entered
         """
+        if self._weights is not None:
+            logger.warning(
+                'Weights were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
+        if self._delays is not None:
+            logger.warning(
+                'Delays were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
         self._weights = weights
         self._delays = delays
         self._check_parameters(weights, delays)

--- a/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
@@ -42,6 +42,16 @@ class AllToAllConnector(AbstractConnector):
             or random number generator
         :raises NotImplementedError: when lists are not supported and entered
         """
+        if self._weights is not None:
+            logger.warning(
+                'Weights were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
+        if self._delays is not None:
+            logger.warning(
+                'Delays were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
         self._weights = weights
         self._delays = delays
         self._check_parameters(weights, delays, allow_lists=True)

--- a/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
@@ -7,6 +7,9 @@ from spinn_utilities.abstract_base import abstractmethod
 import numpy.random
 from six import raise_from
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class MultapseConnector(AbstractConnector):
     """
@@ -58,6 +61,16 @@ class MultapseConnector(AbstractConnector):
             or random number generator
         :raises NotImplementedError: when lists are not supported and entered
         """
+        if self._weights is not None:
+            logger.warning(
+                'Weights were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
+        if self._delays is not None:
+            logger.warning(
+                'Delays were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
         self._weights = weights
         self._delays = delays
         self._check_parameters(weights, delays, allow_lists=True)

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -2,6 +2,9 @@ import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class OneToOneConnector(AbstractConnector):
     """
@@ -32,6 +35,16 @@ class OneToOneConnector(AbstractConnector):
             or random number generator
         :raises NotImplementedError: when lists are not supported and entered
         """
+        if self._weights is not None:
+            logger.warning(
+                'Weights were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
+        if self._delays is not None:
+            logger.warning(
+                'Delays were already set in '+str(self)+', possibly in '
+                'another projection: currently this will overwrite the values '
+                'in the previous projection. For now, set up a new connector.')
         self._weights = weights
         self._delays = delays
         self._check_parameters(weights, delays, allow_lists=True)


### PR DESCRIPTION
Started looking at weights and delays in connectors, in relation to https://github.com/SpiNNakerManchester/sPyNNaker/issues/519; have added warnings for now that the values in a projection get overwritten if the same connector is re-used.  Can continue working on this, but if anyone else wants to jump in on it at some point then feel free...