### PR TITLE
Fix pause-and-resume for eprop neuron model

### DIFF
--- a/neural_modelling/src/neuron/implementations/neuron_impl_eprop_adaptive.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_eprop_adaptive.h
@@ -72,6 +72,9 @@ global_neuron_params_pointer_t global_parameters;
 // The synapse shaping parameters
 static synapse_param_t *neuron_synapse_shaping_params;
 
+// Bool to regularise on the first run
+static bool initial_regularise = true;
+
 static bool neuron_impl_initialise(uint32_t n_neurons) {
     // allocate DTCM for the global parameter details
     if (sizeof(global_neuron_params_t)) {
@@ -204,14 +207,19 @@ static void neuron_impl_load_neuron_parameters(
     // **********************************************
     // ******** for eprop regularisation ************
     // **********************************************
-    global_parameters->core_target_rate = global_parameters->core_target_rate
-    		* n_neurons; // scales target rate depending on number of neurons
-    global_parameters->core_pop_rate = global_parameters->core_pop_rate
-    		* n_neurons; // scale initial value, too
+    if (initial_regularise) {
+    	global_parameters->core_target_rate = global_parameters->core_target_rate
+    			* n_neurons; // scales target rate depending on number of neurons
+    	global_parameters->core_pop_rate = global_parameters->core_pop_rate
+    			* n_neurons; // scale initial value, too
 
+    	initial_regularise = false;
+    }
 
     for (index_t n = 0; n < n_neurons; n++) {
         neuron_model_print_parameters(&neuron_array[n]);
+        log_debug("Neuron id %u", n);
+        neuron_model_print_state_variables(&neuron_array[n]);
     }
 
 #if LOG_LEVEL >= LOG_DEBUG
@@ -403,6 +411,14 @@ static void neuron_impl_store_neuron_parameters(
         next += n_words_needed(n_neurons * sizeof(neuron_t));
     }
 
+    log_info("****** STORING ******");
+    for (index_t n = 0; n < n_neurons; n++) {
+        neuron_model_print_parameters(&neuron_array[n]);
+        log_debug("Neuron id %u", n);
+        neuron_model_print_state_variables(&neuron_array[n]);
+    }
+    log_info("****** STORING COMPLETE ******");
+
     if (sizeof(input_type_t)) {
         log_debug("writing input type parameters");
         spin1_memcpy(&address[next], input_type_array,
@@ -430,6 +446,9 @@ static void neuron_impl_store_neuron_parameters(
                 n_neurons * sizeof(additional_input_t));
         next += n_words_needed(n_neurons * sizeof(additional_input_t));
     }
+
+    log_info("global_parameters, core_target_rate, core_pop_rate %k %k",
+    		global_parameters->core_target_rate, global_parameters->core_pop_rate);
 }
 
 #if LOG_LEVEL >= LOG_DEBUG

--- a/neural_modelling/src/neuron/implementations/neuron_impl_eprop_adaptive.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_eprop_adaptive.h
@@ -411,13 +411,13 @@ static void neuron_impl_store_neuron_parameters(
         next += n_words_needed(n_neurons * sizeof(neuron_t));
     }
 
-    log_info("****** STORING ******");
+    log_debug("****** STORING ******");
     for (index_t n = 0; n < n_neurons; n++) {
         neuron_model_print_parameters(&neuron_array[n]);
         log_debug("Neuron id %u", n);
         neuron_model_print_state_variables(&neuron_array[n]);
     }
-    log_info("****** STORING COMPLETE ******");
+    log_debug("****** STORING COMPLETE ******");
 
     if (sizeof(input_type_t)) {
         log_debug("writing input type parameters");
@@ -447,7 +447,7 @@ static void neuron_impl_store_neuron_parameters(
         next += n_words_needed(n_neurons * sizeof(additional_input_t));
     }
 
-    log_info("global_parameters, core_target_rate, core_pop_rate %k %k",
+    log_debug("global_parameters, core_target_rate, core_pop_rate %k %k",
     		global_parameters->core_target_rate, global_parameters->core_pop_rate);
 }
 

--- a/neural_modelling/src/neuron/models/neuron_model_eprop_adaptive_impl.c
+++ b/neural_modelling/src/neuron/models/neuron_model_eprop_adaptive_impl.c
@@ -89,7 +89,10 @@ state_t neuron_model_state_update(
 //			0.3k *
 			(1.0k - psi_temp2) : 0.0k;
 
-    uint32_t total_synapses_per_neuron = 100; // This parameter is OK to update, as the actual size of the array is set in the header file, which matches the Python code. This should make it possible to do a pause and resume cycle and have reliable unloading of data.
+    // This parameter is OK to update, as the actual size of the array is set in the
+    // header file, which matches the Python code. This should make it possible to do
+    // a pause and resume cycle and have reliable unloading of data.
+    uint32_t total_synapses_per_neuron = 100;
 
 
 //    neuron->psi = neuron->psi << 10;
@@ -133,8 +136,8 @@ state_t neuron_model_state_update(
 		// Update cached total weight change
 		// ******************************************************************
     	REAL this_dt_weight_change =
-    			-local_eta * neuron->L * neuron->syn_state[syn_ind].e_bar;
-    	neuron->syn_state[syn_ind].delta_w += this_dt_weight_change;
+    			local_eta * neuron->L * neuron->syn_state[syn_ind].e_bar;
+    	neuron->syn_state[syn_ind].delta_w -= this_dt_weight_change;
 
 //    	if (!syn_ind || neuron->syn_state[syn_ind].z_bar){// || neuron->syn_state[syn_ind].z_bar_inp){
 //            io_printf(IO_BUF, "total synapses = %u \t syn_ind = %u \t "
@@ -177,6 +180,15 @@ state_t neuron_model_get_membrane_voltage(neuron_pointer_t neuron) {
 
 void neuron_model_print_state_variables(restrict neuron_pointer_t neuron) {
     log_debug("V membrane    = %11.4k mv", neuron->V_membrane);
+    log_debug("learning      = %k ", neuron->L);
+
+    log_debug("Printing synapse state values:");
+    for (uint32_t syn_ind=0; syn_ind < 100; syn_ind++){
+    	log_debug("synapse number %u delta_w, z_bar, z_bar_inp, e_bar, el_a %11.4k %11.4k %11.4k %11.4k %11.4k",
+    			syn_ind, neuron->syn_state[syn_ind].delta_w,
+				neuron->syn_state[syn_ind].z_bar, neuron->syn_state[syn_ind].z_bar_inp,
+				neuron->syn_state[syn_ind].e_bar, neuron->syn_state[syn_ind].el_a);
+    }
 }
 
 void neuron_model_print_parameters(restrict neuron_pointer_t neuron) {

--- a/neural_modelling/src/neuron/models/neuron_model_eprop_adaptive_impl.c
+++ b/neural_modelling/src/neuron/models/neuron_model_eprop_adaptive_impl.c
@@ -90,8 +90,9 @@ state_t neuron_model_state_update(
 			(1.0k - psi_temp2) : 0.0k;
 
     // This parameter is OK to update, as the actual size of the array is set in the
-    // header file, which matches the Python code. This should make it possible to do
-    // a pause and resume cycle and have reliable unloading of data.
+    // header file, which matches the Python code and aligns memory alocations.
+    // The value here can be reduced to limit the number of synapse state updates
+    // required by the neuron
     uint32_t total_synapses_per_neuron = 100;
 
 

--- a/neural_modelling/src/neuron/models/neuron_model_eprop_adaptive_impl.c
+++ b/neural_modelling/src/neuron/models/neuron_model_eprop_adaptive_impl.c
@@ -137,7 +137,7 @@ state_t neuron_model_state_update(
 		// ******************************************************************
     	REAL this_dt_weight_change =
     			local_eta * neuron->L * neuron->syn_state[syn_ind].e_bar;
-    	neuron->syn_state[syn_ind].delta_w -= this_dt_weight_change;
+    	neuron->syn_state[syn_ind].delta_w -= this_dt_weight_change; // -= here to enable compiler to handle previous line (can crash when -ve is at beginning of previous line)
 
 //    	if (!syn_ind || neuron->syn_state[syn_ind].z_bar){// || neuron->syn_state[syn_ind].z_bar_inp){
 //            io_printf(IO_BUF, "total synapses = %u \t syn_ind = %u \t "


### PR DESCRIPTION
Fix pause-and-resume for eprop neuron; basically, the issue was that the global parameters were being regularised again on the second run after pausing.  It's possibly a bit confusing, but the current state of pause-and-resume (binary gets paused, and then starts again from the beginning of c_main()) means that initialise() gets called again at the start of the second run, so anything that should only happen on the first run needs to be guarded against the second time round.