### PR TITLE
exclude csa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ scipy
 lxml
 six
 matplotlib
-csa
+# csa  # needed but excluded due to readthedocs
 # spinnaker_tools

--- a/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
@@ -5,7 +5,7 @@ from .abstract_connector import AbstractConnector
 try:
     import csa
     csa_exception = False
-except ModuleNotFoundError as ex:
+except ModuleNotFoundError as ex: # noqa: F821
     # Importing csa causes problems with readthedocs so allowing it to fail
     csa_exception = ex
 
@@ -127,7 +127,3 @@ class CSAConnector(AbstractConnector):
     def __repr__(self):
         return "CSAConnector({})".format(
             self.__full_cset)
-
-
-if __name__ == "__main__":
-    CSAConnector()

--- a/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
@@ -1,8 +1,13 @@
 import logging
-import csa
 import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_connector import AbstractConnector
+try:
+    import csa
+    csa_exception = False
+except ModuleNotFoundError as ex:
+    # Importing csa causes problems with readthedocs so allowing it to fail
+    csa_exception = ex
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +29,8 @@ class CSAConnector(AbstractConnector):
         :param '?' cset:
             A description of the connection set between populations
         """
+        if csa_exception:
+            raise csa_exception
         super(CSAConnector, self).__init__(safe, verbose)
         self.__cset = cset
 
@@ -120,3 +127,7 @@ class CSAConnector(AbstractConnector):
     def __repr__(self):
         return "CSAConnector({})".format(
             self.__full_cset)
+
+
+if __name__ == "__main__":
+    CSAConnector()

--- a/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
@@ -5,7 +5,7 @@ from .abstract_connector import AbstractConnector
 try:
     import csa
     csa_exception = False
-except ModuleNotFoundError as ex: # noqa: F821
+except ModuleNotFoundError as ex:  # noqa: F821
     # Importing csa causes problems with readthedocs so allowing it to fail
     csa_exception = ex
 


### PR DESCRIPTION
csa causes problems in readthedocs due to its dependency on matplotlib

This (slighlty sticky paster) does
1. Removes csa from requirements

2. Adds it to setup but only if not in READTHEDOCS  (also for spynakker8)
https://github.com/SpiNNakerManchester/sPyNNaker8/pull/237

3. Delays the ModuleNotFoundError until a csaconnector is created 
   Note: as the typical way to create a CSAConnector is with a csa object  for example: CSAConnector(csa.oneToOne) It is likely the script will need to also do import csa   which will fail there.

tested with:
https://spinnaker8manchester.readthedocs.io/en/readthedocs/