### PR TITLE
Fix duplicate error and sort for consitency.

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -352,14 +352,12 @@ class NeuronRecorder(object):
             # make sure indexes is not a generator like range
             indexes = list(indexes)
             self.check_indexes(indexes)
-            if self._indexes[variable] is None:
-                # just use the new indexes
-                self._indexes[variable] = indexes
-            else:
+            if self._indexes[variable] is not None:
                 # merge the two indexes
-                self._indexes[variable] = \
-                    list(set(self._indexes[variable] + indexes))
-                self._indexes[variable].sort()
+                self._indexes[variable] = self._indexes[variable] + indexes
+            # Avoid duplicates and keep in numerical order
+            self._indexes[variable] = list(set(indexes))
+            self._indexes[variable].sort()
 
     def set_recording(self, variable, new_state, sampling_interval=None,
                       indexes=None):


### PR DESCRIPTION
Bugfix if user asks for duplicates in recording indexes.

Note: If the users sets recording on a view gets data on the whole population the data comes out in numerical order. If they also call get_data on the view (or a similar one) goes out in the view order and can include duplicates.