### PR TITLE
Deal with compiler warnings for null arguments to spin1_memcpy

### DIFF
--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -69,7 +69,7 @@ static synapse_param_t *neuron_synapse_shaping_params;
 static bool neuron_impl_initialise(uint32_t n_neurons) {
 
     // allocate DTCM for the global parameter details
-    if (sizeof(global_neuron_params_t) > 0) {
+    if (sizeof(global_neuron_params_t) != 0) {
         global_parameters = (global_neuron_params_t *) spin1_malloc(
             sizeof(global_neuron_params_t));
         if (global_parameters == NULL) {
@@ -148,34 +148,42 @@ static void neuron_impl_load_neuron_parameters(
     log_debug("reading parameters, next is %u, n_neurons is %u ",
         next, n_neurons);
 
-    //log_debug("writing neuron global parameters");
-    spin1_memcpy(global_parameters, &address[next],
-            sizeof(global_neuron_params_t));
-    next += (sizeof(global_neuron_params_t) + 3) / 4;
+    if (sizeof(global_neuron_params_t) != 0) {
+        log_debug("writing neuron global parameters");
+    	spin1_memcpy(global_parameters, &address[next],
+    			sizeof(global_neuron_params_t));
+    	next += (sizeof(global_neuron_params_t) + 3) / 4;
+    }
 
     log_debug("reading neuron local parameters");
     spin1_memcpy(neuron_array, &address[next], n_neurons * sizeof(neuron_t));
     next += ((n_neurons * sizeof(neuron_t)) + 3) / 4;
 
-    log_debug("reading input type parameters");
-    spin1_memcpy(input_type_array, &address[next],
-            n_neurons * sizeof(input_type_t));
-    next += ((n_neurons * sizeof(input_type_t)) + 3) / 4;
+    if (sizeof(input_type_t) != 0) {
+    	log_debug("reading input type parameters");
+    	spin1_memcpy(input_type_array, &address[next],
+    			n_neurons * sizeof(input_type_t));
+    	next += ((n_neurons * sizeof(input_type_t)) + 3) / 4;
+    }
 
-    log_debug("reading threshold type parameters");
-    spin1_memcpy(threshold_type_array, &address[next],
-           n_neurons * sizeof(threshold_type_t));
-    next += ((n_neurons * sizeof(threshold_type_t)) + 3) / 4;
+    if (sizeof(threshold_type_t) != 0) {
+    	log_debug("reading threshold type parameters");
+    	spin1_memcpy(threshold_type_array, &address[next],
+    			n_neurons * sizeof(threshold_type_t));
+    	next += ((n_neurons * sizeof(threshold_type_t)) + 3) / 4;
+    }
 
     log_debug("reading synapse parameters");
     spin1_memcpy(neuron_synapse_shaping_params, &address[next],
-           n_neurons * sizeof(synapse_param_t));
+            n_neurons * sizeof(synapse_param_t));
     next += ((n_neurons * sizeof(synapse_param_t)) + 3) / 4;
 
-    log_debug("reading additional input type parameters");
-        spin1_memcpy(additional_input_array, &address[next],
-               n_neurons * sizeof(additional_input_t));
-    next += ((n_neurons * sizeof(additional_input_t)) + 3) / 4;
+    if (sizeof(additional_input_t) != 0) {
+    	log_debug("reading additional input type parameters");
+    	spin1_memcpy(additional_input_array, &address[next],
+    			n_neurons * sizeof(additional_input_t));
+    	next += ((n_neurons * sizeof(additional_input_t)) + 3) / 4;
+    }
 
     neuron_model_set_global_neuron_params(global_parameters);
 
@@ -280,35 +288,43 @@ static void neuron_impl_store_neuron_parameters(
         address_t address, uint32_t next, uint32_t n_neurons) {
     log_debug("writing parameters");
 
-    //log_debug("writing neuron global parameters");
-    spin1_memcpy(&address[next], global_parameters,
-            sizeof(global_neuron_params_t));
-    next += (sizeof(global_neuron_params_t) + 3) / 4;
+    if (sizeof(global_neuron_params_t) != 0) {
+    	log_debug("writing neuron global parameters");
+    	spin1_memcpy(&address[next], global_parameters,
+    			sizeof(global_neuron_params_t));
+    	next += (sizeof(global_neuron_params_t) + 3) / 4;
+    }
 
     log_debug("writing neuron local parameters");
     spin1_memcpy(&address[next], neuron_array,
             n_neurons * sizeof(neuron_t));
     next += ((n_neurons * sizeof(neuron_t)) + 3) / 4;
 
-    log_debug("writing input type parameters");
-    spin1_memcpy(&address[next], input_type_array,
-            n_neurons * sizeof(input_type_t));
-    next += ((n_neurons * sizeof(input_type_t)) + 3) / 4;
+    if (sizeof(input_type_t) != 0) {
+    	log_debug("writing input type parameters");
+    	spin1_memcpy(&address[next], input_type_array,
+    			n_neurons * sizeof(input_type_t));
+    	next += ((n_neurons * sizeof(input_type_t)) + 3) / 4;
+    }
 
-    log_debug("writing threshold type parameters");
-    spin1_memcpy(&address[next], threshold_type_array,
-            n_neurons * sizeof(threshold_type_t));
-    next += ((n_neurons * sizeof(threshold_type_t)) + 3) / 4;
+    if (sizeof(threshold_type_t) != 0) {
+    	log_debug("writing threshold type parameters");
+    	spin1_memcpy(&address[next], threshold_type_array,
+    			n_neurons * sizeof(threshold_type_t));
+    	next += ((n_neurons * sizeof(threshold_type_t)) + 3) / 4;
+    }
 
     log_debug("writing synapse parameters");
     spin1_memcpy(&address[next], neuron_synapse_shaping_params,
             n_neurons * sizeof(synapse_param_t));
     next += ((n_neurons * sizeof(synapse_param_t)) + 3) / 4;
 
-    log_debug("writing additional input type parameters");
-    spin1_memcpy(&address[next], additional_input_array,
-            n_neurons * sizeof(additional_input_t));
-    next += ((n_neurons * sizeof(additional_input_t)) + 3) / 4;
+    if (sizeof(additional_input_t) != 0) {
+    	log_debug("writing additional input type parameters");
+    	spin1_memcpy(&address[next], additional_input_array,
+    			n_neurons * sizeof(additional_input_t));
+    	next += ((n_neurons * sizeof(additional_input_t)) + 3) / 4;
+    }
 }
 
 #if LOG_LEVEL >= LOG_DEBUG


### PR DESCRIPTION
Following https://github.com/SpiNNakerManchester/spinnaker_tools/pull/95, you can't now specify null arguments in spin1_memcpy(...).  This PR fixes that in cases where we have particular neuron components that (could have) empty structs.