### PR TITLE
Try to switch Travis to Focal Fossa (Ubuntu 20.04LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
   - 2.7
   - 3.6
   - 3.7
-dist: xenial
+dist: focal
 cache: pip
 env:
   - MPLBACKEND=module://matplotlib.backends.backend_agg


### PR DESCRIPTION
This should let us pick up gcc-arm-none-eabi 9.2 or later, which produces tighter code...