### PR TITLE
Put function call arguments in the correct order

### DIFF
--- a/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
+++ b/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
@@ -145,8 +145,8 @@ class SpynnakerExternalDevicePluginManager(object):
 
         # add new edge and vertex if required to SpiNNaker graph
         SpynnakerExternalDevicePluginManager.update_live_packet_gather_tracker(
-            population._vertex, "LiveSpikeReceiver", port, host, tag,
-            board_address, strip_sdp, use_prefix, key_prefix, prefix_type,
+            population._vertex, "LiveSpikeReceiver", port, host, board_address,
+            tag, strip_sdp, use_prefix, key_prefix, prefix_type,
             message_type, right_shift, payload_as_time_stamps,
             use_payload_prefix, payload_prefix, payload_right_shift,
             number_of_packets_sent_per_time_step,


### PR DESCRIPTION
Found this when trying to figure out issues on a different branch.  The only thing I think this affected directly (on master at least) was IntroLab/sudoku, where it tries to set "tag", and this then gets mixed up with "board_address".