### PR TITLE
Fix the connection estimates for FixedNumberPostConnector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_script:
 script:
   # Python
   - py.test --cov-report= unittests --cov spynnaker
-  - flake8 examples spynnaker pyNN-spiNNaker-src
+  - flake8 spynnaker
   - flake8 unittests
   - ( pylint --output-format=colorized --disable=R,C spynnaker; exit $(($? & 35)) )
   # XML

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -172,8 +172,7 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine,
                 synapse_info.n_post_neurons), 1.0)
         n_connections = utility_calls.get_probable_maximum_selected(
             synapse_info.n_pre_neurons * synapse_info.n_post_neurons,
-            self.__n_post * synapse_info.n_pre_neurons, prob_in_slice,
-            chance=1.0/100000.0)
+            self.__n_post, prob_in_slice, chance=1.0/100000.0)
 
         if min_delay is None or max_delay is None:
             return int(math.ceil(n_connections))
@@ -189,7 +188,7 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine,
         selection_prob = 1.0 / float(synapse_info.n_post_neurons)
         n_connections = utility_calls.get_probable_maximum_selected(
             synapse_info.n_pre_neurons * synapse_info.n_post_neurons,
-            self.__n_post * synapse_info.n_pre_neurons, selection_prob,
+            synapse_info.n_pre_neurons, selection_prob,
             chance=1.0/100000.0)
         return int(math.ceil(n_connections))
 

--- a/spynnaker/pyNN/protocols/munich_io_spinnaker_link_protocol.py
+++ b/spynnaker/pyNN/protocols/munich_io_spinnaker_link_protocol.py
@@ -43,16 +43,16 @@ PUSH_BOT_MOTOR_WITHOUT_UART_MASK = 0x7C0
 PUSH_BOT_MOTOR_UART_SHIFT = 0 + _OFFSET_TO_I
 
 
-def munich_key(I, F, D):
-    return (I << _OFFSET_TO_I) | (F << _OFFSET_TO_F) | (D << _OFFSET_TO_D)
+def munich_key(Instr, F, D):
+    return (Instr << _OFFSET_TO_I) | (F << _OFFSET_TO_F) | (D << _OFFSET_TO_D)
 
 
-def munich_key_i_d(I, D):
-    return munich_key(I, 0, D)
+def munich_key_i_d(Instr, D):
+    return munich_key(Instr, 0, D)
 
 
-def munich_key_i(I):
-    return munich_key(I, 0, 0)
+def munich_key_i(Instr):
+    return munich_key(Instr, 0, 0)
 
 
 def get_munich_i(key):


### PR DESCRIPTION
The connection estimates were incorrect for the FixedNumberPostConnector; this fixes it so that scripts that should work now do, rather than failing because of an overestimate of the synaptic row length required.

Additional test added as a check for this in the future: https://github.com/SpiNNakerManchester/sPyNNaker8/pull/406