### PR TITLE
It's pronounced time_scale_factor, not timescale_factor

### DIFF
--- a/spynnaker/pyNN/models/pynn_projection_common.py
+++ b/spynnaker/pyNN/models/pynn_projection_common.py
@@ -227,7 +227,7 @@ class PyNNProjectionCommon(object):
     def _add_delay_extension(
             self, pre_synaptic_population, post_synaptic_population,
             max_delay_for_projection, max_delay_per_neuron, machine_time_step,
-            timescale_factor):
+            time_scale_factor):
         """ Instantiate delay extension component
         """
         # pylint: disable=too-many-arguments
@@ -239,7 +239,7 @@ class PyNNProjectionCommon(object):
             delay_name = "{}_delayed".format(pre_vertex.label)
             delay_vertex = DelayExtensionVertex(
                 pre_vertex.n_atoms, max_delay_per_neuron, pre_vertex,
-                machine_time_step, timescale_factor, label=delay_name)
+                machine_time_step, time_scale_factor, label=delay_name)
             pre_synaptic_population._internal_delay_vertex = delay_vertex
             pre_vertex.add_constraint(
                 SameAtomsAsVertexConstraint(delay_vertex))

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
@@ -68,20 +68,20 @@ class DelayExtensionVertex(
         "__n_atoms",
         "__n_delay_stages",
         "__source_vertex",
-        "__timescale_factor",
+        "__time_scale_factor",
         "__delay_generator_data",
         "__n_subvertices",
         "__n_data_specs"]
 
     def __init__(self, n_neurons, delay_per_stage, source_vertex,
-                 machine_time_step, timescale_factor, constraints=None,
+                 machine_time_step, time_scale_factor, constraints=None,
                  label="DelayExtension"):
         """
         :param n_neurons: the number of neurons
         :param delay_per_stage: the delay per stage
         :param source_vertex: where messages are coming from
         :param machine_time_step: how long is the machine time step
-        :param timescale_factor: what slowdown factor has been applied
+        :param time_scale_factor: what slowdown factor has been applied
         :param constraints: the vertex constraints
         :param label: the vertex label
         """
@@ -93,7 +93,7 @@ class DelayExtensionVertex(
         self.__delay_per_stage = delay_per_stage
         self.__delay_generator_data = defaultdict(list)
         self.__machine_time_step = machine_time_step
-        self.__timescale_factor = timescale_factor
+        self.__time_scale_factor = time_scale_factor
         self.__n_subvertices = 0
         self.__n_data_specs = 0
 
@@ -215,7 +215,7 @@ class DelayExtensionVertex(
         vertex.reserve_provenance_data_region(spec)
 
         self.write_setup_info(
-            spec, self.__machine_time_step, self.__timescale_factor)
+            spec, self.__machine_time_step, self.__time_scale_factor)
 
         spec.comment("\n*** Spec for Delay Extension Instance ***\n\n")
 
@@ -241,7 +241,7 @@ class DelayExtensionVertex(
         self.write_delay_parameters(
             spec, vertex_slice, key, incoming_key, incoming_mask,
             self.__n_subvertices, self.__machine_time_step,
-            self.__timescale_factor, n_outgoing_edges)
+            self.__time_scale_factor, n_outgoing_edges)
 
         key = (vertex_slice.lo_atom, vertex_slice.hi_atom)
         if key in self.__delay_generator_data:

--- a/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
+++ b/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
@@ -296,4 +296,4 @@ class SpynnakerExternalDevicePluginManager(object):
 
     @staticmethod
     def time_scale_factor():
-        return get_simulator().timescale_factor
+        return get_simulator().time_scale_factor


### PR DESCRIPTION
See https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/539

This is also about removing the other places where we “pronounce” it wrong…