### PR TITLE
Fix synapse expander

### DIFF
--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_static.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_static.h
@@ -87,6 +87,8 @@ void matrix_generator_static_write_row(
         uint32_t max_stage) {
     use(data);
 
+    log_debug("Max stage = %u", max_stage);
+
     // Row address and position for each possible delay stage (including no
     // delay stage)
     address_t row_address[max_stage];
@@ -101,6 +103,7 @@ void matrix_generator_static_write_row(
         row_address[0] =
             &(synaptic_matrix[pre_neuron_index * (max_row_n_words + 3)]);
     }
+    log_debug("row[0] = 0x%08x", row_address[0]);
 
     // The delayed row positions and space available
     if (delayed_synaptic_matrix != NULL) {
@@ -112,11 +115,13 @@ void matrix_generator_static_write_row(
         for (uint32_t i = 1; i < max_stage; i++) {
             row_address[i] = &(delayed_address[single_matrix_size * (i - 1)]);
             space[i] = max_delayed_row_n_words;
+            log_debug("row[%u] = 0x%08x", i, row_address[i]);
         }
     } else {
         for (uint32_t i = 1; i < max_stage; i++) {
             row_address[i] = NULL;
             space[i] = 0;
+            log_debug("row[%u] = 0x%08x", i, row_address[i]);
         }
     }
 
@@ -134,6 +139,7 @@ void matrix_generator_static_write_row(
         } else {
             write_address[i] = NULL;
         }
+        log_debug("write[%u] = 0x%08x", i, write_address[i]);
     }
 
 
@@ -149,7 +155,9 @@ void matrix_generator_static_write_row(
         // Work out the delay stage and final value
         struct delay_value delay = get_delay(delays[synapse], max_stage);
         if (write_address[delay.stage] == NULL) {
-            log_error("Delay stage %u has not been initialised", delay.stage);
+            log_error("Delay stage %u has not been initialised; raw delay = %u,"
+                " delay = %u, max stage = %u", delay.stage, delays[synapse],
+                delay.delay, max_stage);
             rt_error(RTE_SWERR);
         }
 

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_static.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_static.h
@@ -155,7 +155,8 @@ void matrix_generator_static_write_row(
 
         // Avoid errors when rows are full
         if (space[delay.stage] == 0) {
-            log_warning("Row for delay stage %u is full - word not added!");
+            log_warning("Row for delay stage %u is full - word not added!",
+                delay.stage);
             continue;
         }
 

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_exponential.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_exponential.h
@@ -44,6 +44,9 @@ void *param_generator_exponential_initialize(address_t *region) {
 }
 
 void param_generator_exponential_free(void *data) {
+    struct param_generator_exponential *params =
+            (struct param_generator_exponential *) data;
+    rng_free(params->rng);
     sark_free(data);
 }
 

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_normal.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_normal.h
@@ -46,6 +46,9 @@ void *param_generator_normal_initialize(address_t *region) {
 }
 
 void param_generator_normal_free(void *data) {
+    struct param_generator_normal *params =
+            (struct param_generator_normal *) data;
+    rng_free(params->rng);
     sark_free(data);
 }
 

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped.h
@@ -52,6 +52,9 @@ void *param_generator_normal_clipped_initialize(address_t *region) {
 }
 
 void param_generator_normal_clipped_free(void *data) {
+    struct param_generator_normal_clipped *params =
+            (struct param_generator_normal_clipped *) data;
+    rng_free(params->rng);
     sark_free(data);
 }
 

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped_to_boundary.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped_to_boundary.h
@@ -52,6 +52,9 @@ void *param_generator_normal_clipped_boundary_initialize(address_t *region) {
 }
 
 void param_generator_normal_clipped_boundary_free(void *data) {
+    struct param_generator_normal_clipped_boundary *params =
+            (struct param_generator_normal_clipped_boundary *) data;
+    rng_free(params->rng);
     sark_free(data);
 }
 

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_uniform.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_uniform.h
@@ -46,6 +46,9 @@ void *param_generator_uniform_initialize(address_t *region) {
 }
 
 void param_generator_uniform_free(void *data) {
+    struct param_generator_uniform *params =
+            (struct param_generator_uniform *) data;
+    rng_free(params->rng);
     sark_free(data);
 }
 

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -716,12 +716,13 @@ class SynapticManager(object):
         # Skip over the delayed bytes but still write a master pop entry
         delayed_synaptic_matrix_offset = 0xFFFFFFFF
         delay_rinfo = None
-        n_delay_stages = app_edge.n_delay_stages
+        n_delay_stages = 0
         delay_key = (app_edge.pre_vertex, pre_vertex_slice.lo_atom,
                      pre_vertex_slice.hi_atom)
         if delay_key in self._delay_key_index:
             delay_rinfo = self._delay_key_index[delay_key]
         if max_row_info.delayed_max_n_synapses:
+            n_delay_stages = app_edge.n_delay_stages
             delayed_synaptic_matrix_offset = \
                 self._poptable_type.get_next_allowed_address(
                     block_addr)

--- a/spynnaker/pyNN/models/utility_models/synapse_expander/synapse_expander.py
+++ b/spynnaker/pyNN/models/utility_models/synapse_expander/synapse_expander.py
@@ -74,27 +74,32 @@ def synapse_expander(
                 "The synapse expander failed to complete")
 
 
-def _extract_iobuf(expander_cores, transceiver, provenance_file_path):
+def _extract_iobuf(expander_cores, transceiver, provenance_file_path,
+                   display=False):
     """ Extract IOBuf from the cores
     """
     io_buffers = transceiver.get_iobuf(expander_cores.all_core_subsets)
     core_to_replacer = dict()
     for binary in expander_cores.binaries:
         replacer = Replacer(binary)
-        for core_subsets in expander_cores.get_cores_for_binary(binary):
-            for core_subset in core_subsets:
-                x = core_subset.x
-                y = core_subset.y
-                for p in core_subset.processor_ids:
-                    core_to_replacer[x, y, p] = replacer
+        for core_subset in expander_cores.get_cores_for_binary(binary):
+            x = core_subset.x
+            y = core_subset.y
+            for p in core_subset.processor_ids:
+                core_to_replacer[x, y, p] = replacer
 
     for io_buf in io_buffers:
         file_path = os.path.join(
             provenance_file_path, "expander_{}_{}_{}.txt".format(
                 io_buf.x, io_buf.y, io_buf.p))
         replacer = core_to_replacer[io_buf.x, io_buf.y, io_buf.p]
+        text = ""
+        for line in io_buf.iobuf.split("\n"):
+            text += replacer.replace(line) + "\n"
         with open(file_path, "w") as writer:
-            writer.write(replacer.replace(io_buf.iobuf))
+            writer.write(text)
+        if display:
+            print("{}:{}:{} {}".format(io_buf.x, io_buf.y, io_buf.p, text))
 
 
 def _handle_failure(expander_cores, transceiver, provenance_file_path):
@@ -109,4 +114,5 @@ def _handle_failure(expander_cores, transceiver, provenance_file_path):
     error_cores = transceiver.get_cores_not_in_state(
         core_subsets, [CPUState.RUNNING, CPUState.FINISHED])
     logger.error(transceiver.get_core_status_string(error_cores))
-    _extract_iobuf(expander_cores, transceiver, provenance_file_path)
+    _extract_iobuf(expander_cores, transceiver, provenance_file_path,
+                   display=True)

--- a/spynnaker/pyNN/models/utility_models/synapse_expander/synapse_expander.py
+++ b/spynnaker/pyNN/models/utility_models/synapse_expander/synapse_expander.py
@@ -79,10 +79,10 @@ def _extract_iobuf(expander_cores, transceiver, provenance_file_path):
     """
     io_buffers = transceiver.get_iobuf(expander_cores.all_core_subsets)
     core_to_replacer = dict()
-    for binary in expander_cores.binaries():
+    for binary in expander_cores.binaries:
         replacer = Replacer(binary)
         for core_subsets in expander_cores.get_cores_for_binary(binary):
-            for core_subset in core_subsets.core_subsets:
+            for core_subset in core_subsets:
                 x = core_subset.x
                 y = core_subset.y
                 for p in core_subset.processor_ids:


### PR DESCRIPTION
Fixes a couple of issues with the synaptic expander, namely that things weren't being free'd completely (and so sometimes the heap and stack would clash), and that where multiple projections existed between a pair of populations but the delay stages were different, incorrect delays could be generated.