### PR TITLE
More efficient division algorithm

### DIFF
--- a/neural_modelling/src/synapse_expander/common_kernel.c
+++ b/neural_modelling/src/synapse_expander/common_kernel.c
@@ -20,23 +20,18 @@
  *! \brief Common functions for kernel generation
  */
 #include "common_kernel.h"
+#include <stdlib.h>
 
 uint16_t uidiv(uint32_t dividend, uint16_t divider, uint16_t *remainder) {
-	uint32_t rem;
-
     if (dividend == 0 || dividend < divider) {
     	*remainder = (uint16_t) dividend;
         return 0;
     }
 
-    uint16_t d = 0;
-    rem = dividend;
-    while (rem >= divider) {
-        d++;
-        rem -= divider;
-    }
-    *remainder = (uint16_t) rem;
-    return d;
+    // Assumes that the dividend is less than 1<<31
+    div_t results = div((int) dividend, (int) (uint32_t) divider);
+    *remainder = (uint16_t) results.rem;
+    return (uint16_t) results.quot;
 }
 
 void post_in_pre_world(uint16_t in_row, uint16_t in_col,


### PR DESCRIPTION
Use the `div` function (from stdlib.h) because that won't degrade in performance horribly when the dividend is significantly larger than the divisor.