### PR TITLE
Magic, with __builtin_assume_aligned()!

### DIFF
--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
@@ -205,7 +205,12 @@ static inline bool sp_structs_add_synapse(
         return false;
     }
 
-    *(current_state->post_to_pre_table_entry) = current_state->post_to_pre;
+    // Critical: tell the compiler that this pointer is aligned so it doesn't
+    // internally convert the assignment to a memcpy(), which is a saving of
+    // hundreds of bytes...
+    post_to_pre_entry *ppentry = __builtin_assume_aligned(
+            current_state->post_to_pre_table_entry, 4);
+    *ppentry = current_state->post_to_pre;
     return true;
 }
 


### PR DESCRIPTION
This prevents GCC from deciding that it has to convert a simple copy of a four-byte structure into a call to `memcpy()`, a function that is hundreds of bytes long on ARM. This is the only place in our code where this was happening, and it was all because the compiler was thinking “but _what if_ this field happens to have a non-aligned value put in it, hmm?” when we can outright prove ourselves (but not quite to the compiler's satisfaction) that this never happens.

The portable(-ish) syntax for doing this is horrible.