### PR TITLE
Deal with reset case with left over delayed spike

### DIFF
--- a/neural_modelling/src/neuron/c_main.c
+++ b/neural_modelling/src/neuron/c_main.c
@@ -282,7 +282,14 @@ void timer_callback(uint timer_count, uint unused) {
         }
         count_rewires++;
     }
-    // otherwise do synapse and neuron time step updates
+
+    // If the time has been reset to zero then the ring buffers need to be
+    // flushed in case there is a delayed spike left over from a previous run
+    if (time == 0) {
+    	synapses_flush_ring_buffers();
+    }
+
+    // Now do synapse and neuron time step updates
     synapses_do_timestep_update(time);
     neuron_do_timestep_update(time, timer_count, timer_period);
 

--- a/neural_modelling/src/neuron/c_main.c
+++ b/neural_modelling/src/neuron/c_main.c
@@ -221,6 +221,14 @@ void resume_callback(void) {
         log_error("failed to resume neuron.");
         rt_error(RTE_SWERR);
     }
+
+    // If the time has been reset to zero then the ring buffers need to be
+    // flushed in case there is a delayed spike left over from a previous run
+    // NOTE: at reset, time is set to UINT_MAX ahead of timer_callback(...)
+    if ((time+1) == 0) {
+    	synapses_flush_ring_buffers();
+    }
+
 }
 
 //! \brief Timer interrupt callback
@@ -281,12 +289,6 @@ void timer_callback(uint timer_count, uint unused) {
             spike_processing_do_rewiring(1);
         }
         count_rewires++;
-    }
-
-    // If the time has been reset to zero then the ring buffers need to be
-    // flushed in case there is a delayed spike left over from a previous run
-    if (time == 0) {
-    	synapses_flush_ring_buffers();
     }
 
     // Now do synapse and neuron time step updates

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -383,7 +383,7 @@ uint32_t synapses_get_pre_synaptic_events(void) {
             synapse_dynamics_get_plastic_pre_synaptic_events());
 }
 
-void synapses_flush_ring_buffers() {
+void synapses_flush_ring_buffers(void) {
     uint32_t n_neurons_power_2 = n_neurons;
     uint32_t log_n_neurons = 1;
     if (n_neurons != 1) {

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -41,6 +41,9 @@ static uint32_t n_synapse_types;
 // Ring buffers to handle delays between synapses and neurons
 static weight_t *ring_buffers;
 
+// Ring buffer size
+static uint32_t ring_buffer_size;
+
 // Amount to left shift the ring buffer by to make it an input
 static uint32_t *ring_buffer_to_input_left_shifts;
 
@@ -274,7 +277,7 @@ bool synapses_initialise(
 
     uint32_t n_ring_buffer_bits =
             log_n_neurons + log_n_synapse_types + SYNAPSE_DELAY_BITS;
-    uint32_t ring_buffer_size = 1 << (n_ring_buffer_bits);
+    ring_buffer_size = 1 << (n_ring_buffer_bits);
 
     ring_buffers = spin1_malloc(ring_buffer_size * sizeof(weight_t));
     if (ring_buffers == NULL) {
@@ -384,25 +387,6 @@ uint32_t synapses_get_pre_synaptic_events(void) {
 }
 
 void synapses_flush_ring_buffers(void) {
-    uint32_t n_neurons_power_2 = n_neurons;
-    uint32_t log_n_neurons = 1;
-    if (n_neurons != 1) {
-        if (!is_power_of_2(n_neurons)) {
-            n_neurons_power_2 = next_power_of_2(n_neurons);
-        }
-        log_n_neurons = ilog_2(n_neurons_power_2);
-    }
-
-    uint32_t n_synapse_types_power_2 = n_synapse_types;
-    if (!is_power_of_2(n_synapse_types)) {
-        n_synapse_types_power_2 = next_power_of_2(n_synapse_types);
-    }
-    uint32_t log_n_synapse_types = ilog_2(n_synapse_types_power_2);
-
-    uint32_t n_ring_buffer_bits =
-            log_n_neurons + log_n_synapse_types + SYNAPSE_DELAY_BITS;
-    uint32_t ring_buffer_size = 1 << (n_ring_buffer_bits);
-
 	for (uint32_t i = 0; i < ring_buffer_size; i++) {
         ring_buffers[i] = 0;
     }

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -382,3 +382,28 @@ uint32_t synapses_get_pre_synaptic_events(void) {
     return (num_fixed_pre_synaptic_events +
             synapse_dynamics_get_plastic_pre_synaptic_events());
 }
+
+void synapses_flush_ring_buffers() {
+    uint32_t n_neurons_power_2 = n_neurons;
+    uint32_t log_n_neurons = 1;
+    if (n_neurons != 1) {
+        if (!is_power_of_2(n_neurons)) {
+            n_neurons_power_2 = next_power_of_2(n_neurons);
+        }
+        log_n_neurons = ilog_2(n_neurons_power_2);
+    }
+
+    uint32_t n_synapse_types_power_2 = n_synapse_types;
+    if (!is_power_of_2(n_synapse_types)) {
+        n_synapse_types_power_2 = next_power_of_2(n_synapse_types);
+    }
+    uint32_t log_n_synapse_types = ilog_2(n_synapse_types_power_2);
+
+    uint32_t n_ring_buffer_bits =
+            log_n_neurons + log_n_synapse_types + SYNAPSE_DELAY_BITS;
+    uint32_t ring_buffer_size = 1 << (n_ring_buffer_bits);
+
+	for (uint32_t i = 0; i < ring_buffer_size; i++) {
+        ring_buffers[i] = 0;
+    }
+}

--- a/neural_modelling/src/neuron/synapses.h
+++ b/neural_modelling/src/neuron/synapses.h
@@ -93,4 +93,7 @@ uint32_t synapses_get_saturation_count(void);
 //! \return the counter for plastic and fixed pre synaptic events or 0
 uint32_t synapses_get_pre_synaptic_events(void);
 
+//! \brief flush the ring buffers
+void synapses_flush_ring_buffers(void);
+
 #endif // _SYNAPSES_H_

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -849,13 +849,7 @@ class AbstractPopulationVertex(
         self.__has_reset_last = True
         self.__change_requires_neuron_parameters_reload = True
 
-        # This is overkill in most cases, but in some instances it's necessary;
-        # for example, to prevent a delayed spike from a previous run being
-        # processed. (It's also not necessarily that easy to work out when
-        # there is a delayed spike left over, particularly if the delays come
-        # from a RandomDistribution).
-        self.__change_requires_data_generation = True
-
         # If synapses change during the run,
         if self.__synapse_manager.changes_during_run:
+            self.__change_requires_data_generation = True
             self.__change_requires_neuron_parameters_reload = False

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -849,7 +849,13 @@ class AbstractPopulationVertex(
         self.__has_reset_last = True
         self.__change_requires_neuron_parameters_reload = True
 
+        # This is overkill in most cases, but in some instances it's necessary;
+        # for example, to prevent a delayed spike from a previous run being
+        # processed. (It's also not necessarily that easy to work out when
+        # there is a delayed spike left over, particularly if the delays come
+        # from a RandomDistribution).
+        self.__change_requires_data_generation = True
+
         # If synapses change during the run,
         if self.__synapse_manager.changes_during_run:
-            self.__change_requires_data_generation = True
             self.__change_requires_neuron_parameters_reload = False


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/766

This is probably overkill, but the alternative is to ask the machine to report back that there are (delayed) spikes left over that have not yet been processed, and I'm not sure that's any better.