### PR TITLE
tau_refrac_timesteps is an integer

### DIFF
--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate_and_fire.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate_and_fire.py
@@ -70,7 +70,8 @@ class NeuronModelLeakyIntegrateAndFire(NeuronModelLeakyIntegrate):
 
     def _tau_refrac_timesteps(self, machine_time_step):
         return self._data[TAU_REFRAC].apply_operation(
-            operation=lambda x: numpy.ceil(x / (machine_time_step / 1000.0)))
+            operation=lambda x: int(
+                numpy.ceil(x / (machine_time_step / 1000.0))))
 
     @inject_items({"machine_time_step": "MachineTimeStep"})
     def get_neural_parameters(self, machine_time_step):


### PR DESCRIPTION
Unit tests in sPyNNaker8 (at least) were failing in python3, as numpy.ceil returns a float and tau_refrac_timesteps is an integer.