### PR TITLE
Improvement to the Izhikevich ODE solver

### DIFF
--- a/neural_modelling/src/neuron/models/neuron_model_izh_impl.c
+++ b/neural_modelling/src/neuron/models/neuron_model_izh_impl.c
@@ -50,14 +50,14 @@ static inline void _rk2_kernel_midpoint(REAL h, neuron_pointer_t neuron,
 
     REAL pre_alph = REAL_CONST(140.0) + input_this_timestep - lastU1;
     REAL alpha = pre_alph
-                 + ( REAL_CONST(5.0) + REAL_CONST(0.0400) * lastV1) * lastV1;
+                 + ( REAL_CONST(5.0) + REAL_CONST(0.040008544921875) * lastV1) * lastV1;
     REAL eta = lastV1 + REAL_HALF(h * alpha);
 
     // could be represented as a long fract?
     REAL beta = REAL_HALF(h * (b * lastV1 - lastU1) * a);
 
     neuron->V += h * (pre_alph - beta
-                      + ( REAL_CONST(5.0) + REAL_CONST(0.0400) * eta) * eta);
+                      + ( REAL_CONST(5.0) + REAL_CONST(0.040008544921875) * eta) * eta);
 
     neuron->U += a * h * (-lastU1 - beta + b * eta);
 }


### PR DESCRIPTION
This patch is fixing an issue with the constants that cannot be exactly represented as accums and are rounded down by GCC (as opposed to rounding to the nearest accum). This reduces the error and significantly improves the spiking lag reported in https://www.ncbi.nlm.nih.gov/pubmed/26313605.

Replicating the experiment from the paper, the spikes that should happen at 101ms, 201ms, 301ms... and so on at each 101st boundary, have a lag. Here are first 29 spikes from the experiment with DC current:

104.9   207.9   310.9   413.9   516.9   619.8   722.7   825.7   928.8 1031.8  1134.8  1237.9  1341.   1444.1  1547.2  1650.3  1753.4  1856.5 1959.5  2062.4  2165.3  2268.3  2371.4  2474.4  2577.4  2680.5  2783.6 2886.7  2989.8

I.e. spike 1 has a lag of 3.9ms and spike 29 has a lag of 88.8ms.

After this fix, the neuron starts having a lead instead of a lag from the exact result (and significantly smaller magnitude):

100.9   200.5   300.2   399.9   499.5   599.1   698.7   798.3   897.9  997.5  1097.1  1196.7  1296.3  1395.9  1495.5  1595.1  1694.7  1794.3 1893.9  1993.5  2093.1  2192.7  2292.3  2391.9  2491.5  2591.1  2690.7 2790.3  2889.9

1st spike has a lead of only 0.1ms and the last spike has a lead of only 11.1ms.

The issue was already discussed with @hopper333 @dr-david-lester.

I have a PyNN script to run this, available.