### PR TITLE
set default to time optimistation in neural make file

### DIFF
--- a/neural_modelling/makefiles/neuron/neural_build.mk
+++ b/neural_modelling/makefiles/neuron/neural_build.mk
@@ -192,7 +192,7 @@ SOURCES = common/out_spikes.c \
 
 include $(SPINN_DIRS)/make/local.mk
 
-FEC_OPT = $(OSPACE)
+FEC_OPT = $(OTIME)
 
 # Synapse build rules
 SYNAPSE_TYPE_COMPILE = $(CC) -DLOG_LEVEL=$(SYNAPSE_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED)


### PR DESCRIPTION
I'm able to build all binaries with time optimisation enabled therefore suggest this be made default given the core processing performance gains it provides.

Any binaries that cannot be built with a time optimisation compiler flag can redefine the FEC_OP value in their own make files to OSPACE