### PR TITLE
Use math magic and numpy magic to compute LUTs efficiently

### DIFF
--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/common/plasticity_helpers.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/common/plasticity_helpers.py
@@ -22,46 +22,24 @@ logger = logging.getLogger(__name__)
 STDP_FIXED_POINT_ONE = (1 << 11)
 
 
-def float_to_fixed(value, fixed_point_one):
-    return int(round(float(value) * float(fixed_point_one)))
+def float_to_fixed(value):
+    return int(round(float(value) * STDP_FIXED_POINT_ONE))
 
 
-def get_exp_lut_values(
-        time_step, time_constant, shift=0,
-        fixed_point_one=STDP_FIXED_POINT_ONE, size=None):
-    # Calculate time constant reciprocal
-    time_constant_reciprocal = time_step / float(time_constant)
+def get_exp_lut_array(time_step, time_constant, shift=0):
+    # Compute the actual exponential decay parameter
+    # NB: lambda is a reserved word in Python
+    l_ambda = time_step / float(time_constant)
 
-    # Generate LUT
-    last_value = 1.0
-    index = 0
-    values = list()
-    while last_value > 0.0 and (size is None or len(values) < size):
+    # Compute the size of the array, which must be a multiple of 2
+    size = math.log(STDP_FIXED_POINT_ONE) / l_ambda
+    size, extra = divmod(size / (1 << shift), 2)
+    size = ((int(size) + (extra > 0)) * 2)
 
-        # Apply shift to get time from index
-        time = (index << shift)
-        index += 1
+    # Fill out the values in the array
+    a = numpy.exp((numpy.arange(size) << shift) * -l_ambda)
+    a = numpy.floor(a * STDP_FIXED_POINT_ONE)
 
-        # Multiply by time constant and calculate negative exponential
-        value = float(time) * time_constant_reciprocal
-        exp_float = math.exp(-value)
-
-        # Convert to fixed-point and write to spec
-        last_value = float_to_fixed(exp_float, fixed_point_one)
-        if last_value > 0.0:
-            values.append(last_value)
-    if size is not None and size > len(values):
-        values.extend([0] * (size - len(values)))
-    return values
-
-
-def get_exp_lut_array(
-        time_step, time_constant, shift=0,
-        fixed_point_one=STDP_FIXED_POINT_ONE, size=None):
-    values = get_exp_lut_values(
-        time_step, time_constant, shift, fixed_point_one, size)
-    values_size = len(values)
-    if len(values) % 2 != 0:
-        values.append(0)
-    return numpy.concatenate(
-        ([values_size, shift], values)).astype("uint16").view("uint32")
+    # Concatenate with the header
+    header = numpy.array([len(a), shift], dtype="uint16")
+    return numpy.concatenate((header, a.astype("uint16"))).view("uint32")

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_vogels_2011.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_vogels_2011.py
@@ -87,8 +87,7 @@ class TimingDependenceVogels2011(AbstractTimingDependence):
     def write_parameters(self, spec, machine_time_step, weight_scales):
 
         # Write alpha to spec
-        fixed_point_alpha = plasticity_helpers.float_to_fixed(
-            self.__alpha, plasticity_helpers.STDP_FIXED_POINT_ONE)
+        fixed_point_alpha = plasticity_helpers.float_to_fixed(self.__alpha)
         spec.write_value(data=fixed_point_alpha, data_type=DataType.INT32)
 
         # Write lookup table


### PR DESCRIPTION
Math magic computes the length of the array without a loop.
Numpy magic fills out the array rapidly.