### PR TITLE
Reorder variables to match C code

### DIFF
--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
@@ -25,10 +25,10 @@ UNITS = {
 class NeuronModelIzh(AbstractNeuronModel):
 
     __slots__ = [
-        "_a", "_b", "_c", "_d", "_i_offset", "_v_init", "_u_init"
+        "_a", "_b", "_c", "_d", "_v_init", "_u_init", "_i_offset"
     ]
 
-    def __init__(self, a, b, c, d,  i_offset, v_init, u_init):
+    def __init__(self, a, b, c, d, v_init, u_init, i_offset):
         super(NeuronModelIzh, self).__init__(
             [DataType.S1615,   # a
              DataType.S1615,   # b
@@ -78,7 +78,7 @@ class NeuronModelIzh(AbstractNeuronModel):
     @overrides(AbstractNeuronModel.get_global_values,
                additional_arguments={'machine_time_step'})
     def get_global_values(self, machine_time_step):
-        return [machine_time_step]
+        return [machine_time_step/1000]
 
     @inject_items({"ts": "MachineTimeStep"})
     @overrides(AbstractNeuronModel.get_values, additional_arguments={'ts'})


### PR DESCRIPTION
There is a misalignment between the C code struct, and what the Python code writes, meaning you end up with incorrect neural dynamics.

Also the global time step which gets written is too big, so you get strange behaviour after the first spike.