### PR TITLE
Fix issues with synapse_info for n_neurons > 255

### DIFF
--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -634,12 +634,19 @@ class SynapticManager(object):
                             weight_scales, machine_time_step, rinfo,
                             all_syn_block_sz, block_addr, single_addr,
                             machine_edge=machine_edge)
-                        synapse_infos.append(synapse_info)
+
+                        # Add a distinct synapse info (determined by
+                        # connector) to the list of synapse info
+                        connector_found = False
+                        for n in range(len(synapse_infos)):
+                            if (synapse_infos[n].connector is connector):
+                                connector_found = True
+                        if not connector_found:
+                            synapse_infos.append(synapse_info)
 
         # Skip blocks that will be written on the machine, but add them
         # to the master population table
         generator_data = list()
-        # numpy.random.shuffle(order)
         for gen_data in generate_on_machine:
             (synapse_info, pre_slices, pre_vertex_slice, pre_slice_idx,
                 app_edge, rinfo) = gen_data
@@ -650,7 +657,15 @@ class SynapticManager(object):
                 post_vertex_slice, master_pop_table_region, rinfo,
                 all_syn_block_sz, block_addr, machine_time_step, app_edge,
                 generator_data)
-            synapse_infos.append(synapse_info)
+
+            # Add a distinct synapse info (determined by
+            # connector) to the list of synapse info
+            connector_found = False
+            for n in range(len(synapse_infos)):
+                if (synapse_infos[n].connector is connector):
+                    connector_found = True
+            if not connector_found:
+                synapse_infos.append(synapse_info)
 
         # Loop over synapse infos as collected above and assign index in order
         for n in range(len(synapse_infos)):


### PR DESCRIPTION
The fix (already in master now) at https://github.com/SpiNNakerManchester/sPyNNaker/pull/667 wasn't comprehensive enough and caused failures in most cases with n_neurons > 255 (found by the cron-job on Jenkins in, for example p8_integration_tests/quick_test/test_connectors/test_all_to_all_connector.py).  This fix should ensure that all cases now work correctly.