### PR TITLE
Throw an exception if requested number of synapses is too large

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
@@ -59,6 +59,11 @@ class MultapseConnector(AbstractGenerateConnectorOnMachine):
             n_pre_atoms = sum([pre.n_atoms for pre in pre_slices])
             n_post_atoms = sum([post.n_atoms for post in post_slices])
             n_connections = n_pre_atoms * n_post_atoms
+            if (not self._with_replacement and
+                    n_connections < self._num_synapses):
+                raise SpynnakerException(
+                    "FixedNumberTotalConnector will not work correctly when "
+                    "with_replacement=False & num_synapses > n_pre * n_post")
             prob_connect = [
                 float(pre.n_atoms * post.n_atoms) / float(n_connections)
                 for pre in pre_slices for post in post_slices]


### PR DESCRIPTION
Fix for issue https://github.com/SpiNNakerManchester/sPyNNaker/issues/605 

Note: this wasn't showing up for FixedNumberPre and FixedNumberPost because they don't use the on-chip expander yet, whereas this connector does - so it was never (with defaults turned on) getting to the point where it should have thrown the exception that was written in there originally (before the expander existed).  I've made it throw an exception now before it even gets to expanding.