### PR TITLE
Ring Buffer left shift preserves smallest weight

### DIFF
--- a/neural_modelling/src/neuron/input_types/input_type_conductance.h
+++ b/neural_modelling/src/neuron/input_types/input_type_conductance.h
@@ -44,7 +44,7 @@ static inline input_t* input_type_get_input_value(
         input_t* value, input_type_pointer_t input_type, uint16_t num_receptors) {
     use(input_type);
     for (int i = 0; i < num_receptors; i++) {
-        value[i] = value[i] >> 10;
+        value[i] = value[i] >> 5;
     }
     return &value[0];
 }

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -186,7 +186,7 @@ class FromListConnector(AbstractConnector):
     @overrides(AbstractConnector.get_weight_mean)
     def get_weight_mean(self, weights):
         if self.__weights is None:
-            return numpy.mean(weights)
+            return super(FromListConnector, self).get_weight_mean(weights)
         else:
             return numpy.mean(numpy.abs(self.__weights))
 
@@ -194,7 +194,7 @@ class FromListConnector(AbstractConnector):
     def get_weight_maximum(self, weights):
         # pylint: disable=too-many-arguments
         if self.__weights is None:
-            return numpy.amax(weights)
+            return self._get_weight_maximum(weights, len(self.__conn_list))
         else:
             return numpy.amax(numpy.abs(self.__weights))
 
@@ -202,7 +202,7 @@ class FromListConnector(AbstractConnector):
     def get_weight_variance(self, weights):
         # pylint: disable=too-many-arguments
         if self.__weights is None:
-            return numpy.var(weights)
+            return super(FromListConnector, self).get_weight_variance(weights)
         else:
             return numpy.var(numpy.abs(self.__weights))
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -196,7 +196,7 @@ class FromListConnector(AbstractConnector):
     def get_weight_maximum(self, synapse_info):
         # pylint: disable=too-many-arguments
         if self.__weights is None:
-            return numpy.amax(synapse_info.weights)
+            return self._get_weight_maximum(self.__weights, len(self.__conn_list))
         else:
             return numpy.amax(numpy.abs(self.__weights))
 

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
@@ -76,7 +76,7 @@ class InputTypeConductance(AbstractInputType):
 
     @overrides(AbstractInputType.get_global_weight_scale)
     def get_global_weight_scale(self):
-        return 1024.0
+        return float(2**5)
 
     @property
     def e_rev_E(self):

--- a/spynnaker/pyNN/models/neuron/synapse_io/synapse_io_row_based.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io/synapse_io_row_based.py
@@ -18,6 +18,7 @@ import numpy
 from six import raise_from
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
+from spynnaker.pyNN.utilities.constants import MAX_SUPPORTED_DELAY_TICS
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractConnector)
 from spynnaker.pyNN.exceptions import SynapseRowTooBigException
@@ -42,7 +43,7 @@ class SynapseIORowBased(AbstractSynapseIO):
     @overrides(AbstractSynapseIO.get_maximum_delay_supported_in_ms)
     def get_maximum_delay_supported_in_ms(self, machine_time_step):
         # There are 16 slots, one per time step
-        return 16 * (machine_time_step / 1000.0)
+        return MAX_SUPPORTED_DELAY_TICS * (machine_time_step / 1000.0)
 
     @staticmethod
     def _n_words(n_bytes):

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -524,8 +524,6 @@ class SynapticManager(object):
                     max_weights[synapse_type], biggest_weight[synapse_type])
             # This is to deal with very small weights that are floored to 0
             mmw = 2**math.floor(math.log(min_max_weight[synapse_type], 2))
-            print("max_weights[", synapse_type, "]", max_weights[synapse_type],
-                  "mmw", mmw)
             max_weights[synapse_type] = min(mmw * 2 ** 15,
                                             max_weights[synapse_type])
 

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -473,7 +473,7 @@ class SynapticManager(object):
                         0.0, delay_variance, n_connections)
 
                     weight_max = (synapse_dynamics.get_weight_maximum(
-                        connector, synapse_info.weight) * weight_scale)
+                        connector, synapse_info.weights) * weight_scale)
                     min_max_weight[synapse_type] = \
                         min(min_max_weight[synapse_type], weight_max)
 

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -544,11 +544,12 @@ class SynapticManager(object):
         # Add another bit of shift to prevent overflows
         if weights_signed:
             max_weight_powers = (m + 1 for m in max_weight_powers)
+        rb_ls = list(max_weight_powers)
         print("=" * 60)
         print("RB left shifts for {:20}".format(application_vertex.label),
-              "=", list(max_weight_powers))
+              "=", rb_ls)
         print("-" * 60)
-        return list(max_weight_powers)
+        return rb_ls
 
     @staticmethod
     def _get_weight_scale(ring_buffer_to_input_left_shift):

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -529,7 +529,6 @@ class SynapticManager(object):
             max_weights[synapse_type] = min(mmw * 2 ** 15,
                                             max_weights[synapse_type])
 
-
         # Convert these to powers
         max_weight_powers = (
             0 if w <= 1 else int(math.ceil(max(0, math.log(w, 2))))
@@ -545,6 +544,10 @@ class SynapticManager(object):
         # Add another bit of shift to prevent overflows
         if weights_signed:
             max_weight_powers = (m + 1 for m in max_weight_powers)
+        print("=" * 60)
+        print("RB left shifts for {:20}".format(application_vertex.label),
+              "=", list(max_weight_powers))
+        print("-" * 60)
         return list(max_weight_powers)
 
     @staticmethod


### PR DESCRIPTION
Use case: cerebellum model -- though it might affect other people without them realising
Context:
```
============================================================
Number of incoming connections per population:
------------------------------------------------------------
        basket     ->      37424 incoming synapses
        purkinje   ->     103906 incoming synapses
        granule    ->      88484 incoming synapses
        golgi      ->      68937 incoming synapses
        dcn        ->       1213 incoming synapses
        stellate   ->      37638 incoming synapses
        glomerulus ->       1002 incoming synapses
============================================================
Number of synapses per projection:
------------------------------------------------------------
        aa_pc      ->       2259 synapses [exc] with a weight of  0.000020 uS
        bc_pc      ->        179 synapses [inh] with a weight of -0.009000 uS
        pf_pc      ->     101289 synapses [exc] with a weight of  0.075000 uS
        sc_pc      ->        179 synapses [inh] with a weight of -0.008500 uS
```
Symptom (on master): weights for `pf_pc` are 0, while some other weights (not mentioned here are way off, although not 0).

Outcome (on PR):  `pf_pc      -> 0.00001526 uS c.f.  0.00002000 uS ( 76.29%)`
`pf_pc` weights are now representable and match more closely.
(Potential) downside: more weight saturations occur.

This PR needs more thought + removing of some debug print statements + probably reverting IF_COND_EXP default left shift back to 10 rather than 5.

This implementation was done with @rowleya next to me.
