### PR TITLE
Really make sure that we reference the correct memory when storing

### DIFF
--- a/neural_modelling/src/neuron/neuron.c
+++ b/neural_modelling/src/neuron/neuron.c
@@ -275,7 +275,7 @@ void neuron_store_neuron_parameters(address_t address){
     uint32_t next = START_OF_GLOBAL_PARAMETERS;
 
     uint32_t n_words_for_n_neurons = (n_neurons + 3) >> 2;
-    next += n_words_for_n_neurons * (n_recorded_vars + 1);
+    next += (n_words_for_n_neurons + 2) * (n_recorded_vars + 1);
 
     // call neuron implementation function to do the work
     neuron_impl_store_neuron_parameters(address, next, n_neurons);

--- a/spynnaker/pyNN/models/neuron/implementations/abstract_standard_neuron_component.py
+++ b/spynnaker/pyNN/models/neuron/implementations/abstract_standard_neuron_component.py
@@ -135,8 +135,8 @@ class AbstractStandardNeuronComponent(object):
         :return: The offset after reading the data
         """
         values = self.struct.read_data(data, offset, vertex_slice.n_atoms)
-        new_offset = offset + self.struct.get_size_in_whole_words(
-            vertex_slice.n_atoms)
+        new_offset = offset + (self.struct.get_size_in_whole_words(
+            vertex_slice.n_atoms) * 4)
         params = RangedDictVertexSlice(parameters, vertex_slice)
         variables = RangedDictVertexSlice(state_variables, vertex_slice)
         self.update_values(values, params, variables)

--- a/spynnaker/pyNN/models/neuron/implementations/ranged_dict_vertex_slice.py
+++ b/spynnaker/pyNN/models/neuron/implementations/ranged_dict_vertex_slice.py
@@ -17,6 +17,11 @@ class RangedDictVertexSlice(object):
         return _RangedListVertexSlice(
             self._ranged_dict[key], self._vertex_slice)
 
+    def __setitem__(self, key, value):
+        ranged_list_vertex_slice = _RangedListVertexSlice(
+            self._ranged_dict[key], self._vertex_slice)
+        ranged_list_vertex_slice.__setitem__(value)
+
 
 class _RangedListVertexSlice(object):
     """ A slice of ranged list to be used to update values
@@ -39,7 +44,7 @@ class _RangedListVertexSlice(object):
             # Go through and set the data in ranges
             start_index = 0
             for end_index in itertools.chain(
-                    changes, [self._vertex_slice.n_items]):
+                    changes, [self._vertex_slice.n_atoms]):
                 self._ranged_list.set_value_by_slice(
                     start_index, end_index, value[start_index])
                 start_index = end_index

--- a/spynnaker/pyNN/models/neuron/implementations/struct.py
+++ b/spynnaker/pyNN/models/neuron/implementations/struct.py
@@ -114,7 +114,7 @@ class Struct(object):
         for i, data_type in enumerate(self.field_types):
 
             # Get the data to set for this item
-            values = numpy_data["f" + i]
+            values = numpy_data["f" + str(i)]
 
             items_to_return.append(values / float(data_type.scale))
 

--- a/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
@@ -68,4 +68,4 @@ class AbstractNeuronModel(AbstractStandardNeuronComponent):
         # Assume that the global data doesn't change
         offset += (self.global_struct.get_size_in_whole_words() * 4)
         return super(AbstractNeuronModel, self).read_data(
-            self, data, offset, vertex_slice, parameters, state_variables)
+            data, offset, vertex_slice, parameters, state_variables)


### PR DESCRIPTION
We mustn't have tested some branch that was merged recently that well because multirun was broken (as originally reported in https://github.com/SpiNNakerManchester/sPyNNaker8/issues/165).  This PR and the associated one in FrontEndCommon - https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/352 - fixes it.