### PR TITLE
neuron.c is smarter and does not save overflow to

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -176,9 +176,6 @@ class NeuronRecorder(object):
                     for index in self._indexes[SPIKES])
                 if neurons_recording == 0:
                     continue
-                if neurons_recording < vertex_slice.n_atoms:
-                    # For spikes the overflow position is also returned
-                    neurons_recording += 1
             # Read the spikes
             n_words = int(math.ceil(neurons_recording / 32.0))
             n_bytes = n_words * self.N_BYTES_PER_WORD

--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -388,10 +388,7 @@ class NeuronRecorder(object):
         if n_neurons == 0:
             return 0
         if variable == SPIKES:
-            if n_neurons < vertex_slice.n_atoms:
-                # Indexing is used rather than gating to determine recording
-                # Non recoding neurons write to an extra slot
-                n_neurons += 1
+            # Overflow can be ignored as it is not save if in an extra word
             out_spike_words = int(math.ceil(n_neurons / 32.0))
             out_spike_bytes = out_spike_words * self.N_BYTES_PER_WORD
             return self.N_BYTES_FOR_TIMESTAMP + out_spike_bytes


### PR DESCRIPTION
Fix for https://github.com/SpiNNakerManchester/sPyNNaker/issues/570

Neuron.c 
save a recoing array for all neurons.

out_spikes_initialize(n_neurons)

But only writes the neurons recording.

out_spikes_record(SPIKE_RECORDING_CHANNEL, time, n_spike_recording_words,             recording_done_callback))

This is the best solution as no need to write and read back the overflow word.

Adjusted the python to not expect and then throw away that word.