### PR TITLE
Synapse expander bug

### DIFF
--- a/neural_modelling/src/synapse_expander/delay_expander.c
+++ b/neural_modelling/src/synapse_expander/delay_expander.c
@@ -34,8 +34,8 @@ struct delay_builder_config {
     // the parameters
     uint32_t max_row_n_synapses;
     uint32_t max_delayed_row_n_synapses;
-    uint32_t post_slice_start;
-    uint32_t post_slice_count;
+    uint32_t pre_slice_start;
+    uint32_t pre_slice_count;
     uint32_t max_stage;
     accum timestep_per_delay;
     // the connector and delay parameter generators
@@ -50,16 +50,16 @@ struct delay_builder_config {
  *!                          after calling.
  *! \param[in/out] neuron_delay_stage_config Bit fields into which to write the
  *!                                          delay information
- *! \param[in] pre_slice_start The start of the slice of the delay extension to
- *!                            generate for
- *! \param[in] pre_slice_count The number of neurons of the delay extension to
- *!                            generate for
+ *! \param[in] post_slice_start The start of the slice of the delay extension to
+ *!                             generate for
+ *! \param[in] post_slice_count The number of neurons of the delay extension to
+ *!                             generate for
  *! \return True if the region was correctly generated, False if there was an
  *!         error
  */
 static bool read_delay_builder_region(address_t *in_region,
-        bit_field_t *neuron_delay_stage_config, uint32_t pre_slice_start,
-        uint32_t pre_slice_count) {
+        bit_field_t *neuron_delay_stage_config, uint32_t post_slice_start,
+        uint32_t post_slice_count) {
     // Get the parameters
     address_t region = *in_region;
     struct delay_builder_config config;
@@ -78,6 +78,8 @@ static bool read_delay_builder_region(address_t *in_region,
     }
 
     // For each pre-neuron, generate the connections
+    uint32_t pre_slice_start = config.pre_slice_start;
+    uint32_t pre_slice_count = config.pre_slice_count;
     uint32_t pre_slice_end = pre_slice_start + pre_slice_count;
     for (uint32_t pre_neuron_index = pre_slice_start;
             pre_neuron_index < pre_slice_end; pre_neuron_index++) {
@@ -87,7 +89,7 @@ static bool read_delay_builder_region(address_t *in_region,
         uint16_t indices[max_n_synapses];
         uint32_t n_indices = connection_generator_generate(
                 connection_generator, pre_slice_start, pre_slice_count,
-                pre_neuron_index, config.post_slice_start, config.post_slice_count,
+                pre_neuron_index, post_slice_start, post_slice_count,
                 max_n_synapses, indices);
         log_debug("Generated %u synapses", n_indices);
 
@@ -155,17 +157,17 @@ static bool run_delay_expander(
 
     // Read the global parameters from the expander region
     uint32_t n_out_edges = *params_address++;
-    uint32_t pre_slice_start = *params_address++;
-    uint32_t pre_slice_count = *params_address++;
+    uint32_t post_slice_start = *params_address++;
+    uint32_t post_slice_count = *params_address++;
 
-    log_debug("Generating %u delay edges for %u atoms starting at %u",
-            n_out_edges, pre_slice_count, pre_slice_start);
+    log_info("Generating %u delay edges for %u atoms starting at %u",
+            n_out_edges, post_slice_count, post_slice_start);
 
     // Go through each connector and make the delay data
     for (uint32_t edge = 0; edge < n_out_edges; edge++) {
         if (!read_delay_builder_region(
                 &params_address, neuron_delay_stage_config,
-                pre_slice_start, pre_slice_count)) {
+                post_slice_start, post_slice_count)) {
             return false;
         }
     }

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -159,8 +159,9 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine):
         prob_in_slice = (
             post_vertex_slice.n_atoms / float(self._n_post_neurons))
         n_connections = utility_calls.get_probable_maximum_selected(
-            self._n_pre_neurons * self._n_pre_neurons,
-            self.__n_post, prob_in_slice, chance=1.0/10000.0)
+            self._n_pre_neurons * self._n_post_neurons,
+            self.__n_post * self._n_pre_neurons, prob_in_slice,
+            chance=1.0/100000.0)
 
         if min_delay is None or max_delay is None:
             return int(math.ceil(n_connections))
@@ -175,7 +176,7 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine):
         selection_prob = 1.0 / float(self._n_post_neurons)
         n_connections = utility_calls.get_probable_maximum_selected(
             self._n_post_neurons * self._n_pre_neurons,
-            self.__n_post * self._n_pre_neurons, selection_prob,
+            self.__n_post, selection_prob,
             chance=1.0/100000.0)
         return int(math.ceil(n_connections))
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -254,7 +254,7 @@ class FixedNumberPreConnector(AbstractGenerateConnectorOnMachine):
             post_slice_index, pre_vertex_slice, post_vertex_slice,
             synapse_type):
         # The same seed needs to be sent to each of the slices
-        key = (id(pre_slices), id(post_slices))
+        key = (id(pre_slices), id(post_vertex_slice))
         if key not in self.__pre_connector_seed:
             self.__pre_connector_seed[key] = [
                 int(i * 0xFFFFFFFF) for i in self._rng.next(n=4)]

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -169,7 +169,7 @@ class FixedNumberPreConnector(AbstractGenerateConnectorOnMachine):
             float(post_vertex_slice.n_atoms) / float(self._n_post_neurons))
         n_connections = utility_calls.get_probable_maximum_selected(
             self._n_pre_neurons * self._n_post_neurons,
-            n_connections_total, prob_in_slice)
+            n_connections_total, prob_in_slice, chance=1.0/100000.0)
 
         if min_delay is None or max_delay is None:
             return int(math.ceil(n_connections))

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
@@ -167,7 +167,7 @@ class DelayExtensionVertex(
             max_stage, machine_time_step):
         """ Add delays for a connection to be generated
         """
