### PR TITLE
LUTs now work at timestep != 1.0

### DIFF
--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_pfister_spike_triplet.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_pfister_spike_triplet.py
@@ -104,11 +104,6 @@ class TimingDependencePfisterSpikeTriplet(AbstractTimingDependence):
     @overrides(AbstractTimingDependence.write_parameters)
     def write_parameters(self, spec, machine_time_step, weight_scales):
 
-        # Check timestep is valid
-        if machine_time_step != 1000:
-            raise NotImplementedError(
-                "STDP LUT generation currently only supports 1ms timesteps")
-
         # Write lookup tables
         spec.write_array(self.__tau_plus_data)
         spec.write_array(self.__tau_minus_data)

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_spike_nearest_pair.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_spike_nearest_pair.py
@@ -86,11 +86,6 @@ class TimingDependenceSpikeNearestPair(AbstractTimingDependence):
     @overrides(AbstractTimingDependence.write_parameters)
     def write_parameters(self, spec, machine_time_step, weight_scales):
 
-        # Check timestep is valid
-        if machine_time_step != 1000:
-            raise NotImplementedError(
-                "STDP LUT generation currently only supports 1ms timesteps")
-
         # Write lookup tables
         spec.write_array(self.__tau_plus_data)
         spec.write_array(self.__tau_minus_data)


### PR DESCRIPTION
Seems as though these were missed during the STDP upgrade.