### PR TITLE
Initial values 2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ flake8
 pytest-cov
 pytest-timeout
 sphinx==1.5.3
+testfixtures

--- a/spynnaker/pyNN/models/abstract_pynn_model.py
+++ b/spynnaker/pyNN/models/abstract_pynn_model.py
@@ -38,6 +38,8 @@ class AbstractPyNNModel(object):
     @staticmethod
     def _get_init_params_and_svars(cls):
         init = getattr(cls, "__init__")
+        while hasattr(init, "_method"):
+            init = getattr(init, "_method")
         params = None
         if hasattr(init, "_parameters"):
             params = getattr(init, "_parameters")

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -22,8 +22,8 @@ def get_dict_from_init(init, skip=None, include=None):
     init_args = getfullargspec(init)
     n_defaults = 0 if init_args.defaults is None else len(init_args.defaults)
     n_args = 0 if init_args.args is None else len(init_args.args)
-    default_args = [] if init_args.args is None else \
-        init_args.args[n_args - n_defaults:]
+    default_args = ([] if init_args.args is None else
+                    init_args.args[n_args - n_defaults:])
     default_values = [] if init_args.defaults is None else init_args.defaults
 
     # Check that included / skipped things exist

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -20,10 +20,11 @@ def _check_args(args_to_find, default_args, init):
 
 def get_dict_from_init(init, skip=None, include=None):
     init_args = getfullargspec(init)
-    n_defaults = len(init_args.defaults)
-    n_args = len(init_args.args)
-    default_args = init_args.args[n_args - n_defaults:]
-    default_values = init_args.defaults
+    n_defaults = 0 if init_args.defaults is None else len(init_args.defaults)
+    n_args = 0 if init_args.args is None else len(init_args.args)
+    default_args = [] if init_args.args is None else \
+        init_args.args[n_args - n_defaults:]
+    default_values = [] if init_args.defaults is None else init_args.defaults
 
     # Check that included / skipped things exist
     if include is not None:

--- a/unittests/model_tests/neuron/test_abstract_neuron_impl.py
+++ b/unittests/model_tests/neuron/test_abstract_neuron_impl.py
@@ -2,11 +2,17 @@ import sys
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spynnaker.pyNN.models.neuron.abstract_pynn_neuron_model import (
     DEFAULT_MAX_ATOMS_PER_CORE, AbstractPyNNNeuronModel)
+from spynnaker.pyNN.models.defaults import default_initial_values, defaults
 
 
+@defaults
 class _MyPyNNModelImpl(AbstractPyNNModel):
 
     default_population_parameters = {}
+
+    @default_initial_values({"svar"})
+    def __init__(self, param=1.0, svar=2.0):
+        pass
 
     def create_vertex(self, n_neurons, label, constraints):
         return None
@@ -37,3 +43,10 @@ def test_reset_max_atoms_per_core():
     assert(_MyNeuronModelImpl.get_max_atoms_per_core() ==
            DEFAULT_MAX_ATOMS_PER_CORE)
     assert(_MyPyNNModelImpl.get_max_atoms_per_core() == sys.maxsize)
+
+
+def test_defaults():
+    assert(_MyPyNNModelImpl.default_initial_values == {"svar": 2.0})
+    assert(_MyPyNNModelImpl.default_parameters == {"param": 1.0})
+    assert(_MyPyNNModelImpl.default_initial_values == {"svar": 2.0})
+    assert(_MyPyNNModelImpl.default_parameters == {"param": 1.0})

--- a/unittests/model_tests/neuron/test_defaults.py
+++ b/unittests/model_tests/neuron/test_defaults.py
@@ -2,6 +2,8 @@ from six import add_metaclass
 from spinn_utilities.abstract_base import AbstractBase, abstractproperty
 from spynnaker.pyNN.models.defaults import (
     defaults, default_parameters, default_initial_values)
+from testfixtures.logcapture import LogCapture
+import re
 
 
 def test_nothing():
