### PR TITLE
Fix to get round error when delay is a RandomDistribution

### DIFF
--- a/spynnaker/pyNN/models/pynn_projection_common.py
+++ b/spynnaker/pyNN/models/pynn_projection_common.py
@@ -14,6 +14,8 @@ from spynnaker.pyNN.models.neural_projections import (
 from spynnaker.pyNN.models.utility_models import DelayExtensionVertex
 from spynnaker.pyNN.utilities import constants
 from spynnaker.pyNN.models.neuron import ConnectionHolder
+from spinn_front_end_common.utilities.globals_variables import get_simulator
+
 # pylint: disable=protected-access
 
 logger = logging.getLogger(__name__)
@@ -60,9 +62,10 @@ class PyNNProjectionCommon(object):
 
         # round the delays to multiples of full timesteps
         # (otherwise SDRAM estimation calculations can go wrong)
-        synapse_dynamics_stdp.delay = numpy.rint(numpy.array(
-            synapse_dynamics_stdp.delay) * (1000.0 / machine_time_step)) * (
-                machine_time_step / 1000.0)
+        if not get_simulator().is_a_pynn_random(synapse_dynamics_stdp.delay):
+            synapse_dynamics_stdp.delay = numpy.rint(numpy.array(
+                synapse_dynamics_stdp.delay) * (
+                    1000.0 / machine_time_step)) * (machine_time_step / 1000.0)
 
         # set the plasticity dynamics for the post pop (allows plastic stuff
         #  when needed)


### PR DESCRIPTION
It's a bit hacky, perhaps, but a way of getting round the TypeError on this line when using a RandomDistribution for the delays needs to happen in order for e.g. the microcortical column to run.  It is extremely unlikely that the edge-case problem that this line solved originally will occur when using a RandomDistribution.