### PR TITLE
Emergency fix: make sure tests can run in parallel

### DIFF
--- a/unittests/model_tests/neuron/test_neural_parameter.py
+++ b/unittests/model_tests/neuron/test_neural_parameter.py
@@ -65,7 +65,8 @@ def test_range_list_as_list():
     with tempfile.NamedTemporaryFile() as temp:
         spec = DataSpecificationGenerator(FileDataWriter(temp.name), None)
         try:
-            value = SpynnakerRangedList(size=10, value=_generator(10), key="test")
+            value = SpynnakerRangedList(
+                size=10, value=_generator(10), key="test")
             param = NeuronParameter(value, DataType.S1615)
             iterator = param.iterator_by_slice(0, 5, spec)
             values = _iterate_parameter_values(iterator, DataType.S1615)

--- a/unittests/model_tests/neuron/test_neural_parameter.py
+++ b/unittests/model_tests/neuron/test_neural_parameter.py
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import struct
+import tempfile
 from six.moves import xrange
 from spinn_storage_handlers import FileDataWriter
 from data_specification.enums import DataType
@@ -41,20 +41,18 @@ def _iterate_parameter_values(iterator, data_type):
 
 def test_range_list():
     MockSimulator().setup()
-
-    spec_writer = FileDataWriter("test.dat")
-    spec = DataSpecificationGenerator(spec_writer, None)
-    try:
-        value = SpynnakerRangedList(size=10, value=1.0, key="test")
-        value[2:4] = 2.0
-        param = NeuronParameter(value, DataType.S1615)
-        iterator = param.iterator_by_slice(0, 5, spec)
-        values = _iterate_parameter_values(iterator, DataType.S1615)
-        assert list(value[0:5]) == values
-        assert isinstance(iterator, _Range_Iterator)
-    finally:
-        spec.end_specification()
-        os.remove("test.dat")
+    with tempfile.NamedTemporaryFile() as temp:
+        spec = DataSpecificationGenerator(FileDataWriter(temp.name), None)
+        try:
+            value = SpynnakerRangedList(size=10, value=1.0, key="test")
+            value[2:4] = 2.0
+            param = NeuronParameter(value, DataType.S1615)
+            iterator = param.iterator_by_slice(0, 5, spec)
+            values = _iterate_parameter_values(iterator, DataType.S1615)
+            assert list(value[0:5]) == values
+            assert isinstance(iterator, _Range_Iterator)
+        finally:
+            spec.end_specification()
 
 
 def _generator(size):
@@ -64,50 +62,44 @@ def _generator(size):
 
 def test_range_list_as_list():
     MockSimulator.setup()
-
-    spec_writer = FileDataWriter("test.dat")
-    spec = DataSpecificationGenerator(spec_writer, None)
-    try:
-        value = SpynnakerRangedList(size=10, value=_generator(10), key="test")
-        param = NeuronParameter(value, DataType.S1615)
-        iterator = param.iterator_by_slice(0, 5, spec)
-        values = _iterate_parameter_values(iterator, DataType.S1615)
-        assert list(value[0:5]) == values
-        assert isinstance(iterator, _Range_Iterator)
-    finally:
-        spec.end_specification()
-        os.remove("test.dat")
+    with tempfile.NamedTemporaryFile() as temp:
+        spec = DataSpecificationGenerator(FileDataWriter(temp.name), None)
+        try:
+            value = SpynnakerRangedList(size=10, value=_generator(10), key="test")
+            param = NeuronParameter(value, DataType.S1615)
+            iterator = param.iterator_by_slice(0, 5, spec)
+            values = _iterate_parameter_values(iterator, DataType.S1615)
+            assert list(value[0:5]) == values
+            assert isinstance(iterator, _Range_Iterator)
+        finally:
+            spec.end_specification()
 
 
 def test_real_list():
     MockSimulator.setup()
-
-    spec_writer = FileDataWriter("test.dat")
-    spec = DataSpecificationGenerator(spec_writer, None)
-    try:
-        value = range(10)
-        param = NeuronParameter(value, DataType.S1615)
-        iterator = param.iterator_by_slice(0, 5, spec)
-        values = _iterate_parameter_values(iterator, DataType.S1615)
-        assert list(value[0:5]) == values
-        assert isinstance(iterator, _Get_Iterator)
-    finally:
-        spec.end_specification()
-        os.remove("test.dat")
+    with tempfile.NamedTemporaryFile() as temp:
+        spec = DataSpecificationGenerator(FileDataWriter(temp.name), None)
+        try:
+            value = range(10)
+            param = NeuronParameter(value, DataType.S1615)
+            iterator = param.iterator_by_slice(0, 5, spec)
+            values = _iterate_parameter_values(iterator, DataType.S1615)
+            assert list(value[0:5]) == values
+            assert isinstance(iterator, _Get_Iterator)
+        finally:
+            spec.end_specification()
 
 
 def test_single_value():
     MockSimulator.setup()
-
-    spec_writer = FileDataWriter("test.dat")
-    spec = DataSpecificationGenerator(spec_writer, None)
-    try:
-        value = 1.0
-        param = NeuronParameter(value, DataType.S1615)
-        iterator = param.iterator_by_slice(0, 5, spec)
-        values = _iterate_parameter_values(iterator, DataType.S1615)
-        assert [value] * 5 == values
-        assert isinstance(iterator, _SingleValue_Iterator)
-    finally:
-        spec.end_specification()
-        os.remove("test.dat")
+    with tempfile.NamedTemporaryFile() as temp:
+        spec = DataSpecificationGenerator(FileDataWriter(temp.name), None)
+        try:
+            value = 1.0
+            param = NeuronParameter(value, DataType.S1615)
+            iterator = param.iterator_by_slice(0, 5, spec)
+            values = _iterate_parameter_values(iterator, DataType.S1615)
+            assert [value] * 5 == values
+            assert isinstance(iterator, _SingleValue_Iterator)
+        finally:
+            spec.end_specification()


### PR DESCRIPTION
Using the same filename in each test can lead to uninformative failures. Use a temporary file instead.