### PR TITLE
calc recordered variable per slice/ machinevertex

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -299,7 +299,7 @@ class NeuronRecorder(object):
                 return True
         return False
 
-    def recorded_region_ids(self, vertex_slice):
+    def recorded_ids_by_slice(self, vertex_slice):
         return [_id
                 for _id, variable in enumerate(self.__sampling_rates.keys())
                 if self._is_recording(variable, vertex_slice)]

--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -288,6 +288,22 @@ class NeuronRecorder(object):
                 results.append(_id)
         return results
 
+    def _is_recording(self, variable, vertex_slice):
+        if self.__sampling_rates[variable] == 0:
+            return False
+        if self.__indexes[variable] is None:
+            return True
+        indexes = self.__indexes[variable]
+        for index in xrange(vertex_slice.lo_atom, vertex_slice.hi_atom+1):
+            if index in indexes:
+                return True
+        return False
+
+    def recorded_region_ids(self, vertex_slice):
+        return [_id
+                for _id, variable in enumerate(self.__sampling_rates.keys())
+                if self._is_recording(variable, vertex_slice)]
+
     def _compute_rate(self, sampling_interval):
         """ Convert a sampling interval into a rate. \
             Remember, machine time step is in nanoseconds

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -249,7 +249,8 @@ class AbstractPopulationVertex(
             constraints=None):
 
         self.__n_subvertices += 1
-        recorded_region_ids = self.__neuron_recorder.recorded_region_ids(vertex_slice)
+        recorded_region_ids = self.__neuron_recorder.recorded_ids_by_slice(
+            vertex_slice)
         return PopulationMachineVertex(
             resources_required, recorded_region_ids,
             label, constraints)

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -249,8 +249,9 @@ class AbstractPopulationVertex(
             constraints=None):
 
         self.__n_subvertices += 1
+        recorded_region_ids = self.__neuron_recorder.recorded_region_ids(vertex_slice)
         return PopulationMachineVertex(
-            resources_required, self.__neuron_recorder.recorded_region_ids,
+            resources_required, recorded_region_ids,
             label, constraints)
 
     def get_cpu_usage_for_atoms(self, vertex_slice):


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/725

Note: get_n_cpu_cycles has NOT been changed as it is already wrong and most of the cpu_cycles per neuron happen regardless of if the variable is actually recording