### PR TITLE
Poisson distribution doesn't have a mu parameter...

### DIFF
--- a/spynnaker/pyNN/utilities/random_stats/random_stats_poisson_impl.py
+++ b/spynnaker/pyNN/utilities/random_stats/random_stats_poisson_impl.py
@@ -22,7 +22,7 @@ class RandomStatsPoissonImpl(AbstractRandomStats):
     """
 
     def _get_params(self, dist):
-        return [dist.parameters['mu'], dist.parameters['lambda_']]
+        return [dist.parameters['lambda_']]
 
     def cdf(self, dist, v):
         return poisson.cdf(v, *self._get_params(dist))


### PR DESCRIPTION
More RandomDistribution stuff - this time, a poisson doesn't have a "mu" parameter...

Merge with https://github.com/SpiNNakerManchester/DataSpecification/pull/84