### PR TITLE
Multi time step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
   - python support/travis_blocking_stdout.py
   - support/rat.sh download
-  # Bring pip up to date 
+  # Bring pip up to date
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
   # SpiNNakerManchester internal dependencies; development mode
@@ -59,7 +59,7 @@ before_install:
 
 install:
   - pip install -r requirements-test.txt
-  - pip install pylint python-coveralls 'coverage>=4.4,<5.0'
+  - pip install 'pylint<2.5' python-coveralls 'coverage>=4.4,<5.0'
   - python ./setup.py install
 
 before_script:
@@ -83,7 +83,7 @@ script:
   - ( pylint --output-format=colorized --disable=R,C spynnaker; exit $(($? & 35)) )
   # XML
   - find spynnaker -name '*.xml' | xargs -n 1 support/validate-xml.sh
-  # C 
+  # C
   - CFLAGS=-fdiagnostics-color make -C neural_modelling
   - support/run-vera.sh neural_modelling/src
   # Copyright check

--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -162,6 +162,7 @@ static void neuron_impl_load_neuron_parameters(
 
     // Read the number of steps per timestep
     n_steps_per_timestep = address[next];
+    log_info("Looping over %u steps each timestep", n_steps_per_timestep);
     next += 1;
 
     if (sizeof(global_neuron_params_t)) {
@@ -270,6 +271,7 @@ static bool neuron_impl_do_timestep_update(index_t neuron_index,
         neuron_recording_record_accum(GSYN_INH_RECORDING_INDEX, neuron_index, total_inh);
 
         // Call functions to convert exc_input and inh_input to current
+        voltage = neuron_model_get_membrane_voltage(neuron);
         input_type_convert_excitatory_input_to_current(
                 exc_input_values, input_type, voltage);
         input_type_convert_inhibitory_input_to_current(

--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -324,11 +324,9 @@ __attribute__((unused)) // Marked unused as only used sometimes
 static void neuron_impl_store_neuron_parameters(
         address_t address, uint32_t next, uint32_t n_neurons) {
     log_debug("writing parameters");
-    //if (global_parameters == NULL) {
-    //   log_error("global parameter storage not allocated");
-    //   rt_error(RTE_SWERR);
-    //   return;
-    //}
+
+    // Skip over the steps per timestep
+    next += 1;
 
     if (sizeof(global_neuron_params_t)) {
         log_debug("writing neuron global parameters");

--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -238,7 +238,8 @@ static bool neuron_impl_do_timestep_update(index_t neuron_index,
     // Store whether the neuron has spiked
     bool spike = false;
 
-    // Loop however many times requested
+    // Loop however many times requested; do this in reverse for efficiency,
+    // and because the index doesn't actually matter
     for (uint32_t i = n_steps_per_timestep; i > 0; i--) {
 
         // Get the voltage

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
@@ -99,11 +99,13 @@ class ExternalDeviceLifControl(AbstractPyNNNeuronModelStandard):
     @overrides(AbstractPyNNNeuronModelStandard.create_vertex)
     def create_vertex(
             self, n_neurons, label, constraints, spikes_per_second,
-            ring_buffer_sigma, incoming_spike_buffer_size):
+            ring_buffer_sigma, incoming_spike_buffer_size,
+            n_steps_per_timestep):
         if n_neurons != len(self._devices):
             raise ConfigurationException(
                 "Number of neurons does not match number of devices in {}"
                 .format(label))
+        self._model.n_steps_per_timestep = n_steps_per_timestep
         max_atoms = self.get_max_atoms_per_core()
         return ExternalDeviceLifControlVertex(
             self._devices, self._create_edges, max_atoms, self._model, self,

--- a/spynnaker/pyNN/external_devices_models/threshold_type_multicast_device_control.py
+++ b/spynnaker/pyNN/external_devices_models/threshold_type_multicast_device_control.py
@@ -64,7 +64,7 @@ class ThresholdTypeMulticastDeviceControl(AbstractThresholdType):
         return variable in UNITS
 
     @overrides(AbstractThresholdType.get_values)
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
 
         # Add the rest of the data
         return [parameters[DEVICE].apply_operation(

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
@@ -17,7 +17,8 @@ from .abstract_pynn_neuron_model import AbstractPyNNNeuronModel
 from spynnaker.pyNN.models.neuron.implementations import NeuronImplStandard
 from spinn_utilities.overrides import overrides
 
-_population_parameters = AbstractPyNNNeuronModel.default_population_parameters
+_population_parameters = dict(
+    AbstractPyNNNeuronModel.default_population_parameters)
 _population_parameters["n_steps_per_timestep"] = 1
 
 

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
@@ -15,6 +15,10 @@
 
 from .abstract_pynn_neuron_model import AbstractPyNNNeuronModel
 from spynnaker.pyNN.models.neuron.implementations import NeuronImplStandard
+from spinn_utilities.overrides import overrides
+
+_population_parameters = AbstractPyNNNeuronModel.default_population_parameters
+_population_parameters["n_steps_per_timestep"] = 1
 
 
 class AbstractPyNNNeuronModelStandard(AbstractPyNNNeuronModel):
@@ -23,6 +27,8 @@ class AbstractPyNNNeuronModelStandard(AbstractPyNNNeuronModel):
     """
 
     __slots__ = []
+
+    default_population_parameters = _population_parameters
 
     def __init__(
             self, model_name, binary, neuron_model, input_type,
@@ -43,3 +49,15 @@ class AbstractPyNNNeuronModelStandard(AbstractPyNNNeuronModel):
         AbstractPyNNNeuronModel.__init__(self, NeuronImplStandard(
             model_name, binary, neuron_model, input_type, synapse_type,
             threshold_type, additional_input_type))
+
+    @overrides(AbstractPyNNNeuronModel.create_vertex,
+               additional_arguments={"n_steps_per_timestep"})
+    def create_vertex(
+            self, n_neurons, label, constraints, spikes_per_second,
+            ring_buffer_sigma, incoming_spike_buffer_size,
+            n_steps_per_timestep):
+        # pylint: disable=arguments-differ
+        self._model.n_steps_per_timestep = n_steps_per_timestep
+        return super(AbstractPyNNNeuronModelStandard, self).create_vertex(
+            n_neurons, label, constraints, spikes_per_second,
+            ring_buffer_sigma, incoming_spike_buffer_size)

--- a/spynnaker/pyNN/models/neuron/additional_inputs/additional_input_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/additional_inputs/additional_input_ca2_adaptive.py
@@ -16,7 +16,6 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_additional_input import AbstractAdditionalInput
 
 I_ALPHA = "i_alpha"
@@ -72,8 +71,7 @@ class AdditionalInputCa2Adaptive(AbstractAdditionalInput):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractAdditionalInput.get_values, additional_arguments={'ts'})
+    @overrides(AbstractAdditionalInput.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         """
         :param int ts: machine time step

--- a/spynnaker/pyNN/models/neuron/implementations/abstract_standard_neuron_component.py
+++ b/spynnaker/pyNN/models/neuron/implementations/abstract_standard_neuron_component.py
@@ -86,7 +86,7 @@ class AbstractStandardNeuronComponent(with_metaclass(AbstractBase, object)):
         """
 
     @abstractmethod
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
         """ Get the values to be written to the machine for this model
 
         :param ~spinn_utilities.ranged.RangeDictionary parameters:
@@ -95,12 +95,14 @@ class AbstractStandardNeuronComponent(with_metaclass(AbstractBase, object)):
             The holder of the state variables
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of variables being retrieved
+        :param float ts:
+            The time to be advanced in one call to the update of this component
         :return: A list with the same length as self.struct.field_types
         :rtype: list(int or float or list(int) or list(float) or
             ~spinn_utilities.ranged.RangedList)
         """
 
-    def get_data(self, parameters, state_variables, vertex_slice):
+    def get_data(self, parameters, state_variables, vertex_slice, ts):
         """ Get the data *to be written to the machine* for this model.
 
         :param ~spinn_utilities.ranged.RangeDictionary parameters:
@@ -111,7 +113,7 @@ class AbstractStandardNeuronComponent(with_metaclass(AbstractBase, object)):
             The slice of the vertex to generate parameters for
         :rtype: ~numpy.ndarray(~numpy.uint32)
         """
-        values = self.get_values(parameters, state_variables, vertex_slice)
+        values = self.get_values(parameters, state_variables, vertex_slice, ts)
         return self.struct.get_data(
             values, vertex_slice.lo_atom, vertex_slice.n_atoms)
 

--- a/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
+++ b/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
@@ -19,6 +19,14 @@ from data_specification.enums import DataType
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.models.neuron.input_types import InputTypeConductance
 from .abstract_neuron_impl import AbstractNeuronImpl
+from spinn_front_end_common.utilities import globals_variables
+from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
+
+# The base size of the data
+_BASE_SIZE = 1 * BYTES_PER_WORD
+
+# The default number of steps per timestep
+_DEFAULT_N_STEPS_PER_TIMESTEP = 1
 
 
 class NeuronImplStandard(AbstractNeuronImpl):
@@ -33,7 +41,8 @@ class NeuronImplStandard(AbstractNeuronImpl):
         "__synapse_type",
         "__threshold_type",
         "__additional_input_type",
-        "__components"
+        "__components",
+        "__n_steps_per_timestep"
     ]
 
     _RECORDABLES = ["v", "gsyn_exc", "gsyn_inh"]
@@ -69,12 +78,21 @@ class NeuronImplStandard(AbstractNeuronImpl):
         self.__synapse_type = synapse_type
         self.__threshold_type = threshold_type
         self.__additional_input_type = additional_input_type
+        self.__n_steps_per_timestep = _DEFAULT_N_STEPS_PER_TIMESTEP
 
         self.__components = [
             self.__neuron_model, self.__input_type, self.__threshold_type,
             self.__synapse_type]
         if self.__additional_input_type is not None:
             self.__components.append(self.__additional_input_type)
+
+    @property
+    def n_steps_per_timestep(self):
+        return self.__n_steps_per_timestep
+
+    @n_steps_per_timestep.setter
+    def n_steps_per_timestep(self, n_steps_per_timestep):
+        self.__n_steps_per_timestep = n_steps_per_timestep
 
     @property
     @overrides(AbstractNeuronImpl.model_name)
@@ -98,7 +116,8 @@ class NeuronImplStandard(AbstractNeuronImpl):
 
     @overrides(AbstractNeuronImpl.get_dtcm_usage_in_bytes)
     def get_dtcm_usage_in_bytes(self, n_neurons):
-        total = self.__neuron_model.get_dtcm_usage_in_bytes(n_neurons)
+        total = _BASE_SIZE
+        total += self.__neuron_model.get_dtcm_usage_in_bytes(n_neurons)
         total += self.__synapse_type.get_dtcm_usage_in_bytes(n_neurons)
         total += self.__input_type.get_dtcm_usage_in_bytes(n_neurons)
         total += self.__threshold_type.get_dtcm_usage_in_bytes(n_neurons)
@@ -109,7 +128,8 @@ class NeuronImplStandard(AbstractNeuronImpl):
 
     @overrides(AbstractNeuronImpl.get_sdram_usage_in_bytes)
     def get_sdram_usage_in_bytes(self, n_neurons):
-        total = self.__neuron_model.get_sdram_usage_in_bytes(n_neurons)
+        total = _BASE_SIZE
+        total += self.__neuron_model.get_sdram_usage_in_bytes(n_neurons)
         total += self.__synapse_type.get_sdram_usage_in_bytes(n_neurons)
         total += self.__input_type.get_sdram_usage_in_bytes(n_neurons)
         total += self.__threshold_type.get_sdram_usage_in_bytes(n_neurons)
@@ -166,10 +186,14 @@ class NeuronImplStandard(AbstractNeuronImpl):
 
     @overrides(AbstractNeuronImpl.get_data)
     def get_data(self, parameters, state_variables, vertex_slice):
-        return numpy.concatenate([
-            component.get_data(parameters, state_variables, vertex_slice)
-            for component in self.__components
-        ])
+        # Work out the time step per step
+        ts = globals_variables.get_simulator().machine_time_step
+        ts /= self.__n_steps_per_timestep
+        items = [numpy.array([self.__n_steps_per_timestep], dtype="uint32")]
+        items.extend(
+            component.get_data(parameters, state_variables, vertex_slice, ts)
+            for component in self.__components)
+        return numpy.concatenate(items)
 
     @overrides(AbstractNeuronImpl.read_data)
     def read_data(

--- a/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
+++ b/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
@@ -198,6 +198,7 @@ class NeuronImplStandard(AbstractNeuronImpl):
     @overrides(AbstractNeuronImpl.read_data)
     def read_data(
             self, data, offset, vertex_slice, parameters, state_variables):
+        offset += _BASE_SIZE
         for component in self.__components:
             offset = component.read_data(
                 data, offset, vertex_slice, parameters, state_variables)

--- a/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
+++ b/spynnaker/pyNN/models/neuron/implementations/neuron_impl_standard.py
@@ -22,8 +22,8 @@ from .abstract_neuron_impl import AbstractNeuronImpl
 from spinn_front_end_common.utilities import globals_variables
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 
-# The base size of the data
-_BASE_SIZE = 1 * BYTES_PER_WORD
+# The size of the n_steps_per_timestep parameter
+_N_STEPS_PER_TIMESTEP_SIZE = 1 * BYTES_PER_WORD
 
 # The default number of steps per timestep
 _DEFAULT_N_STEPS_PER_TIMESTEP = 1
@@ -116,7 +116,7 @@ class NeuronImplStandard(AbstractNeuronImpl):
 
     @overrides(AbstractNeuronImpl.get_dtcm_usage_in_bytes)
     def get_dtcm_usage_in_bytes(self, n_neurons):
-        total = _BASE_SIZE
+        total = _N_STEPS_PER_TIMESTEP_SIZE
         total += self.__neuron_model.get_dtcm_usage_in_bytes(n_neurons)
         total += self.__synapse_type.get_dtcm_usage_in_bytes(n_neurons)
         total += self.__input_type.get_dtcm_usage_in_bytes(n_neurons)
@@ -128,7 +128,7 @@ class NeuronImplStandard(AbstractNeuronImpl):
 
     @overrides(AbstractNeuronImpl.get_sdram_usage_in_bytes)
     def get_sdram_usage_in_bytes(self, n_neurons):
-        total = _BASE_SIZE
+        total = _N_STEPS_PER_TIMESTEP_SIZE
         total += self.__neuron_model.get_sdram_usage_in_bytes(n_neurons)
         total += self.__synapse_type.get_sdram_usage_in_bytes(n_neurons)
         total += self.__input_type.get_sdram_usage_in_bytes(n_neurons)
@@ -198,7 +198,7 @@ class NeuronImplStandard(AbstractNeuronImpl):
     @overrides(AbstractNeuronImpl.read_data)
     def read_data(
             self, data, offset, vertex_slice, parameters, state_variables):
-        offset += _BASE_SIZE
+        offset += _N_STEPS_PER_TIMESTEP_SIZE
         for component in self.__components:
             offset = component.read_data(
                 data, offset, vertex_slice, parameters, state_variables)

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_conductance.py
@@ -69,7 +69,7 @@ class InputTypeConductance(AbstractInputType):
         return variable in UNITS
 
     @overrides(AbstractInputType.get_values)
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
 
         # Add the rest of the data
         return [parameters[E_REV_E], parameters[E_REV_I]]

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_current.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_current.py
@@ -38,7 +38,7 @@ class InputTypeCurrent(AbstractInputType):
         pass
 
     @overrides(AbstractInputType.get_values)
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
         return []
 
     @overrides(AbstractInputType.update_values)

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_current_semd.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_current_semd.py
@@ -66,7 +66,7 @@ class InputTypeCurrentSEMD(AbstractInputType):
         return variable in UNITS
 
     @overrides(AbstractInputType.get_values)
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
 
         # Add the rest of the data
         return [parameters[MULTIPLICATOR], state_variables[INH_INPUT_PREVIOUS]]

--- a/spynnaker/pyNN/models/neuron/input_types/input_type_delta.py
+++ b/spynnaker/pyNN/models/neuron/input_types/input_type_delta.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from spinn_utilities.overrides import overrides
-from pacman.executor.injection_decorator import inject_items
 from data_specification.enums import DataType
 from .abstract_input_type import AbstractInputType
 
@@ -40,8 +39,7 @@ class InputTypeDelta(AbstractInputType):
     def add_state_variables(self, state_variables):
         pass
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractInputType.get_values, additional_arguments={'ts'})
+    @overrides(AbstractInputType.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         # pylint: disable=arguments-differ
         scale_factor = 1000.0 / float(ts)

--- a/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/abstract_neuron_model.py
@@ -69,19 +69,20 @@ class AbstractNeuronModel(
         return usage + (self.__global_struct.get_size_in_whole_words() *
                         BYTES_PER_WORD)
 
-    def get_global_values(self):
+    def get_global_values(self, ts):
         """ Get the global values to be written to the machine for this model
 
+        :param float ts: The time to advance the model at each call
         :return: A list with the same length as self.global_struct.field_types
         :rtype: list(int or float) or ~numpy.ndarray
         """
         return numpy.zeros(0, dtype="uint32")
 
     @overrides(AbstractStandardNeuronComponent.get_data)
-    def get_data(self, parameters, state_variables, vertex_slice):
+    def get_data(self, parameters, state_variables, vertex_slice, ts):
         super_data = super(AbstractNeuronModel, self).get_data(
-            parameters, state_variables, vertex_slice)
-        values = self.get_global_values()
+            parameters, state_variables, vertex_slice, ts)
+        values = self.get_global_values(ts)
         global_data = self.__global_struct.get_data(values)
         return numpy.concatenate([global_data, super_data])
 

--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_izh.py
@@ -16,7 +16,6 @@ from spinn_front_end_common.utilities.constants import \
     MICRO_TO_MILLISECOND_CONVERSION
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_neuron_model import AbstractNeuronModel
 
 A = 'a'
@@ -88,15 +87,12 @@ class NeuronModelIzh(AbstractNeuronModel):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"machine_time_step": "MachineTimeStep"})
-    @overrides(AbstractNeuronModel.get_global_values,
-               additional_arguments={'machine_time_step'})
-    def get_global_values(self, machine_time_step):
+    @overrides(AbstractNeuronModel.get_global_values)
+    def get_global_values(self, ts):
         # pylint: disable=arguments-differ
-        return [float(machine_time_step) / MICRO_TO_MILLISECOND_CONVERSION]
+        return [float(ts) / MICRO_TO_MILLISECOND_CONVERSION]
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractNeuronModel.get_values, additional_arguments={'ts'})
+    @overrides(AbstractNeuronModel.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         # pylint: disable=arguments-differ
 

--- a/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate_and_fire.py
+++ b/spynnaker/pyNN/models/neuron/neuron_models/neuron_model_leaky_integrate_and_fire.py
@@ -16,7 +16,6 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_neuron_model import AbstractNeuronModel
 
 V = "v"
@@ -98,8 +97,7 @@ class NeuronModelLeakyIntegrateAndFire(AbstractNeuronModel):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractNeuronModel.get_values, additional_arguments={'ts'})
+    @overrides(AbstractNeuronModel.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         # pylint: disable=arguments-differ
 

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
@@ -16,7 +16,6 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
 
 EXC_RESPONSE = "exc_response"
@@ -107,8 +106,7 @@ class SynapseTypeAlpha(AbstractSynapseType):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractSynapseType.get_values, additional_arguments={'ts'})
+    @overrides(AbstractSynapseType.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         """
         :param int ts: machine time step

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_delta.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_delta.py
@@ -66,7 +66,7 @@ class SynapseTypeDelta(AbstractSynapseType):
         return variable in UNITS
 
     @overrides(AbstractSynapseType.get_values)
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
 
         # Add the rest of the data
         return [state_variables[ISYN_EXC], state_variables[ISYN_INH]]

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_dual_exponential.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_dual_exponential.py
@@ -16,7 +16,6 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
 
 TAU_SYN_E = 'tau_syn_E'
@@ -97,8 +96,7 @@ class SynapseTypeDualExponential(AbstractSynapseType):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractSynapseType.get_values, additional_arguments={'ts'})
+    @overrides(AbstractSynapseType.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         """
         :param int ts: machine time step

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_exponential.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_exponential.py
@@ -16,7 +16,6 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
 
 TAU_SYN_E = 'tau_syn_E'
@@ -80,8 +79,7 @@ class SynapseTypeExponential(AbstractSynapseType):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractSynapseType.get_values, additional_arguments={'ts'})
+    @overrides(AbstractSynapseType.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         """
         :param int ts: machine time step

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_semd.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_semd.py
@@ -16,7 +16,6 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_synapse_type import AbstractSynapseType
 
 TAU_SYN_E = 'tau_syn_E'
@@ -101,8 +100,7 @@ class SynapseTypeSEMD(AbstractSynapseType):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractSynapseType.get_values, additional_arguments={'ts'})
+    @overrides(AbstractSynapseType.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         # pylint: disable=arguments-differ
 

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_maass_stochastic.py
@@ -15,7 +15,6 @@
 
 from spinn_utilities.overrides import overrides
 from data_specification.enums import DataType
-from pacman.executor.injection_decorator import inject_items
 from .abstract_threshold_type import AbstractThresholdType
 
 DU_TH = "du_th"
@@ -79,8 +78,7 @@ class ThresholdTypeMaassStochastic(AbstractThresholdType):
     def has_variable(self, variable):
         return variable in UNITS
 
-    @inject_items({"ts": "MachineTimeStep"})
-    @overrides(AbstractThresholdType.get_values, additional_arguments={'ts'})
+    @overrides(AbstractThresholdType.get_values)
     def get_values(self, parameters, state_variables, vertex_slice, ts):
         # pylint: disable=arguments-differ
 

--- a/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_static.py
+++ b/spynnaker/pyNN/models/neuron/threshold_types/threshold_type_static.py
@@ -57,7 +57,7 @@ class ThresholdTypeStatic(AbstractThresholdType):
         return variable in UNITS
 
     @overrides(AbstractThresholdType.get_values)
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
 
         # Add the rest of the data
         return [parameters[V_THRESH]]

--- a/unittests/test_populations/test_vertex.py
+++ b/unittests/test_populations/test_vertex.py
@@ -39,7 +39,7 @@ class EmptyNeuronComponent(AbstractStandardNeuronComponent):
     def add_state_variables(self, state_variables):
         pass
 
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
         return numpy.zeros(dtype="uint32")
 
     def update_values(self, values, parameters, state_variables):
@@ -81,7 +81,7 @@ class _MyNeuronModel(AbstractNeuronModel):
         state_variables["foo"] = self._foo
         state_variables["bar"] = self._bar
 
-    def get_values(self, parameters, state_variables, vertex_slice):
+    def get_values(self, parameters, state_variables, vertex_slice, ts):
         return numpy.zeros(dtype="uint32")
 
     def update_values(self, values, parameters, state_variables):


### PR DESCRIPTION
Requested by @pabogdan.  This allows a neuron model to split its time step into multiple calls to the updates, so it is more precise, whilst the time step is still kept at a lower rate.  This can be configured per-population for any model using the standard implementation (with the components).

Also see changes in SpiNNakerManchester/sPyNNaker8NewModelTemplate#54

Tested by SpiNNakerManchester/sPyNNaker8#398