### PR TITLE
work-around for numpy.float64 having __getitem__

### DIFF
--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -461,7 +461,7 @@ class SynapticManager(object):
                         if (rate != 0):
                             spikes_per_second = rate
                         if hasattr(spikes_per_second, "__getitem__"):
-                            spikes_per_second = max(spikes_per_second)
+                            spikes_per_second = numpy.max(spikes_per_second)
                         elif get_simulator().is_a_pynn_random(
                                 spikes_per_second):
                             spikes_per_second = get_maximum_probable_value(


### PR DESCRIPTION
Issue explained in more detail https://github.com/numpy/numpy/issues/13653  

Basically, numpy.float64 has a ` __getitem__` attribute and the check of whether `spikes_per_second` is iterable passes and `max(spikes_per_second)` crashes with the error:
```
Traceback (most recent call last):
  File "C:/Work/phd/sundry/npfloat64_bug.py", line 8, in <module>
    print(max(y))
TypeError: 'numpy.float64' object is not iterable
```
### MWE
``` 
import sys, numpy; print(numpy.__version__, sys.version)
import numpy as np
x = np.float(80)
if hasattr(x, "__getitem__"):
    print(max(x))
y = np.float64(80)
if hasattr(y, "__getitem__"):
    print(max(y))
``` 


Numpy and sys versions: 1.16.2 3.6.8 (tags/v3.6.8:3c6b436a57, Dec 24 2018, 00:16:47) [MSC v.1916 64 bit (AMD64)]


# Work-around
Using `np.max()` instead of `max()`  behaves correctly.