### PR TITLE
Fix slow rate live setting

### DIFF
--- a/neural_modelling/src/spike_source/poisson/spike_source_poisson.c
+++ b/neural_modelling/src/spike_source/poisson/spike_source_poisson.c
@@ -698,8 +698,9 @@ void set_spike_source_rate(uint32_t id, REAL rate) {
             ((id - global_parameters.first_source_id) <
              global_parameters.n_spike_sources)) {
         uint32_t sub_id = id - global_parameters.first_source_id;
-        log_debug("Setting rate of %u (%u) to %kHz", id, sub_id, rate);
         REAL rate_per_tick = rate * global_parameters.seconds_per_tick;
+        log_debug("Setting rate of %u (%u) to %kHz (%k per tick)",
+                id, sub_id, rate, rate_per_tick);
         if (rate_per_tick >= global_parameters.slow_rate_per_tick_cutoff) {
             poisson_parameters[sub_id].is_fast_source = true;
             if (rate_per_tick >= global_parameters.fast_rate_per_tick_cutoff) {
@@ -708,11 +709,15 @@ void set_spike_source_rate(uint32_t id, REAL rate) {
             } else {
                 poisson_parameters[sub_id].exp_minus_lambda =
                         (UFRACT) EXP(-rate_per_tick);
+                poisson_parameters[sub_id].sqrt_lambda = REAL_CONST(0.0);
             }
         } else {
             poisson_parameters[sub_id].is_fast_source = false;
             poisson_parameters[sub_id].mean_isi_ticks =
-                (uint32_t) rate * global_parameters.ticks_per_second;
+                    (uint32_t) (REAL_CONST(1.0) / rate_per_tick);
+            poisson_parameters[sub_id].time_to_spike_ticks =
+                    slow_spike_source_get_time_to_spike(
+                        poisson_parameters[sub_id].mean_isi_ticks);
         }
     }
 }


### PR DESCRIPTION
This was still wrong (and must have been wrong for some time!).  This should fix it as it now does the same thing that the host does.  This also fixes the fast-but-not-faster case after setting a faster rate previously (it resets the faster item to 0 to make sure it doesn't get used any more).