### PR TITLE
Exception is users tries something that currently broken

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -270,6 +270,14 @@ class NeuronRecorder(object):
 
         found = False
         warning = None
+        indexes = list(indexes)
+        if sorted(indexes) != indexes:
+            if len(indexes) != len(set(indexes)):
+                raise ConfigurationException(
+                    "Repeated indexes are currently not supported")
+            else:
+                raise ConfigurationException(
+                    "Unsorted indexes are currently not supported")
         for index in indexes:
             if index < 0:
                 raise ConfigurationException(


### PR DESCRIPTION
Current selective record is broken if indexes (or view used to create indexes) has repeats or out of order neuron ids.

Not sure this is worth fixing so just going boom!