### PR TITLE
Add safety check to prevent underflow in _get_max_row_length

### DIFF
--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -512,7 +512,7 @@ class SynapseDynamicsSTDP(
 
         # Reduce until correct
         while (self.get_n_words_for_plastic_connections(n_connections) >
-                   n_words):
+               n_words):
             n_connections -= 1
 
         return n_connections

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -508,10 +508,12 @@ class SynapseDynamicsSTDP(
         n_connections = (n_words_space * BYTES_PER_WORD) // (
             bytes_per_pp + bytes_per_fp)
 
-        # Reduce until correct
-        while (self.get_n_words_for_plastic_connections(n_connections) >
-               n_words):
-            n_connections -= 1
+        # Reduce until correct, if padding (i.e. structural plasticity)
+        # is not present (otherwise this can underflow)
+        if self.__pad_to_length is None:
+            while (self.get_n_words_for_plastic_connections(n_connections) >
+                   n_words):
+                n_connections -= 1
 
         return n_connections
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -289,8 +289,6 @@ class SynapseDynamicsSTDP(
         :rtype: int
         """
         synapse_structure = self.__timing_dependence.synaptic_structure
-        if self.__pad_to_length is not None:
-            n_connections = max(n_connections, self.__pad_to_length)
         if n_connections == 0:
             return 0
         # 2 == two half words per word
@@ -508,12 +506,14 @@ class SynapseDynamicsSTDP(
         n_connections = (n_words_space * BYTES_PER_WORD) // (
             bytes_per_pp + bytes_per_fp)
 
-        # Reduce until correct, if padding (i.e. structural plasticity)
-        # is not present (otherwise this can underflow)
-        if self.__pad_to_length is None:
-            while (self.get_n_words_for_plastic_connections(n_connections) >
+        # Calculate n_connections if padding
+        if self.__pad_to_length is not None:
+            n_connections = max(n_connections, self.__pad_to_length)
+
+        # Reduce until correct
+        while (self.get_n_words_for_plastic_connections(n_connections) >
                    n_words):
-                n_connections -= 1
+            n_connections -= 1
 
         return n_connections
 

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -213,12 +213,16 @@ class SynapseIORowBased(object):
                 max_delayed_n_synapses)
 
         # Adjust for the allowed row lengths from the population table
-        undelayed_max_n_words = self._get_max_row_length(
-            undelayed_n_words, dynamics, population_table, in_edge,
-            max_undelayed_n_synapses)
-        delayed_max_n_words = self._get_max_row_length(
-            delayed_n_words, dynamics, population_table, in_edge,
-            max_delayed_n_synapses)
+        undelayed_max_n_words = 0
+        if undelayed_n_words > 0:
+            undelayed_max_n_words = self._get_max_row_length(
+                ndelayed_n_words, dynamics, population_table, in_edge,
+                max_undelayed_n_synapses)
+        delayed_max_n_words = 0
+        if delayed_n_words > 0:
+            delayed_max_n_words = self._get_max_row_length(
+                delayed_n_words, dynamics, population_table, in_edge,
+                max_delayed_n_synapses)
 
         undelayed_max_bytes = 0
         if undelayed_max_n_words > 0:

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -216,7 +216,7 @@ class SynapseIORowBased(object):
         undelayed_max_n_words = 0
         if undelayed_n_words > 0:
             undelayed_max_n_words = self._get_max_row_length(
-                ndelayed_n_words, dynamics, population_table, in_edge,
+                undelayed_n_words, dynamics, population_table, in_edge,
                 max_undelayed_n_synapses)
         delayed_max_n_words = 0
         if delayed_n_words > 0:

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -213,16 +213,12 @@ class SynapseIORowBased(object):
                 max_delayed_n_synapses)
 
         # Adjust for the allowed row lengths from the population table
-        undelayed_max_n_words = 0
-        if undelayed_n_words > 0:
-            undelayed_max_n_words = self._get_max_row_length(
-                undelayed_n_words, dynamics, population_table, in_edge,
-                max_undelayed_n_synapses)
-        delayed_max_n_words = 0
-        if delayed_n_words > 0:
-            delayed_max_n_words = self._get_max_row_length(
-                delayed_n_words, dynamics, population_table, in_edge,
-                max_delayed_n_synapses)
+        undelayed_max_n_words = self._get_max_row_length(
+            undelayed_n_words, dynamics, population_table, in_edge,
+            max_undelayed_n_synapses)
+        delayed_max_n_words = self._get_max_row_length(
+            delayed_n_words, dynamics, population_table, in_edge,
+            max_delayed_n_synapses)
 
         undelayed_max_bytes = 0
         if undelayed_max_n_words > 0:

--- a/unittests/model_tests/neuron/test_get_max_synapses.py
+++ b/unittests/model_tests/neuron/test_get_max_synapses.py
@@ -1,0 +1,16 @@
+from spynnaker.pyNN.models.neuron.synapse_dynamics import SynapseDynamicsSTDP
+from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence import (
+    TimingDependenceSpikePair)
+from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence import (
+    WeightDependenceAdditive)
+from unittests.mocks import MockSimulator
+import pytest
+
+
+@pytest.mark.timeout(1)
+def test_get_max_synapses():
+    MockSimulator.setup()
+    d = SynapseDynamicsSTDP(timing_dependence=TimingDependenceSpikePair(),
+                            weight_dependence=WeightDependenceAdditive(),
+                            pad_to_length=258)
+    assert d.get_max_synapses(256) <= 256

--- a/unittests/model_tests/neuron/test_get_max_synapses.py
+++ b/unittests/model_tests/neuron/test_get_max_synapses.py
@@ -1,10 +1,25 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
 from spynnaker.pyNN.models.neuron.synapse_dynamics import SynapseDynamicsSTDP
 from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence import (
     TimingDependenceSpikePair)
 from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence import (
     WeightDependenceAdditive)
 from unittests.mocks import MockSimulator
-import pytest
 
 
 @pytest.mark.timeout(1)


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/759

@pabogdan does this help with what you were seeing?  (If not can you create a minimal example that fails?)