### PR TITLE
Reload neuron parameters after setting initial value

### DIFF
--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -627,9 +627,9 @@ class AbstractPopulationVertex(
                 " parameter {}".format(variable))
 
         parameter = self._get_parameter(variable)
-
         ranged_list = self._state_variables[parameter]
         ranged_list.set_value_by_selector(selector, value)
+        self.__change_requires_neuron_parameters_reload = True
 
     @property
     def conductance_based(self):


### PR DESCRIPTION
Most likely an oversight in the recent-ish multi-run / reset changes, as this is not a standard PyNN function.  This fixes the issue at https://github.com/SpiNNakerManchester/sPyNNaker8/issues/331.

Have added the script from @ej159 as a test in https://github.com/SpiNNakerManchester/sPyNNaker8/pull/409.