### PR TITLE
Compare using both the max and the min, otherwise mixed cases are missed

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -1,6 +1,7 @@
 import logging
 import numpy
 from spinn_utilities.overrides import overrides
+from spinn_front_end_common.utilities import globals_variables
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.exceptions import InvalidParameterType
 
@@ -219,7 +220,11 @@ class FromListConnector(AbstractConnector):
         self._delays = None
         try:
             delay_column = column_names.index('delay') + _FIRST_PARAM
-            self._delays = self._conn_list[:, delay_column]
+            machine_time_step = globals_variables.get_simulator(
+                ).machine_time_step
+            self._delays = numpy.rint(
+                numpy.array(self._conn_list[:, delay_column]) * (
+                    1000.0 / machine_time_step)) * (machine_time_step / 1000.0)
         except ValueError:
             pass
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -43,9 +43,9 @@ class OneToOneConnector(AbstractGenerateConnectorOnMachine):
 
         slice_min_delay = min(delays)
         slice_max_delay = max(delays)
-        if slice_max_delay >= min_delay and slice_max_delay <= max_delay:
+        if min_delay <= slice_max_delay <= max_delay:
             return 1
-        if slice_min_delay >= min_delay and slice_min_delay <= max_delay:
+        if min_delay <= slice_min_delay <= max_delay:
             return 1
         return 0
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -43,7 +43,9 @@ class OneToOneConnector(AbstractGenerateConnectorOnMachine):
 
         slice_min_delay = min(delays)
         slice_max_delay = max(delays)
-        if slice_min_delay >= min_delay and slice_max_delay <= max_delay:
+        if slice_max_delay >= min_delay and slice_max_delay <= max_delay:
+            return 1
+        if slice_min_delay >= min_delay and slice_min_delay <= max_delay:
             return 1
         return 0
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -43,10 +43,10 @@ class OneToOneConnector(AbstractGenerateConnectorOnMachine):
 
         slice_min_delay = min(delays)
         slice_max_delay = max(delays)
-        if min_delay <= slice_max_delay <= max_delay:
+        if ((min_delay <= slice_max_delay <= max_delay) or
+                (min_delay <= slice_min_delay <= max_delay)):
             return 1
-        if min_delay <= slice_min_delay <= max_delay:
-            return 1
+
         return 0
 
     @overrides(AbstractConnector.get_n_connections_to_post_vertex_maximum)

--- a/spynnaker/pyNN/models/pynn_projection_common.py
+++ b/spynnaker/pyNN/models/pynn_projection_common.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import numpy
 from spinn_utilities.progress_bar import ProgressBar
 from pacman.model.constraints.partitioner_constraints import (
     SameAtomsAsVertexConstraint)
@@ -56,6 +57,12 @@ class PyNNProjectionCommon(object):
             raise ConfigurationException(
                 "Synapse target {} not found in {}".format(
                     target, post_synaptic_population.label))
+
+        # round the delays to multiples of full timesteps
+        # (otherwise SDRAM estimation calculations can go wrong)
+        synapse_dynamics_stdp.delay = numpy.rint(numpy.array(
+            synapse_dynamics_stdp.delay) * (1000.0 / machine_time_step)) * (
+                machine_time_step / 1000.0)
 
         # set the plasticity dynamics for the post pop (allows plastic stuff
         #  when needed)

--- a/unittests/mocks.py
+++ b/unittests/mocks.py
@@ -52,6 +52,7 @@ class MockSimulator(object):
                                   "enable_buffered_recording": "False"}
         self.config["MasterPopTable"] = {"generator": "BinarySearch"}
         self.config["Reports"] = {"n_profile_samples": 0}
+        self.config["Machine"] = {"machine_time_step": 1000}
 
     def is_a_pynn_random(self, values):
         return isinstance(values, MockRNG)

--- a/unittests/mocks.py
+++ b/unittests/mocks.py
@@ -52,7 +52,6 @@ class MockSimulator(object):
                                   "enable_buffered_recording": "False"}
         self.config["MasterPopTable"] = {"generator": "BinarySearch"}
         self.config["Reports"] = {"n_profile_samples": 0}
-        self.config["Machine"] = {"machine_time_step": 1000}
 
     def is_a_pynn_random(self, values):
         return isinstance(values, MockRNG)
@@ -74,6 +73,10 @@ class MockSimulator(object):
 
     def has_reset_last(self):
         return False
+
+    @property
+    def machine_time_step(self):
+        return 1000
 
     @property
     def id_counter(self):


### PR DESCRIPTION
Fix for https://github.com/SpiNNakerManchester/sPyNNaker/issues/618 - the case where the delays were an array containing mixed values where some required delay extensions and some did not was not dealt with correctly.