### PR TITLE
Deal with input arrays in generate_weights and generate_delays correctly

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -142,14 +142,26 @@ class FromListConnector(AbstractConnector):
         block["target"] = self._targets[mask]
         # check that conn_list has weights, if not then use the value passed in
         if self._weights is None:
-            block["weight"] = self._generate_weights(
-                weights, sources.size, None)
+            if sources.size:
+                # create connection slices for this pre+post based on the mask
+                connection_slices = [
+                    slice(n, n+1) for n in range(mask.size) if mask[n]]
+                block["weight"] = self._generate_weights(
+                    weights, sources.size, connection_slices) # None)
+            else:
+                block["weight"] = 0
         else:
             block["weight"] = self._weights[mask]
         # check that conn_list has delays, if not then use the value passed in
         if self._delays is None:
-            block["delay"] = self._generate_delays(
-                delays, sources.size, None)
+            if sources.size:
+                # create connection slices for this pre+post based on the mask
+                connection_slices = [
+                    slice(n, n+1) for n in range(mask.size) if mask[n]]
+                block["delay"] = self._generate_delays(
+                    delays, sources.size, connection_slices) # None)
+            else:
+                block["delay"] = 0
         else:
             block["delay"] = self._clip_delays(self._delays[mask])
         block["synapse_type"] = synapse_type

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -141,6 +141,7 @@ class FromListConnector(AbstractConnector):
         block["source"] = sources
         block["target"] = self._targets[mask]
         # check that conn_list has weights, if not then use the value passed in
+        connection_slices = None
         if self._weights is None:
             if sources.size:
                 # create connection slices for this pre+post based on the mask
@@ -156,8 +157,9 @@ class FromListConnector(AbstractConnector):
         if self._delays is None:
             if sources.size:
                 # create connection slices for this pre+post based on the mask
-                connection_slices = [
-                    slice(n, n+1) for n in range(mask.size) if mask[n]]
+                if connection_slices is None:
+                    connection_slices = [
+                        slice(n, n+1) for n in range(mask.size) if mask[n]]
                 block["delay"] = self._generate_delays(
                     delays, sources.size, connection_slices)
             else:

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -147,7 +147,7 @@ class FromListConnector(AbstractConnector):
                 connection_slices = [
                     slice(n, n+1) for n in range(mask.size) if mask[n]]
                 block["weight"] = self._generate_weights(
-                    weights, sources.size, connection_slices) # None)
+                    weights, sources.size, connection_slices)
             else:
                 block["weight"] = 0
         else:
@@ -159,7 +159,7 @@ class FromListConnector(AbstractConnector):
                 connection_slices = [
                     slice(n, n+1) for n in range(mask.size) if mask[n]]
                 block["delay"] = self._generate_delays(
-                    delays, sources.size, connection_slices) # None)
+                    delays, sources.size, connection_slices)
             else:
                 block["delay"] = 0
         else:


### PR DESCRIPTION
Fix for https://github.com/SpiNNakerManchester/sPyNNaker/issues/617 - the calls to _generate_weights and _generate_delays needed to be updated when the user passes in arrays in the (Static)Synapse.