### PR TITLE
Move negation of timescale factor into Python

### DIFF
--- a/neural_modelling/src/neuron/threshold_types/threshold_type_maass_stochastic.h
+++ b/neural_modelling/src/neuron/threshold_types/threshold_type_maass_stochastic.h
@@ -20,8 +20,8 @@ typedef struct threshold_type_t {
     // soft threshold value  [mV]
     REAL     v_thresh;
 
-    //
-    REAL     machine_time_step_ms_div_10;
+    // time step scaling factor
+    REAL     neg_machine_time_step_ms_div_10;
 
 } threshold_type_t;
 
@@ -38,8 +38,8 @@ static inline bool threshold_type_is_above_threshold(state_t value,
     UREAL result;
     if (exponent < 5.0k) {
         REAL hazard = expk(exponent) * threshold_type->tau_th_inv;
-        result = (1. - expk(-hazard *
-                            threshold_type->machine_time_step_ms_div_10)) *
+        result = (1. - expk(hazard *
+                            threshold_type->neg_machine_time_step_ms_div_10)) *
                   PROB_SATURATION;
 
     } else {

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
@@ -61,7 +61,7 @@ class ThresholdTypeMaassStochastic(AbstractThresholdType):
         # Add the rest of the data
         return [parameters[DU_TH].apply_operation(lambda x: 1.0 / x),
                 parameters[TAU_TH].apply_operation(lambda x: 1.0 / x),
-                parameters[V_THRESH], float(ts) / 10000.0]
+                parameters[V_THRESH], float(ts) / -10000.0]
 
     @overrides(AbstractThresholdType.update_values)
     def update_values(self, values, parameters, state_variables):


### PR DESCRIPTION
Fixes issue #551; it's better to have this one in Python anyway, as that's one less arithmetic op in the computation (and who doesn't like avoiding a compiler crash?!)