### PR TITLE
Remove gnu functions

### DIFF
--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/formation/formation_distance_dependent_impl.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/formation/formation_distance_dependent_impl.h
@@ -125,8 +125,7 @@ static inline bool synaptogenesis_formation_rule(
         }
         probability = params->prob_tables[params->ff_prob_size + distance];
     }
-    uint16_t r = ulrbits(mars_kiss64_seed(*(current_state->local_seed)))
-            * MAX_SHORT;
+    uint32_t r = rand_int(MAX_SHORT, *(current_state->local_seed));
     if (r > probability) {
         return false;
     }

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/formation/formation_distance_dependent_impl.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/formation/formation_distance_dependent_impl.h
@@ -42,6 +42,10 @@ struct formation_params {
     uint32_t grid_x;
     //! Size of grid containing neurons, Y-dimension
     uint32_t grid_y;
+    //! Reciprocal of grid_x
+    unsigned long fract grid_x_recip;
+    //! Reciprocal of grid_y
+    unsigned long fract grid_y_recip;
     //! Size of FF probability table
     uint32_t ff_prob_size;
     //! Size of LAT probability table
@@ -74,23 +78,26 @@ static inline bool synaptogenesis_formation_rule(
     // To do this I need to take the DIV and MOD of the
     // post-synaptic neuron ID, of the pre-synaptic neuron ID
     // Compute the distance of these 2 measures
-    int32_t pre_x, pre_y, post_x, post_y, pre_global_id, post_global_id;
+    uint32_t pre_x, pre_y, post_x, post_y;
     // Pre computation requires querying the table with global information
-    pre_global_id = current_state->key_atom_info->lo_atom +
+    uint32_t pre_global_id = current_state->key_atom_info->lo_atom +
             current_state->pre_syn_id;
-    post_global_id = current_state->post_syn_id + current_state->post_low_atom;
+    uint32_t post_global_id = current_state->post_syn_id +
+            current_state->post_low_atom;
 
     if (params->grid_x > 1) {
-        pre_x = pre_global_id / params->grid_x;
-        post_x = post_global_id / params->grid_x;
+        pre_x = muliulr(pre_global_id, params->grid_x_recip);
+        post_x = muliulr(post_global_id, params->grid_x_recip);
     } else {
         pre_x = 0;
         post_x = 0;
     }
 
     if (params->grid_y > 1) {
-        pre_y = pre_global_id % params->grid_y;
-        post_y = post_global_id % params->grid_y;
+        uint32_t pre_y_div = muliulr(pre_global_id, params->grid_y_recip);
+        uint32_t post_y_div = muliulr(post_global_id, params->grid_y_recip);
+        pre_y = pre_global_id - (pre_y_div * params->grid_y);
+        post_y = post_global_id - (post_y_div * params->grid_y);
     } else {
         pre_y = 0;
         post_y = 0;

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/last_neuron_selection_impl.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/last_neuron_selection_impl.h
@@ -73,8 +73,7 @@ static inline bool potential_presynaptic_partner(
     if (!n_spikes[buffer]) {
         return false;
     }
-    uint32_t offset = ulrbits(mars_kiss64_seed(rewiring_data.local_seed)) *
-            n_spikes[buffer];
+    uint32_t offset = rand_int(n_spikes[buffer], rewiring_data.local_seed);
     *spike = last_spikes_buffer[buffer][offset];
     return sp_structs_find_by_spike(&pre_info, *spike, neuron_id,
             population_id, sub_population_id, m_pop_index);

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
@@ -109,6 +109,14 @@ typedef struct {
     uint32_t synapse_type;
 } current_state_t;
 
+//! Get a random unsigned integer up to (but not including) a given maximum
+//! \param[in] max The maximum value allowed
+//! \param[in] seed The random seed to use
+//! \return The generated value
+static inline uint32_t rand_int(uint32_t max, mars_kiss64_seed_t seed) {
+    return muliulr(max, ulrbits(mars_kiss64_seed(seed)));
+}
+
 //! \brief unpack the spike into key and identifying information for the
 //!     neuron; Identify pop, sub-population and low and high atoms
 //! \param[in] pre_pop_info_table: The prepopulation information table
@@ -197,8 +205,8 @@ static inline bool sp_structs_add_synapse(
     uint32_t actual_delay;
     uint32_t offset = current_state->pre_population_info->delay_hi -
             current_state->pre_population_info->delay_lo;
-    actual_delay = ulrbits(mars_kiss64_seed(*(current_state->local_seed))) *
-        offset + current_state->pre_population_info->delay_lo;
+    actual_delay = rand_int(offset, *(current_state->local_seed)) +
+            current_state->pre_population_info->delay_lo;
 
     if (!synapse_dynamics_add_neuron(
             current_state->post_syn_id, row, appr_scaled_weight, actual_delay,

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/topographic_map_impl.c
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/topographic_map_impl.c
@@ -191,8 +191,8 @@ bool synaptogenesis_dynamics_rewire(
         uint32_t *n_bytes) {
 
     // Randomly choose a postsynaptic (application neuron)
-    uint32_t post_id = ulrbits(mars_kiss64_seed(rewiring_data.shared_seed)) *
-            rewiring_data.app_no_atoms;
+    uint32_t post_id = rand_int(rewiring_data.app_no_atoms,
+        rewiring_data.shared_seed);
 
     // Check if neuron is in the current machine vertex
     if (post_id < rewiring_data.low_atom ||
@@ -203,9 +203,8 @@ bool synaptogenesis_dynamics_rewire(
 
     // Select an arbitrary synaptic element for the neurons
     uint32_t row_offset = post_id * rewiring_data.s_max;
-    uint32_t column_offset =
-            ulrbits(mars_kiss64_seed(rewiring_data.local_seed)) *
-            rewiring_data.s_max;
+    uint32_t column_offset = rand_int(rewiring_data.s_max,
+        rewiring_data.local_seed);
     uint32_t total_offset = row_offset + column_offset;
     post_to_pre_entry entry = post_to_pre_table[total_offset];
     uint32_t pre_app_pop = 0, pre_sub_pop = 0, m_pop_index = 0, neuron_id = 0;

--- a/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
+++ b/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
@@ -16,6 +16,7 @@
 import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_formation import AbstractFormation
+from data_specification.enums.data_type import DataType
 
 
 class DistanceDependentFormation(AbstractFormation):
@@ -146,6 +147,8 @@ class DistanceDependentFormation(AbstractFormation):
     @overrides(AbstractFormation.write_parameters)
     def write_parameters(self, spec):
         spec.write_array(self.__grid)
+        spec.write_array(DataType.S031.encode_as_numpy_int_array(
+            1 / self._grid))
         spec.write_value(len(self.__ff_distance_probabilities))
         spec.write_value(len(self.__lat_distance_probabilities))
         spec.write_array(self.__ff_distance_probabilities.view("<u4"))

--- a/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
+++ b/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
@@ -19,8 +19,9 @@ from .abstract_formation import AbstractFormation
 from data_specification.enums.data_type import DataType
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 
-# Number of words in the parameter struct excluding VLAs
-_WORDS_IN_STRUCT = 6
+# 6 32-bit words (grid_x, grid_y, grid_x_recip, grid_y_recep, ff_prob_size,
+#                 lat_prob_size)
+_PARAMS_SIZE_IN_BYTES = 6 * BYTES_PER_WORD
 
 
 class DistanceDependentFormation(AbstractFormation):
@@ -75,7 +76,7 @@ class DistanceDependentFormation(AbstractFormation):
 
     @overrides(AbstractFormation.get_parameters_sdram_usage_in_bytes)
     def get_parameters_sdram_usage_in_bytes(self):
-        return (BYTES_PER_WORD * _WORDS_IN_STRUCT +
+        return (_PARAMS_SIZE_IN_BYTES +
                 len(self.__ff_distance_probabilities) * 2 +
                 len(self.__lat_distance_probabilities) * 2)
 

--- a/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
+++ b/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
@@ -152,8 +152,11 @@ class DistanceDependentFormation(AbstractFormation):
     @overrides(AbstractFormation.write_parameters)
     def write_parameters(self, spec):
         spec.write_array(self.__grid)
-        spec.write_array(DataType.S031.encode_as_numpy_int_array(
-            1 / self.__grid))
+        # Work out the reciprocal, but zero them if >= 1 as they are not
+        # representable as S031 in that case, and not used anyway
+        recip = 1 / self.__grid
+        recip[recip >= 1.0] = 0
+        spec.write_array(DataType.S031.encode_as_numpy_int_array(recip))
         spec.write_value(len(self.__ff_distance_probabilities))
         spec.write_value(len(self.__lat_distance_probabilities))
         spec.write_array(self.__ff_distance_probabilities.view("<u4"))

--- a/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
+++ b/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
@@ -148,7 +148,7 @@ class DistanceDependentFormation(AbstractFormation):
     def write_parameters(self, spec):
         spec.write_array(self.__grid)
         spec.write_array(DataType.S031.encode_as_numpy_int_array(
-            1 / self._grid))
+            1 / self.__grid))
         spec.write_value(len(self.__ff_distance_probabilities))
         spec.write_value(len(self.__lat_distance_probabilities))
         spec.write_array(self.__ff_distance_probabilities.view("<u4"))

--- a/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
+++ b/spynnaker/pyNN/models/neuron/structural_plasticity/synaptogenesis/formation/distance_dependent_formation.py
@@ -17,6 +17,10 @@ import numpy
 from spinn_utilities.overrides import overrides
 from .abstract_formation import AbstractFormation
 from data_specification.enums.data_type import DataType
+from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
+
+# Number of words in the parameter struct excluding VLAs
+_WORDS_IN_STRUCT = 6
 
 
 class DistanceDependentFormation(AbstractFormation):
@@ -71,7 +75,8 @@ class DistanceDependentFormation(AbstractFormation):
 
     @overrides(AbstractFormation.get_parameters_sdram_usage_in_bytes)
     def get_parameters_sdram_usage_in_bytes(self):
-        return (4 + 4 + 4 + 4 + len(self.__ff_distance_probabilities) * 2 +
+        return (BYTES_PER_WORD * _WORDS_IN_STRUCT +
+                len(self.__ff_distance_probabilities) * 2 +
                 len(self.__lat_distance_probabilities) * 2)
 
     def generate_distance_probability_array(self, probability, sigma):


### PR DESCRIPTION
Removes type conversion and division making the code size much smaller.  Ideally the rule that encodes distance might use a look-up-table but because the size of this is unknown it might have to live in SDRAM, making it less ideal.  Hence the division is now replaced by reciprocal multiplication.