### PR TITLE
Update argument list for SmallWorldConnector to match PyNN better

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -77,7 +77,6 @@ class AbstractConnector(with_metaclass(AbstractBase, object)):
         self.__space = None
         self.__verbose = verbose
 
-        # something needs to be done about this?
         self._rng = rng
 
         self.__n_clipped_delays = 0

--- a/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
@@ -27,10 +27,11 @@ class SmallWorldConnector(AbstractConnector):
         "__rewiring"]
 
     def __init__(
-            self, degree, rewiring, allow_self_connections=True, safe=True,
-            callback=None, verbose=False, n_connections=None):
+            self, degree, rewiring, allow_self_connections=True,
+            n_connections=None, rng=None, safe=True, callback=None,
+            verbose=False):
         # pylint: disable=too-many-arguments
-        super(SmallWorldConnector, self).__init__(safe, callback, verbose)
+        super(SmallWorldConnector, self).__init__(safe, callback, verbose, rng)
         self.__rewiring = rewiring
         self.__degree = degree
         self.__allow_self_connections = allow_self_connections


### PR DESCRIPTION
Overnight failure of the small-world connector test (http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/sPyNNaker8_Cron_Job/detail/sPyNNaker8_Cron_Job/355/pipeline) made me go back and look at the actual connector and modify it to match PyNN (and so that rngs can actually be passed through...).