### PR TITLE
Remove synapse type header as not now needed

### DIFF
--- a/neural_modelling/makefiles/neuron/neural_build.mk
+++ b/neural_modelling/makefiles/neuron/neural_build.mk
@@ -224,7 +224,7 @@ $(BUILD_DIR)neuron/population_table/population_table_binary_search_impl.o: $(MOD
 
 #STDP Build rules If and only if STDP used
 ifeq ($(STDP_ENABLED), 1)
-    STDP_INCLUDES:= -include $(SYNAPSE_TYPE_H) -include $(WEIGHT_DEPENDENCE_H) -include $(TIMING_DEPENDENCE_H)
+    STDP_INCLUDES:= -include $(WEIGHT_DEPENDENCE_H) -include $(TIMING_DEPENDENCE_H)
     STDP_COMPILE = $(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED) -DSYNGEN_ENABLED=$(SYNGEN_ENABLED) $(STDP_INCLUDES)
 
     $(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
@@ -259,14 +259,13 @@ $(WEIGHT_DEPENDENCE_O): $(WEIGHT_DEPENDENCE_C) $(SYNAPSE_TYPE_H)
 	# WEIGHT_DEPENDENCE_O
 	-mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) \
-	        -include $(SYNAPSE_TYPE_H) -o $@ $<
+	        -o $@ $<
 
 $(TIMING_DEPENDENCE_O): $(TIMING_DEPENDENCE_C) $(SYNAPSE_TYPE_H) \
                         $(WEIGHT_DEPENDENCE_H)
 	# TIMING_DEPENDENCE_O
 	-mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) \
-	        -include $(SYNAPSE_TYPE_H)\
 	        -include $(WEIGHT_DEPENDENCE_H) -o $@ $<
 
 $(BUILD_DIR)neuron/neuron.o: $(MODIFIED_DIR)neuron/neuron.c $(NEURON_MODEL_H) \

--- a/neural_modelling/src/neuron/additional_inputs/additional_input_ca2_adaptive_impl.h
+++ b/neural_modelling/src/neuron/additional_inputs/additional_input_ca2_adaptive_impl.h
@@ -25,6 +25,7 @@ typedef struct additional_input_t {
 static input_t additional_input_get_input_value_as_current(
         additional_input_pointer_t additional_input,
         state_t membrane_voltage) {
+	use(membrane_voltage);
 
     // Decay Ca2 trace
     additional_input->I_Ca2 *= additional_input->exp_TauCa;

--- a/neural_modelling/src/neuron/plasticity/stdp/maths.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/maths.h
@@ -3,6 +3,7 @@
 
 // Standard includes
 #include <common/neuron-typedefs.h>
+#include <spin1_api.h>
 
 //---------------------------------------
 // Macros


### PR DESCRIPTION
Change implemented to enable building of a neuron model with non-standard neuron implementation and STDP.

This update works for me!