### PR TITLE
Fixed prob connector fix

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -50,11 +50,6 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine):
             self._n_pre_neurons * self._n_post_neurons, self._p_connect)
         return self._get_delay_maximum(delays, n_connections)
 
-    def _get_n_connections(self, out_of):
-        return utility_calls.get_probable_maximum_selected(
-            self._n_pre_neurons * self._n_post_neurons, out_of,
-            self._p_connect)
-
     @overrides(AbstractConnector.get_n_connections_from_pre_vertex_maximum)
     def get_n_connections_from_pre_vertex_maximum(
             self, delays, post_vertex_slice, min_delay=None, max_delay=None):

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -100,7 +100,7 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine):
         if not self.__allow_self_connections:
             items[0:n_items:post_vertex_slice.n_atoms + 1] = numpy.inf
 
-        present = items < self._p_connect
+        present = items <= self._p_connect
         ids = numpy.where(present)[0]
         n_connections = numpy.sum(present)
 
@@ -130,10 +130,16 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine):
             self, pre_slices, pre_slice_index, post_slices,
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             synapse_type):
+        prob_value = round(decimal.Decimal(
+            str(self._p_connect)) * DataType.U032.scale)
+        # If prob=1.0 has been specified, take care when scaling value to
+        # ensure that it doesn't wrap round to zero as an unsigned long fract
+        if (self._p_connect == 1.0):
+            prob_value = round(decimal.Decimal(
+                str(self._p_connect)) * (DataType.U032.scale - 1))
         params = [
             self.__allow_self_connections,
-            round(decimal.Decimal(
-                str(self._p_connect)) * DataType.U032.scale)]
+            prob_value]
         params.extend(self._get_connector_seed(
             pre_vertex_slice, post_vertex_slice, self._rng))
         return numpy.array(params, dtype="uint32")

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -56,7 +56,7 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine):
         # pylint: disable=too-many-arguments
         n_connections = utility_calls.get_probable_maximum_selected(
             self._n_pre_neurons * self._n_post_neurons,
-            post_vertex_slice.n_atoms, self._p_connect)
+            post_vertex_slice.n_atoms, self._p_connect, chance=1.0/10000.0)
 
         if min_delay is None or max_delay is None:
             return int(math.ceil(n_connections))

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -70,7 +70,7 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine):
         # pylint: disable=too-many-arguments
         n_connections = utility_calls.get_probable_maximum_selected(
             self._n_pre_neurons * self._n_post_neurons,
-            self._n_pre_neurons, self._p_connect)
+            self._n_pre_neurons, self._p_connect, chance=1.0/10000.0)
         return n_connections
 
     @overrides(AbstractConnector.get_weight_maximum)

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -163,7 +163,7 @@ def read_spikes_from_file(file_path, min_atom=0, max_atom=float('inf'),
 
 
 def get_probable_maximum_selected(
-        n_total_trials, n_trials, selection_prob, chance=(1.0 / 10000.0)):
+        n_total_trials, n_trials, selection_prob, chance=(1.0 / 100.0)):
     """ Get the likely maximum number of items that will be selected from a\
         set of n_trials from a total set of n_total_trials\
         with a probability of selection of selection_prob

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -163,7 +163,7 @@ def read_spikes_from_file(file_path, min_atom=0, max_atom=float('inf'),
 
 
 def get_probable_maximum_selected(
-        n_total_trials, n_trials, selection_prob, chance=(1.0 / 100.0)):
+        n_total_trials, n_trials, selection_prob, chance=(1.0 / 10000.0)):
     """ Get the likely maximum number of items that will be selected from a\
         set of n_trials from a total set of n_total_trials\
         with a probability of selection of selection_prob


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/587

It seems to simply be the case that this was being done correctly for other probabilistic connectors, but not for the FixedProbabilityConnector.  I haven't seen any failures in this test since adjusting the chance values to those used in other connectors.  (Given that it is probabilistic, it's possible this test will fail very occasionally; if we see it failing again as often as it was before then my suggestion would be to make the chance values even smaller than they already are).

[It would also be instructive to check whether this causes any problems with SDRAM requirements for larger jobs - I've tested a few but by no means exhaustively.]