### PR TITLE
on no spikes returns an empty shaped array

### DIFF
--- a/spynnaker/pyNN/models/common/eieio_spike_recorder.py
+++ b/spynnaker/pyNN/models/common/eieio_spike_recorder.py
@@ -74,7 +74,7 @@ class EIEIOSpikeRecorder(object):
                 "Population {} is missing spike data in region {} from the"
                 " following cores: {}", label, region, missing_str)
         if not results:
-            return []
+            return numpy.empty(shape=(0, 2))
         result = numpy.vstack(results)
         return result[numpy.lexsort((result[:, 1], result[:, 0]))]
 


### PR DESCRIPTION
Actual fix for bug discovered by @SimonDavidson 

Return an empty array with the correct shape