### PR TITLE
Make synapse printing code inside LOG_DEBUG work again

### DIFF
--- a/neural_modelling/makefiles/neuron/neural_build.mk
+++ b/neural_modelling/makefiles/neuron/neural_build.mk
@@ -234,7 +234,7 @@ $(BUILD_DIR)neuron/population_table/population_table_binary_search_impl.o: $(MOD
 
 #STDP Build rules If and only if STDP used
 ifeq ($(STDP_ENABLED), 1)
-    STDP_INCLUDES:= -include $(WEIGHT_DEPENDENCE_H) -include $(TIMING_DEPENDENCE_H)
+    STDP_INCLUDES:= -include $(SYNAPSE_TYPE_H) -include $(WEIGHT_DEPENDENCE_H) -include $(TIMING_DEPENDENCE_H)
     STDP_COMPILE = $(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED) -DSYNGEN_ENABLED=$(SYNGEN_ENABLED) $(STDP_INCLUDES)
 
     $(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -179,8 +179,6 @@ void synapse_dynamics_print_plastic_synapses(
             synapse_row_plastic_controls(fixed_region_address);
     size_t plastic_synapse =
             synapse_row_num_plastic_controls(fixed_region_address);
-    const pre_event_history_t *event_history =
-            plastic_event_history(plastic_region_address);
 
     log_debug("Plastic region %u synapses\n", plastic_synapse);
 
@@ -245,10 +243,10 @@ address_t synapse_dynamics_initialise(
     uint32_t n_neurons_power_2 = n_neurons;
     uint32_t log_n_neurons = 1;
     if (n_neurons != 1) {
-    	if (!is_power_of_2(n_neurons)) {
-    		n_neurons_power_2 = next_power_of_2(n_neurons);
-    	}
-    	log_n_neurons = ilog_2(n_neurons_power_2);
+        if (!is_power_of_2(n_neurons)) {
+            n_neurons_power_2 = next_power_of_2(n_neurons);
+        }
+        log_n_neurons = ilog_2(n_neurons_power_2);
     }
 
     uint32_t n_synapse_types_power_2 = n_synapse_types;


### PR DESCRIPTION
Not sure how many people ever bother to compile with `SPYNNAKER_DEBUG=DEBUG` nowadays, but if they do at the moment then it won't work - this fixes that.  (Note however that at the moment compiling with this puts `IF_curr_exp_stdp_mad_pair_additive_structural` and `IF_cond_exp_stdp_mad_pair_additive_structural` over the ITCM limit - I guess it'll be worth trying this again once https://github.com/SpiNNakerManchester/sPyNNaker/pull/687 is merged.)

A related question, is `FEC_DEBUG=DEBUG` intended just for FrontEndCommon, or should it work from sPyNNaker as well? (i.e. should you be able to do `make SPYNNAKER_DEBUG=DEBUG FEC_DEBUG=DEBUG` from sPyNNaker?  I tried it and it complained about something related to assert(...), which led me down a rabbit-hole of confusion in spinn_common and spinnaker_tools...)