-        key = (pre_vertex_slice.lo_atom, pre_vertex_slice.hi_atom)
+        key = (post_vertex_slice.lo_atom, post_vertex_slice.hi_atom)
         self.__delay_generator_data[key].append(
             DelayGeneratorData(
                 max_row_n_synapses, max_delayed_row_n_synapses,

--- a/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
@@ -77,8 +77,8 @@ class DelayGeneratorData(object):
         items.append(numpy.array([
             self.__max_row_n_synapses,
             self.__max_delayed_row_n_synapses,
-            self.__post_vertex_slice.lo_atom,
-            self.__post_vertex_slice.n_atoms,
+            self.__pre_vertex_slice.lo_atom,
+            self.__pre_vertex_slice.n_atoms,
             self.__max_stage,
             (decimal.Decimal(str(1000.0 / float(self.__machine_time_step))) *
              DataType.S1615.scale),
@@ -92,4 +92,5 @@ class DelayGeneratorData(object):
         items.append(connector.gen_delay_params(
             self.__synapse_information.delay, self.__pre_vertex_slice,
             self.__post_vertex_slice))
+        print('delay.gen_data - items: ', items)
         return numpy.concatenate(items)

--- a/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
@@ -92,5 +92,4 @@ class DelayGeneratorData(object):
         items.append(connector.gen_delay_params(
             self.__synapse_information.delay, self.__pre_vertex_slice,
             self.__post_vertex_slice))
-        print('delay.gen_data - items: ', items)
         return numpy.concatenate(items)


### PR DESCRIPTION
Fix to make integration test in https://github.com/SpiNNakerManchester/sPyNNaker8/pull/270 work.  Basically, the delay_expander was performing the work in a different order to the synapse_expander, and this was causing it to fail in the specific instance outlined in that test.

While I was there I also (prompted by what @Christian-B was trying to do) fixed the FixedNumberPre- and Post- so that they should now work correctly at 1 neuron per core, rather than giving synaptic memory size errors.