@@ -44,8 +46,18 @@ def test_both():
         @default_initial_values({"param_2"})
         def __init__(self, param_1=1, param_2=2, param_3=3):
             pass
+
+    @defaults
+    class _AnotherClass(object):
+
+        @default_initial_values({"param_1"})
+        @default_parameters({"param_2"})
+        def __init__(self, param_1=1, param_2=2, param_3=3):
+            pass
     assert(_AClass.default_parameters == {"param_1": 1})
     assert(_AClass.default_initial_values == {"param_2": 2})
+    assert(_AnotherClass.default_parameters == {"param_2": 2})
+    assert(_AnotherClass.default_initial_values == {"param_1": 1})
 
 
 def test_abstract():
@@ -74,3 +86,55 @@ def test_abstract():
     assert(_AClass.default_parameters == {"param": "test"})
     assert(_AClass.default_initial_values == {})
     _AClass()
+
+
+def test_setting_state_variables():
+
+    @defaults
+    class _AClass(object):
+
+        @default_parameters({"param_1"})
+        def __init__(self, param_1=1, param_2=2, param_3=3):
+            pass
+
+    @defaults
+    class _AnotherClass(object):
+
+        @default_initial_values({"param_1"})
+        def __init__(self, param_1=1, param_2=2, param_3=3):
+            pass
+
+    with LogCapture() as lc:
+        _AClass(param_1=1)
+        _check_warnings(lc, [], ["param_1", "param_2", "param_3"])
+    with LogCapture() as lc:
+        _AClass(param_2=2)
+        _check_warnings(lc, ["param_2"], ["param_1", "param_3"])
+    with LogCapture() as lc:
+        _AClass(param_3=3)
+        _check_warnings(lc, ["param_3"], ["param_1", "param_2"])
+
+    with LogCapture() as lc:
+        _AnotherClass(param_1=1)
+        _check_warnings(lc, ["param_1"], ["param_2", "param_3"])
+    with LogCapture() as lc:
+        _AnotherClass(param_2=2)
+        _check_warnings(lc, [], ["param_1", "param_2", "param_3"])
+    with LogCapture() as lc:
+        _check_warnings(lc, [], ["param_1", "param_2", "param_3"])
+        _AnotherClass(param_3=3)
+
+
+def _check_warnings(lc, expected, not_expected):
+    line_matcher = re.compile(
+        "Formal PyNN specifies that (.*) should be set using initial_values"
+        " not cell_params")
+    warning_variables = set()
+    for record in lc.records:
+        match = line_matcher.match(record.getMessage())
+        if record.levelname == "WARNING" and match:
+            warning_variables.add(match.group(1))
+
+    print("Found warnings for variables {}".format(warning_variables))
+    assert(all(item in warning_variables for item in expected))
+    assert(all(item not in warning_variables for item in not_expected))

--- a/unittests/test_populations/test_vertex.py
+++ b/unittests/test_populations/test_vertex.py
@@ -4,7 +4,7 @@ from spynnaker.pyNN.models.neuron import (
     AbstractPopulationVertex, AbstractPyNNNeuronModelStandard)
 from spynnaker.pyNN.models.neuron.synapse_types import AbstractSynapseType
 from spynnaker.pyNN.models.neuron.neuron_models import AbstractNeuronModel
-from spynnaker.pyNN.models.defaults import default_initial_values
+from spynnaker.pyNN.models.defaults import default_initial_values, defaults
 from spynnaker.pyNN.models.neuron.implementations import (
     AbstractStandardNeuronComponent)
 from unittests.mocks import MockSimulator
@@ -79,6 +79,7 @@ class _MyNeuronModel(AbstractNeuronModel):
         return None
 
 
+@defaults
 class FooBar(AbstractPyNNNeuronModelStandard):
 
     @default_initial_values({"foo", "bar"})


### PR DESCRIPTION
A replacement for #640 which uses the existing infrastructure to check for the assignment of initial values through the constructor.  Note that this version keeps the values of the initial values in tact, so the default_initial_values still works.