### PR TITLE
Minor bugfixes

### DIFF
--- a/neural_modelling/Doxyfile
+++ b/neural_modelling/Doxyfile
@@ -907,7 +907,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.
@@ -1551,7 +1551,7 @@ SKIP_FUNCTION_MACROS   = YES
 # the path). If a tag file is not located in the directory in which doxygen is
 # run, you must also specify the path to the tagfile here.
 
-TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/ common.tag=http://spinnakermanchester.github.io/spinn_common/ fec.tag=http://spinnakermanchester.github.io/SpiNNFrontEndCommon/c/ 
+TAGFILES               = sllt.tag=http://spinnakermanchester.github.io/spinnaker_tools/ common.tag=http://spinnakermanchester.github.io/spinn_common/ fec.tag=http://spinnakermanchester.github.io/SpiNNFrontEndCommon/c/
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to

--- a/neural_modelling/src/common/neuron-typedefs.h
+++ b/neural_modelling/src/common/neuron-typedefs.h
@@ -17,6 +17,11 @@
 
 /*! \file
  * \brief   Data type definitions for SpiNNaker Neuron-modelling
+ * \details
+ *      Defines a spike with either a payload or not and implements the
+ *      functionality to extract the key and payload in both cases. If the
+ *      spike is compiled as not having a payload, the payload will always be
+ *      returned as 0.
  */
 
 #ifndef __NEURON_TYPEDEFS_H__
@@ -25,22 +30,13 @@
 #include <common-typedefs.h>
 #include "maths-util.h"
 
-// Determine the type of a spike
-/*
- * defines a spike with either a pay load or not and implements the
- * functionality to extract the key and pay load in both cases. If the
- * spike is compiled as not having a pay load, the pay load will always be
- * returned as 0
- */
-#ifndef __SPIKE_T__
-
-//! The type of a SpiNNaker multicast message key word
+//! The type of a SpiNNaker multicast message key word.
 typedef uint32_t key_t;
-//! The type of a SpiNNaker multicast message payload word
+
+//! The type of a SpiNNaker multicast message payload word.
 typedef uint32_t payload_t;
 
 #ifdef SPIKES_WITH_PAYLOADS
-
 //! The type of a spike
 typedef uint64_t spike_t;
 
@@ -51,56 +47,46 @@ union _spike_t {
         key_t key;
     };
 };
+#else  /*SPIKES_WITHOUT_PAYLOADS*/
+//! The type of a spike
+typedef uint32_t spike_t;
+#endif /*SPIKES_WITH_PAYLOADS*/
 
-//! \brief helper method to retrieve the key from a spike
+//! \brief Retrieve the key from a spike.
 //! \param[in] s: the spike to get the key from
-//! \return key_t: the key from the spike
+//! \return the key from the spike
 static inline key_t spike_key(spike_t s) {
+#ifdef SPIKES_WITH_PAYLOADS
     union _spike_t spike;
     spike.pair = s;
     return spike.key;
+#else  /*SPIKES_WITHOUT_PAYLOADS*/
+    return s;
+#endif /*SPIKES_WITH_PAYLOADS*/
 }
 
-//! \brief helper method to retrieve the pay-load from a spike
-//! \param[in] s: the spike to get the pay-load from
-//! \return payload_t: the pay-load from the spike (only used if the model
-//!     is compiled with SPIKES_WITH_PAYLOADS)
+//! \brief Retrieve the payload from a spike.
+//! \param[in] s: the spike to get the payload from
+//! \return the payload from the spike; always zero when `SPIKES_WITH_PAYLOADS`
+//!     is not defined.
 static inline payload_t spike_payload(spike_t s) {
+#ifdef SPIKES_WITH_PAYLOADS
     union _spike_t spike;
     spike.pair = s;
     return spike.payload;
-}
-
 #else  /*SPIKES_WITHOUT_PAYLOADS*/
-
-//! The type of a spike
-typedef uint32_t spike_t;
-
-//! \brief helper method to retrieve the key from a spike
-//! \param[in] s: the spike to get the key from
-//! \return key_t: the key from the spike
-static inline key_t spike_key(spike_t s) {
-    return s;
-}
-
-//! \brief helper method to retrieve the pay-load from a spike
-//! \param[in] s: the spike to get the pay-load from
-//! \return payload_t: the pay-load from the spike (default-ly set to zero if
-//!                    the model is not compiled with SPIKES_WITH_PAYLOADS)
-static inline payload_t spike_payload(spike_t s) {
     use(s);
     return 0;
-}
 #endif /*SPIKES_WITH_PAYLOADS*/
-#endif /*__SPIKE_T__*/
+}
 
-//! The type of a synaptic row
+//! The type of a synaptic row.
 typedef address_t synaptic_row_t;
 
-//! The type of an input
+//! The type of an input.
 typedef REAL input_t;
 
-//! The type of a state variable
+//! The type of a state variable.
 typedef REAL state_t;
 
 #endif /* __NEURON_TYPEDEFS_H__ */

--- a/neural_modelling/src/delay_extension/delay_extension.c
+++ b/neural_modelling/src/delay_extension/delay_extension.c
@@ -28,11 +28,12 @@
 #include <simulation.h>
 #include <spin1_api.h>
 
-//! values for the priority for each callback
+//! Tthe priority for each callback
 enum delay_extension_callback_priorities {
     MC_PACKET = -1, //!< multicast packet reception uses FIQ
-    SDP = 0,        //!< SDP handling is highest ordinary priority
-    USER = 1,       //!< User interrupt is next (clearing packet received queue)
+    SDP = 0,        //!< SDP handling is direct interrupt
+    USER = 1,       //!< User interrupt is highest queued priority (used for
+                    //!< clearing the packet received queue)
     DMA = 2,        //!< DMA complete handling is next
     TIMER = 3,      //!< Regular timer tick handling is lowest priority
 };
@@ -124,9 +125,7 @@ static uint32_t timer_period = 0;
 //---------------------------------------
 // Because we don't want to include string.h or strings.h for memset
 //! \brief Sets an array of counters to zero
-//!
-//! This is basically just bzero()
-//!
+//! \details This is basically just `bzero()`
 //! \param[out] counters: The array to zero
 //! \param[in] num_items: The size of the array
 static inline void zero_spike_counters(
@@ -297,10 +296,9 @@ static bool initialize(void) {
 
 // Callbacks
 //! \brief Handles incoming spikes (FIQ)
-//!
-//! Adds the spikes to the circular buffer handling spikes for later handling by
-//! ::spike_process()
-//!
+//! \details
+//!     Adds the spikes to the circular buffer handling spikes for later
+//!     handling by ::spike_process()
 //! \param[in] key: the key of the multicast message
 //! \param payload: ignored
 static void incoming_spike_callback(uint key, uint payload) {
@@ -321,8 +319,9 @@ static inline index_t key_n(key_t k) {
 }
 
 //! \brief Processes spikes queued by ::incoming_spike_callback()
-//!
-//! Note that this has to be fairly fast; it is processing with interrupts off.
+//! \details
+//!     Note that this has to be fairly fast; it is processing with interrupts
+//!     off.
 static inline void spike_process(void) {
     // turn off interrupts as this function is critical for
     // keeping time in sync.

--- a/neural_modelling/src/neuron/c_main.c
+++ b/neural_modelling/src/neuron/c_main.c
@@ -148,7 +148,7 @@ static void c_main_store_provenance_data(address_t provenance_region) {
     log_debug("finished other provenance data");
 }
 
-//! \brief Initialises the model by reading in the regions and checking
+//! \brief Initialise the model by reading in the regions and checking
 //!        recording data.
 //! \return True if it successfully initialised, false otherwise
 static bool initialise(void) {
@@ -246,7 +246,7 @@ static bool initialise(void) {
     return true;
 }
 
-//! \brief the function to call when resuming a simulation
+//! \brief Callback called when resuming a simulation
 void resume_callback(void) {
     data_specification_metadata_t *ds_regions =
             data_specification_get_data_address();

--- a/neural_modelling/src/neuron/decay.h
+++ b/neural_modelling/src/neuron/decay.h
@@ -17,8 +17,9 @@
 
 /*! \file
  *
- *  \brief utility method for decaying a value by a given amount
- *
+ *  \brief Utility functions for decaying a value multiplicatively by a given
+ *      amount
+ *  \details
  *    The API includes:
  *
  *     - decay_s1615()
@@ -44,11 +45,11 @@
 //! the future if the type is redefined
 typedef UFRACT decay_t;
 
-//! \brief this method takes a s1615 and decays it by a given amount
-//! (denoted by the decay) (to compensate for the valve behaviour of a synapse
-//! in biology (spike goes in, synapse opens, then closes slowly)).
-//! \param[in] x the s1615 value to decayed
-//! \param[in] decay the amount to decay the value by
+//! \brief Decay a s1615 by a given amount (denoted by the decay) to
+//!     compensate for the valve behaviour of a synapse in biology (spike goes
+//!     in, synapse opens, then closes slowly).
+//! \param[in] x: the s1615 value to decayed
+//! \param[in] decay: the amount to decay the value by
 //! \return the new decayed s1615 value
 static inline s1615 decay_s1615(s1615 x, decay_t decay) {
     int64_t s = (int64_t) bitsk(x);
@@ -57,12 +58,12 @@ static inline s1615 decay_s1615(s1615 x, decay_t decay) {
     return kbits((int_k_t) ((s * u) >> 32));
 }
 
-//! \brief this method takes a s1616 and decays it by a given amount
-//! (denoted by the decay) (to compensate for the valve behaviour of a synapse
-//! in biology (spike goes in, synapse opens, then closes slowly)).
-//! \param[in] x the s1616 value to decayed
-//! \param[in] decay the amount to decay the value by
-//! \return the new decayed s1616 value
+//! \brief Decay a u1616 by a given amount (denoted by the decay) to compensate
+//!     for the valve behaviour of a synapse in biology (spike goes in, synapse
+//!     opens, then closes slowly).
+//! \param[in] x: the u1616 value to decayed
+//! \param[in] decay: the amount to decay the value by
+//! \return the new decayed u1616 value
 static inline u1616 decay_u1616(u1616 x, decay_t decay) {
     uint64_t s = (uint64_t) bitsuk(x);
     uint64_t u = (uint64_t) bitsulr(decay);
@@ -70,11 +71,11 @@ static inline u1616 decay_u1616(u1616 x, decay_t decay) {
     return ukbits((uint_uk_t) ((s * u) >> 32));
 }
 
-//! \brief this method takes a s015 and decays it by a given amount
-//! (denoted by the decay) (to compensate for the valve behaviour of a synapse
-//! in biology (spike goes in, synapse opens, then closes slowly)).
-//! \param[in] x the s015 value to decayed
-//! \param[in] decay the amount to decay the value by
+//! \brief Decay a s015 by a given amount (denoted by the decay) (to compensate
+//!     for the valve behaviour of a synapse in biology (spike goes in, synapse
+//!     opens, then closes slowly).
+//! \param[in] x: the s015 value to decayed
+//! \param[in] decay: the amount to decay the value by
 //! \return the new decayed s015 value
 static inline s015 decay_s015(s015 x, decay_t decay) {
     int64_t s = (int64_t) bitsk(x);
@@ -83,12 +84,12 @@ static inline s015 decay_s015(s015 x, decay_t decay) {
     return rbits((int_r_t) ((s * u) >> 32));
 }
 
-//! \brief this method takes a s016 and decays it by a given amount
-//! (denoted by the decay) (to compensate for the valve behaviour of a synapse
-//! in biology (spike goes in, synapse opens, then closes slowly)).
-//! \param[in] x the s016 value to decayed
-//! \param[in] decay the amount to decay the value by
-//! \return the new decayed s016 value
+//! \brief Decay a u016 by a given amount (denoted by the decay) (to compensate
+//!     for the valve behaviour of a synapse in biology (spike goes in, synapse
+//!     opens, then closes slowly).
+//! \param[in] x: the u016 value to decayed
+//! \param[in] decay: the amount to decay the value by
+//! \return the new decayed u016 value
 static inline u016 decay_u016(u016 x, decay_t decay) {
     uint64_t s = (uint64_t) bitsuk(x);
     uint64_t u = (uint64_t) bitsulr(decay);
@@ -105,20 +106,22 @@ static inline u016 decay_u016(u016 x, decay_t decay) {
  * the abort statement and therefore kills scripts dead on SpiNNaker.
  * ---------------------------------
  */
-//! \brief This is a type-generic decay "function".
+//! \brief Decay a value by a given amount (denoted by the decay) (to
+//!     compensate for the valve behaviour of a synapse in biology (spike goes
+//!     in, synapse opens, then closes slowly).
 //! \param[in] x: the value to decayed
-//! \param[in] d: the amount to decay the value by
+//! \param[in] d: the amount to decay the value by (a decay_t)
 //! \return the new decayed value
 #define decay(x, d) ({ \
     __typeof__(x) tmp = (x); \
     if (__builtin_types_compatible_p(__typeof__(x), s1615)) {\
-        tmp = decay_s1615(x, d); \
+        tmp = decay_s1615(tmp, d); \
     } else if (__builtin_types_compatible_p(__typeof__(x), u1616)) {\
-        tmp = decay_u1616(x, d); \
+        tmp = decay_u1616(tmp, d); \
     } else if (__builtin_types_compatible_p(__typeof__(x), s015)) {\
-        tmp = decay_s015(x, d); \
+        tmp = decay_s015(tmp, d); \
     } else if (__builtin_types_compatible_p(__typeof__(x), u016)) {\
-        tmp = decay_u016(x, d); \
+        tmp = decay_u016(tmp, d); \
     } else {\
         abort(1); \
     }\

--- a/neural_modelling/src/neuron/implementations/neuron_impl.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl.h
@@ -51,7 +51,7 @@ static void neuron_impl_load_neuron_parameters(
 static bool neuron_impl_do_timestep_update(
         index_t neuron_index, input_t external_bias);
 
-//! \brief Stores neuron parameters back into SDRAM
+//! \brief Store neuron parameters back into SDRAM
 //! \param[out] address: the address in SDRAM to start the store
 //! \param[in] next: Offset of next address in store
 //! \param[in] n_neurons: The number of neurons

--- a/neural_modelling/src/neuron/implementations/neuron_impl_external_devices.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_external_devices.h
@@ -44,7 +44,7 @@ enum send_type {
 #include <debug.h>
 
 
-//! The definition of the threshold
+//! The definition of the threshold, and what to do when that happens
 typedef struct packet_firing_data_t {
     //! The key to send to update the value
     uint32_t key;
@@ -114,7 +114,9 @@ static uint n_steps_per_timestep;
 #endif // !SOMETIMES_UNUSED
 
 
-// Typesafe magic reinterpret cast
+//! \brief Typesafe magic reinterpret cast
+//! \param[in] value: The value to reinterpret
+//! \return The reinterpreted value
 static inline uint _int_bits(int value) {
     typedef union _int_bits_union {
         int int_value;
@@ -126,7 +128,7 @@ static inline uint _int_bits(int value) {
     return converter.uint_value;
 }
 
-//! \brief Converts the value into the right form for sending as a payload
+//! \brief Convert the value into the right form for sending as a payload
 //! \param[in] type: what type of payload are we really dealing with
 //! \param[in] value: the value, after scaling
 //! \return The word to go in the multicast packet payload
@@ -160,7 +162,7 @@ static bool neuron_impl_initialise(uint32_t n_neurons) {
     if (sizeof(global_neuron_params_t)) {
         global_parameters = spin1_malloc(sizeof(global_neuron_params_t));
         if (global_parameters == NULL) {
-            log_error("Unable to allocate global neuron parameters"
+            log_error("Unable to allocate global neuron parameters "
                     "- Out of DTCM");
             return false;
         }
@@ -313,13 +315,12 @@ static void neuron_impl_load_neuron_parameters(
 }
 
 
-//! \brief helper method for spreading out the spikes over the timer tick
+//! \brief Spread out the spikes over the timer tick
 //! \param[in] key: the key to fire
 //! \param[in] payload: the payload to fire
-//! \param[in] with_payload: bool saying if a payload is needed or not
+//! \param[in] with_payload: Whether a payload is needed or not
 static inline void send_packet(
         uint32_t key, uint32_t payload, bool with_payload) {
-
     if (with_payload) {
         while (!spin1_send_mc_packet(key, payload, WITH_PAYLOAD)) {
             spin1_delay_us(1);
@@ -331,9 +332,9 @@ static inline void send_packet(
     }
 }
 
-//! \brief Determines if the device should fire
-//! \param[in] packet_firing: The parameters to use to determine if it
-//!                           should fire now
+//! \brief Determine if the device should fire
+//! \param[in] packet_firing:
+//!     The parameters to use to determine if it should fire now
 //! \return True if the neuron should fire
 static bool _test_will_fire(packet_firing_data_t *packet_firing) {
     if (packet_firing->time_until_next_send == 0) {
@@ -469,7 +470,7 @@ static bool neuron_impl_do_timestep_update(index_t neuron_index,
 }
 
 SOMETIMES_UNUSED // Marked unused as only used sometimes
-//! \brief Stores neuron parameters back into SDRAM
+//! \brief Store neuron parameters back into SDRAM
 //! \param[out] address: the address in SDRAM to start the store
 //! \param[in] next: Offset of next address in store
 //! \param[in] n_neurons: number of neurons

--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -352,7 +352,7 @@ static bool neuron_impl_do_timestep_update(index_t neuron_index,
 }
 
 SOMETIMES_UNUSED // Marked unused as only used sometimes
-//! \brief Stores neuron parameters back into SDRAM
+//! \brief Store neuron parameters back into SDRAM
 //! \param[out] address: the address in SDRAM to start the store
 //! \param[in] next: Offset of next address in store
 //! \param[in] n_neurons: number of neurons

--- a/neural_modelling/src/neuron/input_types/input_type.h
+++ b/neural_modelling/src/neuron/input_types/input_type.h
@@ -48,7 +48,7 @@ typedef struct input_type_t input_type_t;
 //! Declaration of the input type pointer
 typedef input_type_t *input_type_pointer_t;
 
-//! \brief Gets the actual input value. This allows any scaling to take place
+//! \brief Get the actual input value. This allows any scaling to take place
 //! \param[in,out] value: The array of the receptor-based values of the input
 //!     before scaling
 //! \param[in] input_type: The input type pointer to the parameters
@@ -60,7 +60,7 @@ static input_t *input_type_get_input_value(
         input_t *restrict value, const input_type_t *input_type,
         uint16_t num_receptors);
 
-//! \brief Converts an excitatory input into an excitatory current
+//! \brief Convert an excitatory input into an excitatory current
 //! \param[in,out] exc_input: Pointer to array of excitatory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()
@@ -70,7 +70,7 @@ static void input_type_convert_excitatory_input_to_current(
         input_t *restrict exc_input, const input_type_t *input_type,
         state_t membrane_voltage);
 
-//! \brief Converts an inhibitory input into an inhibitory current
+//! \brief Convert an inhibitory input into an inhibitory current
 //! \param[in,out] inh_input: Pointer to array of inhibitory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()

--- a/neural_modelling/src/neuron/input_types/input_type_conductance.h
+++ b/neural_modelling/src/neuron/input_types/input_type_conductance.h
@@ -30,7 +30,7 @@ typedef struct input_type_t {
     REAL     V_rev_I;
 } input_type_t;
 
-//! \brief Gets the actual input value. This allows any scaling to take place
+//! \brief Get the actual input value. This allows any scaling to take place
 //! \param[in,out] value: The array of the receptor-based values of the input
 //!     before scaling
 //! \param[in] input_type: The input type pointer to the parameters
@@ -48,7 +48,7 @@ static inline input_t *input_type_get_input_value(
     return &value[0];
 }
 
-//! \brief Converts an excitatory input into an excitatory current
+//! \brief Convert an excitatory input into an excitatory current
 //! \param[in,out] exc_input: Pointer to array of excitatory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()
@@ -63,7 +63,7 @@ static inline void input_type_convert_excitatory_input_to_current(
     }
 }
 
-//! \brief Converts an inhibitory input into an inhibitory current
+//! \brief Convert an inhibitory input into an inhibitory current
 //! \param[in,out] inh_input: Pointer to array of inhibitory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()

--- a/neural_modelling/src/neuron/input_types/input_type_current.h
+++ b/neural_modelling/src/neuron/input_types/input_type_current.h
@@ -28,7 +28,7 @@ typedef struct input_type_t {
 //! Scaling factor (trivial!) for input currents
 static const REAL INPUT_SCALE_FACTOR = ONE;
 
-//! \brief Gets the actual input value. This allows any scaling to take place
+//! \brief Get the actual input value. This allows any scaling to take place
 //! \param[in,out] value: The array of the receptor-based values of the input
 //!     before scaling
 //! \param[in] input_type: The input type pointer to the parameters
@@ -48,7 +48,7 @@ static inline input_t *input_type_get_input_value(
     return &value[0];
 }
 
-//! \brief Converts an excitatory input into an excitatory current
+//! \brief Convert an excitatory input into an excitatory current
 //! \param[in,out] exc_input: Pointer to array of excitatory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()
@@ -62,7 +62,7 @@ static inline void input_type_convert_excitatory_input_to_current(
     use(exc_input);
 }
 
-//! \brief Converts an inhibitory input into an inhibitory current
+//! \brief Convert an inhibitory input into an inhibitory current
 //! \param[in,out] inh_input: Pointer to array of inhibitory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()

--- a/neural_modelling/src/neuron/input_types/input_type_delta.h
+++ b/neural_modelling/src/neuron/input_types/input_type_delta.h
@@ -30,7 +30,7 @@ struct input_type_t {
 //! Scaling factor (trivial!) for input currents
 static const REAL INPUT_SCALE_FACTOR = ONE;
 
-//! \brief Gets the actual input value. This allows any scaling to take place
+//! \brief Get the actual input value. This allows any scaling to take place
 //! \param[in,out] value: The array of the receptor-based values of the input
 //!     before scaling
 //! \param[in] input_type: The input type pointer to the parameters
@@ -48,7 +48,7 @@ static inline input_t *input_type_get_input_value(
     return &value[0];
 }
 
-//! \brief Converts an excitatory input into an excitatory current
+//! \brief Convert an excitatory input into an excitatory current
 //! \param[in,out] exc_input: Pointer to array of excitatory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()
@@ -63,7 +63,7 @@ static inline void input_type_convert_excitatory_input_to_current(
     }
 }
 
-//! \brief Converts an inhibitory input into an inhibitory current
+//! \brief Convert an inhibitory input into an inhibitory current
 //! \param[in,out] inh_input: Pointer to array of inhibitory inputs from
 //!     different receptors this timestep. Note that this will already have
 //!     been scaled by input_type_get_input_value()

--- a/neural_modelling/src/neuron/input_types/input_type_none.h
+++ b/neural_modelling/src/neuron/input_types/input_type_none.h
@@ -34,7 +34,7 @@
 struct input_type_t {
 };
 
-//! \brief Gets the actual input value. This allows any scaling to take place
+//! \brief Get the actual input value. This allows any scaling to take place
 //! \details Actually does nothing; no receptors
 //! \param[in,out] value: The array of the receptor-based values of the input
 //!     before scaling
@@ -52,7 +52,7 @@ static input_t *input_type_get_input_value(
     return 0;
 }
 
-//! \brief Converts an excitatory input into an excitatory current
+//! \brief Convert an excitatory input into an excitatory current
 //! \details Actually does nothing; no receptors
 //! \param[in,out] exc_input: Pointer to array of excitatory inputs from
 //!     different receptors this timestep. Note that this will already have
@@ -67,7 +67,7 @@ static void input_type_convert_excitatory_input_to_current(
     use(membrane_voltage);
 }
 
-//! \brief Converts an inhibitory input into an inhibitory current
+//! \brief Convert an inhibitory input into an inhibitory current
 //! \details Actually does nothing; no receptors
 //! \param[in,out] inh_input: Pointer to array of inhibitory inputs from
 //!     different receptors this timestep. Note that this will already have

--- a/neural_modelling/src/neuron/models/neuron_model.h
+++ b/neural_modelling/src/neuron/models/neuron_model.h
@@ -39,12 +39,12 @@ typedef struct global_neuron_params_t global_neuron_params_t;
 //! pointer to global neuron parameters
 typedef global_neuron_params_t* global_neuron_params_pointer_t;
 
-//! \brief set the global neuron parameters
+//! \brief Set the global neuron parameters
 //! \param[in] params: The parameters to set
 void neuron_model_set_global_neuron_params(
         const global_neuron_params_t *params);
 
-//! \brief primary function called in timer loop after synaptic updates
+//! \brief Primary function called in timer loop after synaptic updates
 //! \param[in] num_excitatory_inputs: Number of excitatory receptor types.
 //! \param[in] exc_input: Pointer to array of inputs per receptor type received
 //!     this timer tick that produce a positive reaction within the neuron in
@@ -64,24 +64,26 @@ state_t neuron_model_state_update(
         uint16_t num_inhibitory_inputs, const input_t *inh_input,
         input_t external_bias, neuron_t *restrict neuron);
 
-//! \brief Indicates that the neuron has spiked
-//! \param[in, out] neuron pointer to a neuron parameter struct which contains
+//! \brief Tell the model for a specific neuron that it has has spiked
+//! \param[in, out] neuron: The neuron parameter struct which contains
 //!     all the parameters for a specific neuron
 void neuron_model_has_spiked(neuron_t *restrict neuron);
 
-//! \brief get the neuron membrane voltage for a given neuron parameter set
+//! \brief Get the neuron membrane voltage for a given neuron parameter set
 //! \param[in] neuron: a pointer to a neuron parameter struct which contains
 //!     all the parameters for a specific neuron
 //! \return the membrane voltage for a given neuron with the neuron
 //!     parameters specified in neuron
 state_t neuron_model_get_membrane_voltage(const neuron_t *neuron);
 
-//! \brief printout of state variables i.e. those values that might change
+//! \brief Print state variables i.e. those values that might change each
+//!     timestep
 //! \param[in] neuron: a pointer to a neuron parameter struct which contains all
 //!     the parameters for a specific neuron
 void neuron_model_print_state_variables(const neuron_t *neuron);
 
-//! \brief printout of parameters i.e. those values that don't change
+//! \brief Print parameters i.e. those values that don't usually change for the
+//!     duration of the simulation
 //! \param[in] neuron: a pointer to a neuron parameter struct which contains all
 //!     the parameters for a specific neuron
 void neuron_model_print_parameters(const neuron_t *neuron);

--- a/neural_modelling/src/neuron/neuron.c
+++ b/neural_modelling/src/neuron/neuron.c
@@ -59,10 +59,10 @@ struct neuron_parameters {
 #define START_OF_GLOBAL_PARAMETERS \
     (sizeof(struct neuron_parameters) / sizeof(uint32_t))
 
-//! \brief does the memory copy for the neuron parameters
+//! \brief Copy the neuron parameters into working memory
 //! \param[in] address: the address where the neuron parameters are stored
 //!     in SDRAM
-//! \return bool which is true if the mem copy's worked, false otherwise
+//! \return true if the memory copies worked, false otherwise
 static bool neuron_load_neuron_parameters(address_t address) {
     log_debug("loading parameters");
     // call the neuron implementation functions to do the work

--- a/neural_modelling/src/neuron/neuron.h
+++ b/neural_modelling/src/neuron/neuron.h
@@ -35,7 +35,7 @@
 #include <common/neuron-typedefs.h>
 #include <spin1_api.h>
 
-//! \brief translate the data stored in the NEURON_PARAMS data region in SDRAM
+//! \brief Translate the data stored in the NEURON_PARAMS data region in SDRAM
 //!        and convert it into c based objects for use.
 //! \param[in] address: the absolute address in SDRAM for the start of the
 //!            NEURON_PARAMS data region in SDRAM
@@ -56,7 +56,7 @@ bool neuron_initialise(
         uint32_t *n_synapse_types_value, uint32_t *incoming_spike_buffer_size,
         uint32_t *timer_offset);
 
-//! \brief executes all the updates to neural parameters when a given timer
+//! \brief Execute all the updates to neural parameters when a given timer
 //!        period has occurred.
 //! \param[in] time: the timer tick value currently being executed
 //! \param[in] timer_count: used for detecting a wrapping timer
@@ -65,15 +65,15 @@ void neuron_do_timestep_update(
         timer_t time, uint timer_count, uint timer_period);
 
 //! \brief Prepare to resume simulation of the neurons
-//! \param[in] address: the address where the neuron parameters are stored
-//!                     in SDRAM
+//! \param[in] address:
+//!     the address where the neuron parameters are stored in SDRAM
 //! \return bool which is true if the resume was successful or not
 bool neuron_resume(address_t address);
 
 //! \brief Perform steps needed before pausing a simulation.
 //! \details Stores neuron parameters back into SDRAM.
-//! \param[in] address: the address where the neuron parameters are stored
-//!                     in SDRAM
+//! \param[in] address:
+//!     the address where the neuron parameters are stored in SDRAM
 void neuron_pause(address_t address);
 
 //! \brief Add inputs to the neuron

--- a/neural_modelling/src/neuron/neuron_recording.c
+++ b/neural_modelling/src/neuron/neuron_recording.c
@@ -51,7 +51,7 @@ static void *reset_address;
 //! Add to a number before applying floor to 4 to turn it into a ceil operation
 #define CEIL_TO_4 3
 
-//! \brief resets all states back to start state.
+//! \brief Reset all states back to start state.
 static void reset_record_counter(void) {
     for (uint32_t i = 0; i < N_RECORDED_VARS; i++) {
         if (recording_info[i].rate == 0) {
@@ -89,19 +89,20 @@ static void reset_record_counter(void) {
     }
 }
 
-//! \brief wrapper to recording finalise
+//! \brief Wrapper for recording_finalise()
 void neuron_recording_finalise(void) {
     recording_finalise();
 }
 
-//! \brief the number of bytes used in bitfield recording for n_neurons
+//! \brief Comute the number of bytes used in bitfield recording for
+//!     \p n_neurons
 //! \param[in] n_neurons: The number of neurons to create a bitfield for
 //! \return the size of the bitfield data structure for the number of neurons
 static inline uint32_t bitfield_data_size(uint32_t n_neurons) {
     return sizeof(bitfield_values_t) + (get_bit_field_size(n_neurons) * sizeof(uint32_t));
 }
 
-//! \brief reads recording data from SDRAM
+//! \brief Read recording data from SDRAM
 //! \param[in] recording_address: SDRAM location for the recording data
 //! \param[in] n_neurons: the number of neurons to setup for
 //! \return Whether the read was successful
@@ -193,7 +194,7 @@ bool neuron_recording_reset(uint32_t n_neurons) {
     return true;
 }
 
-//! \brief handles all the DTCM allocations for recording words
+//! \brief Handle all the DTCM allocations for recording words (state vars)
 //! \param[in] n_neurons: how many neurons to set DTCM for
 //! \return True on success
 static inline bool allocate_word_dtcm(uint32_t n_neurons) {
@@ -233,7 +234,7 @@ static inline bool allocate_word_dtcm(uint32_t n_neurons) {
     return true;
 }
 
-//! \brief handles all the DTCM allocations for recording bitfields
+//! \brief Handle all the DTCM allocations for recording bitfields (event sets)
 //! \param[in] n_neurons: how many neurons to set DTCM for
 //! \return True on success
 static inline bool allocate_bitfield_dtcm(uint32_t n_neurons) {

--- a/neural_modelling/src/neuron/neuron_recording.h
+++ b/neural_modelling/src/neuron/neuron_recording.h
@@ -80,13 +80,13 @@ extern uint8_t **recording_values;
 //! An array of spaces into which bitfields can be written
 extern uint32_t **bitfield_values;
 
-//! \brief function to handle when a recording stage finished
+//! \brief Handle when a recording stage finished
 static void recording_done_callback(void) {
     n_recordings_outstanding -= 1;
 }
 
-//! \brief stores a recording of a value of any type, except bitfield;
-//!        use the functions below for common types as these will be faster.
+//! \brief Store a recording of a value of any type, except bitfield;
+//!     use the functions below for common types as these will be faster.
 //! \param[in] var_index: which recording variable to write this is
 //! \param[in] neuron_index: the neuron id for this recorded data
 //! \param[in] value: pointer to the value to record for this neuron.
@@ -98,8 +98,8 @@ static inline void neuron_recording_record_value(
     spin1_memcpy(&recording_values[var_index][p], value, size);
 }
 
-//! \brief stores a recording of an accum variable only; this is faster than
-//!        neuron_recording_record_value for this type
+//! \brief Store a recording of an \p accum variable only; this is faster than
+//!     neuron_recording_record_value() for this type
 //! \param[in] var_index: which recording variable to write this is
 //! \param[in] neuron_index: the neuron id for this recorded data
 //! \param[in] value: the results to record for this neuron.
@@ -110,8 +110,8 @@ static inline void neuron_recording_record_accum(
     data[index] = value;
 }
 
-//! \brief stores a recording of a double variable only; this is faster than
-//!        neuron_recording_record_value for this type
+//! \brief Store a recording of a \p double variable only; this is faster than
+//!     neuron_recording_record_value() for this type
 //! \param[in] var_index: which recording variable to write this is
 //! \param[in] neuron_index: the neuron id for this recorded data
 //! \param[in] value: the results to record for this neuron.
@@ -122,8 +122,8 @@ static inline void neuron_recording_record_double(
     data[index] = value;
 }
 
-//! \brief stores a recording of a float variable only; this is faster than
-//!        neuron_recording_record_value for this type
+//! \brief Store a recording of a \p float variable only; this is faster than
+//!     neuron_recording_record_value() for this type
 //! \param[in] var_index: which recording variable to write this is
 //! \param[in] neuron_index: the neuron id for this recorded data
 //! \param[in] value: the results to record for this neuron.
@@ -134,8 +134,8 @@ static inline void neuron_recording_record_float(
     data[index] = value;
 }
 
-//! \brief stores a recording of an int32_t variable only; this is faster than
-//!        neuron_recording_record_value for this type
+//! \brief Store a recording of an \p int32_t variable only; this is faster
+//!     than neuron_recording_record_value() for this type
 //! \param[in] var_index: which recording variable to write this is
 //! \param[in] neuron_index: the neuron id for this recorded data
 //! \param[in] value: the results to record for this neuron.
@@ -146,9 +146,8 @@ static inline void neuron_recording_record_int32(
     data[index] = value;
 }
 
-
-//! \brief stores a recording of a set bit; this is the only way to set a bit
-//!        in a bitfield; neuron_recording_record_value doesn't work for this!
+//! \brief Store a recording of a set bit; this is the only way to set a bit
+//!     in a bitfield; neuron_recording_record_value() doesn't work for this!
 //! \param[in] var_index: which bitfield recording variable to write this is
 //! \param[in] neuron_index: which neuron to set the bit for
 static inline void neuron_recording_record_bit(
@@ -158,7 +157,7 @@ static inline void neuron_recording_record_bit(
     bit_field_set(bitfield_values[var_index], index);
 }
 
-//! \brief does the recording process of handing over to basic recording
+//! \brief The recording process of handing over to basic recording
 //! \param[in] time: the time to put into the recording stamps.
 static inline void neuron_recording_record(uint32_t time) {
     // go through all recordings
@@ -175,7 +174,6 @@ static inline void neuron_recording_record(uint32_t time) {
             recording_record_and_notify(
                 i - 1, rec_info->values, rec_info->size, recording_done_callback);
         } else {
-
             // Not recording this time, so increment by specified amount
             rec_info->count += rec_info->increment;
         }
@@ -199,14 +197,13 @@ static inline void neuron_recording_record(uint32_t time) {
                 i + N_RECORDED_VARS - 1, bf_info->values, bf_info->size,
                 recording_done_callback);
         } else {
-
             // Not recording this time, so increment by specified amount
             bf_info->count += bf_info->increment;
         }
     }
 }
 
-//! \brief sets up state for next recording.
+//! \brief Set up state for next recording.
 static inline void neuron_recording_setup_for_next_recording(void) {
     // Wait until recordings have completed, to ensure the recording space
     // can be re-written
@@ -223,22 +220,22 @@ static inline void neuron_recording_setup_for_next_recording(void) {
     }
 }
 
-//! \brief reads recording data from sdram on reset.
+//! \brief Read recording data from SDRAM on reset.
 //! \param[in] n_neurons: the number of neurons to setup for
-//! \return bool stating if the read was successful or not
+//! \return whether the read was successful or not
 bool neuron_recording_reset(uint32_t n_neurons);
 
-//! \brief sets up the recording stuff
-//! \param[in] recording_address: sdram location for the recording data
+//! \brief Set up the recording stuff
+//! \param[in] recording_address: SDRAM location for the recording data
 //! \param[out] recording_flags: Output of flags which can be used to check if
 //!            a channel is enabled for recording
 //! \param[in] n_neurons: the number of neurons to setup for
-//! \return bool stating if the init was successful or not
+//! \return whether the init was successful or not
 bool neuron_recording_initialise(
         void *recording_address, uint32_t *recording_flags,
         uint32_t n_neurons);
 
-//! \brief finishes recording
+//! \brief Finish recording
 void neuron_recording_finalise(void);
 
 #endif //_NEURON_RECORDING_H_

--- a/neural_modelling/src/neuron/plasticity/stdp/maths.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/maths.h
@@ -40,8 +40,7 @@
 #define MAX(X, Y)	((X) > (Y) ? (X) : (Y))
 
 //! \brief Lookup Table of 16-bit integers.
-//!
-//! Will be padded to a word boundary at the end.
+//! \details Will be padded to a word boundary at the end.
 typedef struct int16_lut {
     uint16_t size;    //!< Number of entries in table
     uint16_t shift;   //!< Mapping from time to table index
@@ -100,10 +99,9 @@ static inline int32_t maths_clamp_pot(int32_t x, uint32_t shift) {
 }
 
 //---------------------------------------
-//! \brief multiply two 16-bit numbers to get a 32-bit number.
-//!
-//! **NOTE:** this should 'encourage' GCC to insert SMULxy 16x16 multiply
-//!
+//! \brief Multiply two 16-bit numbers to get a 32-bit number.
+//! \details
+//!     **NOTE:** this should 'encourage' GCC to insert SMULxy 16x16 multiply
 //! \param[in] x: The first multiplicand
 //! \param[in] y: The first multiplicand
 //! \return The product
@@ -112,7 +110,7 @@ static inline int32_t maths_mul_16x16(int16_t x, int16_t y) {
 }
 
 //---------------------------------------
-//! \brief multiply two 16-bit fixed point numbers (encoded in int32_t)
+//! \brief Multiply two 16-bit fixed point numbers (encoded in int32_t)
 //! \param[in] a: The first multiplicand
 //! \param[in] b: The first multiplicand
 //! \param[in] fixed_point_position: The location of the fixed point
@@ -127,7 +125,7 @@ static inline int32_t maths_fixed_mul16(
 }
 
 //---------------------------------------
-//! \brief multiply two 32-bit fixed point numbers (encoded in int32_t)
+//! \brief Multiply two 32-bit fixed point numbers (encoded in int32_t)
 //! \param[in] a: The first multiplicand
 //! \param[in] b: The first multiplicand
 //! \param[in] fixed_point_position: The location of the fixed point

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -478,7 +478,7 @@ bool synapse_dynamics_remove_neuron(uint32_t offset, address_t row) {
     return true;
 }
 
-//! \brief packing all of the information into the required plastic control word
+//! \brief Pack all of the information into the required plastic control word
 //! \param[in] id: The spike ID
 //! \param[in] delay: The delay
 //! \param[in] type: The synapse type

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -270,7 +270,7 @@ bool synapse_dynamics_initialise(
 
     // Load timing dependence data
     address_t weight_region_address = timing_initialise(address);
-    if (address == NULL) {
+    if (weight_region_address == NULL) {
         return false;
     }
 

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_accumulator_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_accumulator_impl.h
@@ -31,8 +31,8 @@ typedef struct plastic_synapse_t {
     int16_t accumulator;
 } plastic_synapse_t;
 
-//! The update state is a weight state with 32-bit ARM-friendly version of the
-//! accumulator
+//! \brief The update state is a weight state with 32-bit ARM-friendly version
+//!     of the accumulator
 typedef struct update_state_t {
     //! The weight staet
     weight_state_t weight_state;

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_state_accumulator_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_state_accumulator_impl.h
@@ -23,16 +23,16 @@
 //---------------------------------------
 // Structures
 //---------------------------------------
-//! Plastic synapse contains normal 16-bit weight, a small state machine and an
-//! accumulator
+//! \brief Plastic synapse contains normal 16-bit weight, a small state machine
+//!     and an accumulator
 typedef struct plastic_synapse_t {
     weight_t weight;    //!< Weight
     int8_t accumulator; //!< Accumulator
     uint8_t state;      //!< State machine state
 } plastic_synapse_t;
 
-//! The update state is a weight state with 32-bit ARM-friendly versions of the
-//! accumulator and the state
+//! \brief The update state is a weight state with 32-bit ARM-friendly versions
+//!     of the accumulator and the state
 typedef struct update_state_t {
     weight_state_t weight_state; //!< Weight state
     int32_t accumulator;         //!< Accumulator

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_state_accumulator_window_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_structure/synapse_structure_weight_state_accumulator_window_impl.h
@@ -21,7 +21,7 @@
 #define _SYNAPSE_STRUCTURE_WEIGHT_STATE_ACCUMULATOR_WINDOW_H_
 
 //! \brief Plastic synapse contains normal 16-bit weight, a small state machine,
-//! an accumulator, and the size of the relevance window
+//!     an accumulator, and the size of the relevance window
 typedef struct plastic_synapse_t {
     unsigned int weight : 16;        //!< The weight
     int accumulator : 4;             //!< The accumulator
@@ -29,8 +29,8 @@ typedef struct plastic_synapse_t {
     unsigned int window_length : 10; //!< The window length
 } plastic_synapse_t;
 
-//! The update state is a weight state with 32-bit ARM-friendly versions of the
-//! accumulator, state and window length
+//! \brief The update state is a weight state with 32-bit ARM-friendly versions
+//!     of the accumulator, state and window length
 typedef struct update_state_t {
     weight_state_t weight_state; //!< The weight state
 

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/random_util.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/random_util.h
@@ -17,6 +17,8 @@
 
 //! \file
 //! \brief Utility function for random number generation
+//! \details Note that this function and its state are global to the included
+//!     file, but are local to that file.
 
 //! \brief **YUCK** copy and pasted RNG to allow inlining and also to avoid
 //!     horrific executable bloat.
@@ -27,7 +29,7 @@
 //! \return random number, uniformly distributed over range 0 ..
 //!     2<sup>::STDP_FIXED_POINT_ONE</sup>
 static inline int32_t mars_kiss_fixed_point(void) {
-    // **YUCK** copy and pasted rng to allow inlining and also to avoid
+    // **YUCK** copy and pasted RNG to allow inlining and also to avoid
     // horrific executable bloat
 
     /* Seed variables */

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing.h
@@ -26,7 +26,8 @@
 
 //! \brief Initialise the timing dependence state (global) from SDRAM
 //! \param[in] address: Location in SDRAM of timing data
-//! \return address of first word after the timing data
+//! \return address of first word in SDRAM after the timing data;
+//!     if NULL, the initialisation failed
 address_t timing_initialise(address_t address);
 
 //! \brief Get an initial post-synaptic timing trace

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_recurrent_common.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_recurrent_common.h
@@ -35,27 +35,27 @@
 
 #include "random_util.h"
 
-//! \brief API: Check if there was an event in the pre-window
+//! \brief Check if there was an event in the pre-window
 //! \param[in] time_since_last_event: Length of time since last event
 //! \param[in] previous_state: The state we're in right now
 //! \return True if an event is there.
 static bool timing_recurrent_in_pre_window(
         uint32_t time_since_last_event, update_state_t previous_state);
 
-//! \brief API: Check if there was an event in the post-window
+//! \brief Check if there was an event in the post-window
 //! \param[in] time_since_last_event: Length of time since last event
 //! \param[in] previous_state: The state we're in right now
 //! \return True if an event is there.
 static bool timing_recurrent_in_post_window(
         uint32_t time_since_last_event, update_state_t previous_state);
 
-//! \brief API: Update the state with the pre-window information
+//! \brief Update the state with the pre-window information
 //! \param[in] previous_state: The state we're in right now
 //! \return The new state.
 static update_state_t timing_recurrent_calculate_pre_window(
         update_state_t previous_state);
 
-//! \brief API: Update the state with the post-window information
+//! \brief Update the state with the post-window information
 //! \param[in] previous_state: The state we're in right now
 //! \return The new state.
 static update_state_t timing_recurrent_calculate_post_window(

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_recurrent_dual_fsm_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_recurrent_dual_fsm_impl.c
@@ -23,10 +23,10 @@
 // Globals
 //---------------------------------------
 //! \brief Lookup table for picking exponentially distributed random value for
-//! pre-traces
+//!     pre-traces, in DTCM
 uint16_t pre_exp_dist_lookup[STDP_FIXED_POINT_ONE];
 //! \brief Lookup table for picking exponentially distributed random value for
-//! post-traces
+//!     post-traces, in DTCM
 uint16_t post_exp_dist_lookup[STDP_FIXED_POINT_ONE];
 
 // Global plasticity parameter data

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_recurrent_pre_stochastic_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_recurrent_pre_stochastic_impl.c
@@ -52,12 +52,11 @@ address_t timing_initialise(address_t address) {
             plasticity_trace_region_data.accumulator_potentiation_minus_one + 1);
 
     // Copy LUTs from following memory
-    // Copy LUTs from following memory
-        uint32_t word_size = STDP_FIXED_POINT_ONE / 2;
-        spin1_memcpy(pre_exp_dist_lookup, &address[2],
-                STDP_FIXED_POINT_ONE * sizeof(uint16_t));
-        spin1_memcpy(post_exp_dist_lookup, &address[2 + word_size],
-                STDP_FIXED_POINT_ONE * sizeof(uint16_t));
+    uint32_t word_size = STDP_FIXED_POINT_ONE / 2;
+    spin1_memcpy(pre_exp_dist_lookup, &address[2],
+            STDP_FIXED_POINT_ONE * sizeof(uint16_t));
+    spin1_memcpy(post_exp_dist_lookup, &address[2 + word_size],
+            STDP_FIXED_POINT_ONE * sizeof(uint16_t));
 
     log_debug("timing_initialise: completed successfully");
 

--- a/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight.h
@@ -45,7 +45,8 @@
  * \param[in] ring_buffer_to_input_buffer_left_shifts: how much a value needs
  *      to be shifted in the left direction to support comprises with fixed
  *      point arithmetic
- * \return the end of the weight region as an absolute SDRAM memory address.
+ * \return the end of the weight region as an absolute SDRAM memory address;
+ *      if NULL, the initialisation failed.
  */
 address_t weight_initialise(
         address_t address, uint32_t n_synapse_types,

--- a/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight.h
@@ -38,7 +38,7 @@
 #include <neuron/synapse_row.h>
 
 /*!
- * \brief Initialises the weight aspect of an STDP rule.
+ * \brief Initialise the weight aspect of an STDP rule.
  * \param[in] address: the absolute address in SRAM where the weight parameters
  *      are stored.
  * \param[in] n_synapse_types: The number of synapse types
@@ -53,7 +53,7 @@ address_t weight_initialise(
         uint32_t *ring_buffer_to_input_buffer_left_shifts);
 
 /*!
- * \brief Gets the initial weight state.
+ * \brief Prepare the initial weight state.
  * \param[in] weight: The weight at the start
  * \param[in] synapse_type: The type of synapse involved
  * \return The initial weight state.
@@ -61,7 +61,7 @@ address_t weight_initialise(
 static weight_state_t weight_get_initial(weight_t weight, index_t synapse_type);
 
 /*!
- * \brief Gets the final weight.
+ * \brief Compute the final weight.
  * \param[in] new_state: The updated weight state
  * \return The new weight.
  */

--- a/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight_additive_one_term_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight_additive_one_term_impl.h
@@ -56,7 +56,7 @@ typedef struct {
 // STDP weight dependence functions
 //---------------------------------------
 /*!
- * \brief Gets the initial weight state.
+ * \brief Prepare the initial weight state.
  * \param[in] weight: The weight at the start
  * \param[in] synapse_type: The type of synapse involved
  * \return The initial weight state.
@@ -97,7 +97,7 @@ static inline weight_state_t weight_one_term_apply_potentiation(
 
 //---------------------------------------
 /*!
- * \brief Gets the final weight.
+ * \brief Compute the final weight.
  * \param[in] new_state: The updated weight state
  * \return The new weight.
  */

--- a/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight_additive_two_term_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight_additive_two_term_impl.h
@@ -60,7 +60,7 @@ typedef struct weight_state_t {
 // STDP weight dependence functions
 //---------------------------------------
 /*!
- * \brief Gets the initial weight state.
+ * \brief Prepare the initial weight state.
  * \param[in] weight: The weight at the start
  * \param[in] synapse_type: The type of synapse involved
  * \return The initial weight state.
@@ -107,7 +107,7 @@ static inline weight_state_t weight_two_term_apply_potentiation(
 
 //---------------------------------------
 /*!
- * \brief Gets the final weight.
+ * \brief Compute the final weight.
  * \param[in] new_state: The updated weight state
  * \return The new weight.
  */

--- a/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight_multiplicative_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/weight_dependence/weight_multiplicative_impl.h
@@ -55,7 +55,7 @@ typedef struct {
 // Weight dependance functions
 //---------------------------------------
 /*!
- * \brief Gets the initial weight state.
+ * \brief Prepare the initial weight state.
  * \param[in] weight: The weight at the start
  * \param[in] synapse_type: The type of synapse involved
  * \return The initial weight state.
@@ -113,7 +113,7 @@ static inline weight_state_t weight_one_term_apply_potentiation(
 }
 //---------------------------------------
 /*!
- * \brief Gets the final weight.
+ * \brief Compute the final weight.
  * \param[in] new_state: The updated weight state
  * \return The new weight.
  */

--- a/neural_modelling/src/neuron/plasticity/synapse_dynamics.h
+++ b/neural_modelling/src/neuron/plasticity/synapse_dynamics.h
@@ -36,7 +36,7 @@ bool synapse_dynamics_initialise(
         address_t address, uint32_t n_neurons, uint32_t n_synapse_types,
         uint32_t *ring_buffer_to_input_buffer_left_shifts);
 
-//! \brief Processes the dynamics of the synapses
+//! \brief Process the dynamics of the synapses
 //! \param[in,out] plastic_region_address: Where the plastic data is
 //! \param[in] fixed_region_address: Where the fixed data is
 //! \param[in,out] ring_buffers: The ring buffers
@@ -46,7 +46,7 @@ bool synapse_dynamics_process_plastic_synapses(
         address_t plastic_region_address, address_t fixed_region_address,
         weight_t *ring_buffers, uint32_t time);
 
-//! \brief Informs the synapses that the neuron fired
+//! \brief Inform the synapses that the neuron fired
 //! \param[in] time: The current simulation time
 //! \param[in] neuron_index: Which neuron are we processing
 void synapse_dynamics_process_post_synaptic_event(
@@ -68,12 +68,13 @@ void synapse_dynamics_print_plastic_synapses(
         address_t plastic_region_address, address_t fixed_region_address,
         uint32_t *ring_buffer_to_input_buffer_left_shifts);
 
-//! \brief returns the counters for plastic pre synaptic events based on (if
-//!     the model was compiled with SYNAPSE_BENCHMARK parameter) or returns 0
+//! \brief Get the counters for plastic pre-synaptic events based on (if
+//!     the model was compiled with `SYNAPSE_BENCHMARK` parameter defined) or
+//!     returns 0
 //! \return counters for plastic pre synaptic events or 0
 uint32_t synapse_dynamics_get_plastic_pre_synaptic_events(void);
 
-//! \brief returns the number of ring buffer saturation events due to adding
+//! \brief Get the number of ring buffer saturation events due to adding
 //!     plastic weights.
 //! \return counter for saturation events or 0
 uint32_t synapse_dynamics_get_plastic_saturation_count(void);
@@ -82,7 +83,7 @@ uint32_t synapse_dynamics_get_plastic_saturation_count(void);
 // Synaptic rewiring functions
 //-----------------------------------------------------------------------------
 
-//! \brief Searches the synaptic row for the the connection with the
+//! \brief Search the synaptic row for the the connection with the
 //!     specified post-synaptic ID
 //! \param[in] id: the (core-local) ID of the neuron to search for in the
 //!     synaptic row

--- a/neural_modelling/src/neuron/plasticity/synapse_dynamics_static_impl.c
+++ b/neural_modelling/src/neuron/plasticity/synapse_dynamics_static_impl.c
@@ -151,7 +151,7 @@ bool synapse_dynamics_remove_neuron(uint32_t offset, address_t row) {
     return true;
 }
 
-//! packing all of the information into the required static control word
+//! Pack all of the information into the required static control word
 static inline uint32_t _fixed_synapse_convert(
         uint32_t id, weight_t weight, uint32_t delay, uint32_t type) {
     uint32_t new_synapse = weight << (32 - SYNAPSE_WEIGHT_BITS);

--- a/neural_modelling/src/neuron/population_table/population_table.h
+++ b/neural_modelling/src/neuron/population_table/population_table.h
@@ -25,15 +25,15 @@
 #include <common/neuron-typedefs.h>
 #include <bit_field.h>
 
-//! \brief Sets up the table
+//! \brief Set up the table
 //! \param[in] table_address: The address of the start of the table data
-//! \param[in] synapse_rows_address: The address of the start of the synapse
-//!                                  data
-//! \param[in] direct_rows_address: The address of the start of the direct
-//!                                 synapse data
-//! \param[out] row_max_n_words: Updated with the maximum length of any row in
-//!                              the table in words
-//! \return True if the table was initialised successfully, False otherwise
+//! \param[in] synapse_rows_address:
+//!     The address of the start of the synapse data
+//! \param[in] direct_rows_address:
+//!     The address of the start of the direct synapse data
+//! \param[out] row_max_n_words:
+//!     Updated with the maximum length of any row in the table in words
+//! \return True if the table was initialised successfully, false otherwise
 bool population_table_initialise(
         address_t table_address, address_t synapse_rows_address,
         address_t direct_rows_address, uint32_t *row_max_n_words);
@@ -41,8 +41,9 @@ bool population_table_initialise(
 //! \brief Get the first row data for the given input spike
 //! \param[in] spike: The spike received
 //! \param[out] row_address: Updated with the address of the row
-//! \param[out] n_bytes_to_transfer: Updated with the number of bytes to read
-//! \return True if there is a row to read, False if not
+//! \param[out] n_bytes_to_transfer: Updated with the number of bytes to read;
+//!     zero means that the address is actually a direct row address.
+//! \return True if there is a row to read, false if not
 bool population_table_get_first_address(
         spike_t spike, address_t* row_address, size_t* n_bytes_to_transfer);
 
@@ -52,19 +53,20 @@ bool population_table_get_first_address(
 int population_table_position_in_the_master_pop_array(spike_t spike);
 
 //! \brief Get the next row data for a previously given spike.  If no spike has
-//!        been given, return False.
+//!     been given, return False.
 //! \param[out] spike: The initiating spike
 //! \param[out] row_address: Updated with the address of the row
-//! \param[out] n_bytes_to_transfer: Updated with the number of bytes to read
-//! \return True if there is a row to read, False if not
+//! \param[out] n_bytes_to_transfer: Updated with the number of bytes to read;
+//!     zero means that the address is actually a direct row address.
+//! \return True if there is a row to read, false if not
 bool population_table_get_next_address(
         spike_t *spike, address_t* row_address, size_t* n_bytes_to_transfer);
 
-//! \brief Reports how many DMAs were pointless
+//! \brief Report how many DMAs were pointless
 //! \return How many were done that were not required
 uint32_t population_table_get_ghost_pop_table_searches(void);
 
-//! \brief Sets the connectivity lookup map.
+//! \brief Set the connectivity lookup map.
 //! \param[in] connectivity_bit_fields: the connectivity lookup bitfield
 void population_table_set_connectivity_bit_field(
         bit_field_t* connectivity_bit_fields);
@@ -73,7 +75,7 @@ void population_table_set_connectivity_bit_field(
 //! \return the number of master pop table key misses
 uint32_t population_table_get_invalid_master_pop_hits(void);
 
-//! \brief Clears the DTCM allocated by the population table.
+//! \brief Clear the DTCM allocated by the population table.
 //! \return If the clearing was successful or not.
 bool population_table_shut_down(void);
 

--- a/neural_modelling/src/neuron/population_table/population_table_binary_search_impl.c
+++ b/neural_modelling/src/neuron/population_table/population_table_binary_search_impl.c
@@ -104,9 +104,8 @@ static inline uint32_t get_direct_address(address_and_row_length entry) {
 }
 
 //! \brief Get the standard address out of an entry
-//!
-//! The address is in units of four words, so this multiplies by 16 (= up
-//! shifts by 4)
+//! \details The address is in units of four words, so this multiplies by 16
+//!     (= up shifts by 4)
 //! \param[in] entry: the table entry
 //! \return a row address
 static inline uint32_t get_address(address_and_row_length entry) {
@@ -137,9 +136,8 @@ static inline uint32_t get_neuron_id(
     return spike & ~entry.mask;
 }
 
-//! \brief Prints the master pop table.
-//!
-//! For debugging
+//! \brief Print the master pop table.
+//! \details For debugging
 static inline void print_master_population_table(void) {
     log_info("master_population\n");
     for (uint32_t i = 0; i < master_population_table_length; i++) {

--- a/neural_modelling/src/neuron/spike_processing.c
+++ b/neural_modelling/src/neuron/spike_processing.c
@@ -26,8 +26,8 @@
 #include <simulation.h>
 #include <debug.h>
 
-//! DMA buffer structure combines the row read from SDRAM with information
-//! about the read.
+//! \brief DMA buffer structure combines the row read from SDRAM with
+//!     information about the read.
 typedef struct dma_buffer {
     //! Address in SDRAM to write back plastic region to
     address_t sdram_writeback_address;
@@ -69,21 +69,23 @@ static uint32_t next_buffer_to_fill;
 //! The index of the buffer currently being filled by a DMA read
 static uint32_t buffer_being_read;
 
-//! Number of outstanding synaptogenic rewirings
+//! The number of outstanding synaptogenic rewirings
 static volatile uint32_t rewires_to_do = 0;
 
-//! The number of rewires to do when the DMA completes.  When a DMA is first set
-//! up, only this or dma_n_spikes can be 1 with the other being 0.
+//! \brief The number of rewires to do when the DMA completes.
+//! \details When a DMA is first set up, only this or ::dma_n_spikes can be 1
+//!     with the other being 0.
 static uint32_t dma_n_rewires;
 
-//! The number of spikes to do when the DMA completes.  When a DMA is first set
-//! up, only this or dma_n_rewires can be 1 with the other being 0.
+//! \brief The number of spikes to do when the DMA completes.
+//! \details When a DMA is first set up, only this or ::dma_n_rewires can be 1
+//!     with the other being 0.
 static uint32_t dma_n_spikes;
 
-//! the number of dma completes (used in provenance generation)
+//! The number of DMA completes (used in provenance generation)
 static uint32_t dma_complete_count = 0;
 
-//! the number of spikes that were processed (used in provenance generation)
+//! The number of spikes that were processed (used in provenance generation)
 static uint32_t spike_processing_count = 0;
 
 //! The number of successful rewires
@@ -427,7 +429,7 @@ uint32_t spike_processing_get_spike_processing_count(void) {
     return spike_processing_count;
 }
 
-//! \brief get the address of the circular buffer used for buffering received
+//! \brief Get the address of the circular buffer used for buffering received
 //!     spikes before processing them
 //! \return address of circular buffer
 circular_buffer get_circular_buffer(void) { // EXPORTED

--- a/neural_modelling/src/neuron/spike_processing.h
+++ b/neural_modelling/src/neuron/spike_processing.h
@@ -35,29 +35,29 @@ bool spike_processing_initialise(
         size_t row_max_n_bytes, uint mc_packet_callback_priority,
         uint user_event_priority, uint incoming_spike_buffer_size);
 
-//! \brief Gets the number of times the input buffer has overflowed
+//! \brief Get the number of times the input buffer has overflowed
 //! \return the number of times the input buffer has overflowed
 uint32_t spike_processing_get_buffer_overflows(void);
 
-//! \brief Gets the number of ghost searches of the master population table
+//! \brief Get the number of ghost searches of the master population table
 //!     that occurred
 //! \return the number of times a ghost search occurred.
 uint32_t spike_processing_get_ghost_pop_table_searches(void);
 
-//! \brief Gets the number of DMA's that were completed
+//! \brief Get the number of DMA's that were completed
 //! \return the number of DMA's that were completed.
 uint32_t spike_processing_get_dma_complete_count(void);
 
-//! \brief Gets the number of spikes that were processed
+//! \brief Get the number of spikes that were processed
 //! \return the number of spikes that were processed
 uint32_t spike_processing_get_spike_processing_count(void);
 
-//! \brief Gets the number of master population table searches that failed to
+//! \brief Get the number of master population table searches that failed to
 //!     find a hit.
 //! \return the number of times a spike did not have a master pop table entry
 uint32_t spike_processing_get_invalid_master_pop_table_hits(void);
 
-//! \brief Gets the number of successful rewires performed
+//! \brief Get the number of successful rewires performed
 //! \return the number of successful rewires
 uint32_t spike_processing_get_successful_rewires(void);
 

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/elimination/elimination_random_by_weight_impl.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/elimination/elimination_random_by_weight_impl.h
@@ -24,12 +24,14 @@
 
 //! Configuration of synapse elimination rule
 struct elimination_params {
-    //! Probability of elimination of depressed synapse
+    //! Probability of elimination of depressed synapse;
+    //! ::u032 in integer form
     uint32_t prob_elim_depression;
-    //! Probability of elimination of potentiated synapse
+    //! Probability of elimination of potentiated synapse;
+    //! ::u032 in integer form
     uint32_t prob_elim_potentiation;
-    //! Threshold below which a synapse is depressed, and above which it is
-    //! potentiated
+    //! Threshold weight below which a synapse is depressed, and above which it
+    //! is potentiated
     uint32_t threshold;
 };
 
@@ -38,7 +40,7 @@ struct elimination_params {
 //! \param[in] params: The elimination rule configuration.
 //! \param[in] time: Time of elimination
 //! \param[in,out] row: The row to eliminate from
-//! \return if row was modified
+//! \return whether the row was modified
 static inline bool synaptogenesis_elimination_rule(
         current_state_t *restrict current_state,
         const elimination_params_t *params,
@@ -47,16 +49,17 @@ static inline bool synaptogenesis_elimination_rule(
 
     uint32_t random_number = mars_kiss64_seed(*(current_state->local_seed));
 
-    // Is weight depressed?
-    if (current_state->weight < params->threshold &&
-            random_number > params->prob_elim_depression) {
-        return false;
-    }
-
-    // Is weight potentiated or unchanged?
-    if (current_state->weight >= params->threshold &&
-            random_number > params->prob_elim_potentiation) {
-        return false;
+    // Test whether we should not eliminate any
+    if (current_state->weight < params->threshold) {
+        // Weight is depressed
+        if (random_number > params->prob_elim_depression) {
+            return false;
+        }
+    } else {
+        // Weight potentiated or unchanged
+        if (random_number > params->prob_elim_potentiation) {
+            return false;
+        }
     }
 
     return sp_structs_remove_synapse(current_state, row);

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/last_neuron_selection_impl.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/last_neuron_selection_impl.h
@@ -33,7 +33,7 @@ extern spike_t* last_spikes_buffer[2];
 //! \details Two counters, one for current timestep, one for previous
 extern uint32_t n_spikes[2];
 
-//! \brief Notifies the rule that a spike has been received
+//! \brief Notify the rule that a spike has been received
 //! \param[in] time: The time that the spike was received at
 //! \param[in] spike:
 //!     The spike that was received (includes the sending neuron ID)
@@ -61,7 +61,7 @@ static inline void partner_spike_received(uint32_t time, spike_t spike) {
 //! \param[out] neuron_id: The ID of the neuron within the subpopulation
 //! \param[out] spike: The spike that made this a meaningful choice
 //! \param[out] m_pop_index: The master population table index
-//! \return True if a choice was made
+//! \return Whether a choice was made
 static inline bool potential_presynaptic_partner(
         uint32_t time, uint32_t *restrict population_id,
         uint32_t *restrict sub_population_id, uint32_t *restrict neuron_id,

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/partner.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/partner.h
@@ -40,7 +40,7 @@
 //!     configuration data.
 void partner_init(uint8_t **data);
 
-//! \brief Notifies the rule that a spike has been received
+//! \brief Notify the rule that a spike has been received
 //! \param[in] time: The time that the spike was received at
 //! \param[in] spike:
 //!     The spike that was received (includes the sending neuron ID)
@@ -54,7 +54,7 @@ static inline void partner_spike_received(uint32_t time, spike_t spike);
 //! \param[out] neuron_id: The ID of the neuron within the subpopulation
 //! \param[out] spike: The spike that made this a meaningful choice
 //! \param[out] m_pop_index: The master population table index
-//! \return True if a choice was made
+//! \return Whether a choice was made
 static inline bool potential_presynaptic_partner(
         uint32_t time, uint32_t *restrict population_id,
         uint32_t *restrict sub_population_id,

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/random_selection_impl.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/partner_selection/random_selection_impl.h
@@ -24,7 +24,7 @@
 #include <neuron/spike_processing.h>
 #include <debug.h>
 
-//! \brief Notifies the rule that a spike has been received
+//! \brief Notify the rule that a spike has been received
 //! \details Not used by this rule
 //! \param[in] time: The time that the spike was received at
 //! \param[in] spike:
@@ -43,7 +43,7 @@ static inline void partner_spike_received(uint32_t time, spike_t spike) {
 //! \param[out] spike: The spike that made this a meaningful choice.
 //!     This rule synthesises this.
 //! \param[out] m_pop_index: The master population table index.
-//! \return True if a choice was made
+//! \return Whether a choice was made
 static inline bool potential_presynaptic_partner(
         uint32_t time, uint32_t *restrict population_id,
         uint32_t *restrict sub_population_id, uint32_t *restrict neuron_id,

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
@@ -109,15 +109,16 @@ typedef struct {
     uint32_t synapse_type;
 } current_state_t;
 
-//! Get a random unsigned integer up to (but not including) a given maximum
-//! \param[in] max The maximum value allowed
-//! \param[in] seed The random seed to use
+//! \brief Get a random unsigned integer up to (but not including) a given
+//!     maximum
+//! \param[in] max: The maximum value allowed
+//! \param[in] seed: The random seed to use
 //! \return The generated value
 static inline uint32_t rand_int(uint32_t max, mars_kiss64_seed_t seed) {
     return muliulr(max, ulrbits(mars_kiss64_seed(seed)));
 }
 
-//! \brief unpack the spike into key and identifying information for the
+//! \brief Unpack the spike into key and identifying information for the
 //!     neuron; Identify pop, sub-population and low and high atoms
 //! \param[in] pre_pop_info_table: The prepopulation information table
 //! \param[in] spike: The spike to look up the information from
@@ -181,7 +182,7 @@ static inline bool sp_structs_get_sub_pop_info(
     return false;
 }
 
-//! \brief Removes a synapse from the relevant structures
+//! \brief Remove a synapse from the relevant structures
 //! \param[in,out] current_state: Describes what is to be done
 //! \param[in,out] row: The row of the synaptic matrix to be updated
 //! \return True if the synapse was removed
@@ -194,7 +195,7 @@ static inline bool sp_structs_remove_synapse(
     return true;
 }
 
-//! \brief Adds a synapse to the relevant structures
+//! \brief Add a synapse to the relevant structures
 //! \param[in,out] current_state: Describes what is to be done
 //! \param[in,out] row: The row of the synaptic matrix to be updated
 //! \return True if the synapse was added

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis_dynamics.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis_dynamics.h
@@ -27,7 +27,7 @@
 
 #include <common/neuron-typedefs.h>
 
-//! \brief Initialisation of synaptic rewiring (synaptogenesis)
+//! \brief Initialise synaptic rewiring (synaptogenesis)
 //!     parameters (random seed, spread of receptive field etc.)
 //! \param[in] sdram_sp_address: Address of the start of the SDRAM region
 //!     which contains synaptic rewiring params.
@@ -35,8 +35,8 @@
 bool synaptogenesis_dynamics_initialise(
         address_t sdram_sp_address);
 
-//! \brief Function called (usually on a timer from c_main()) to
-//!     trigger the process of synaptic rewiring
+//! \brief Trigger the process of synaptic rewiring
+//! \details Usually called on a timer registered in c_main()
 //! \param[in] time: the current timestep
 //! \param[out] spike: variable to hold the spike
 //! \param[out] synaptic_row_address: variable to hold the address of the row
@@ -45,30 +45,30 @@ bool synaptogenesis_dynamics_initialise(
 bool synaptogenesis_dynamics_rewire(uint32_t time,
         spike_t *spike, address_t *synaptic_row_address, uint32_t *n_bytes);
 
-//! \brief Performs the actual restructuring of a row
+//! \brief Perform the actual restructuring of a row
 //! \param[in] time: The time of the restructure
 //! \param[in] row: The row to restructure
 //! \return True if the row was changed and needs to be written back
 bool synaptogenesis_row_restructure(uint32_t time, address_t row);
 
-//! \brief retrieve the period of rewiring
+//! \brief Get the period of rewiring
 //! \return Based on synaptogenesis_is_fast(), this can either be how many times
 //!     rewiring happens in a timestep, or how many timesteps have to pass until
 //!     rewiring happens.
 int32_t synaptogenesis_rewiring_period(void);
 
-//! \brief controls whether rewiring is attempted multiple times per timestep
+//! \brief Get whether rewiring is attempted multiple times per timestep
 //!     or after a number of timesteps.
 //! \return true if the result of synaptogenesis_rewiring_period() is the number
 //!     of attempts to try per timestep.
 bool synaptogenesis_is_fast(void);
 
-//! Indicates that a spike has been received
+//! \brief Indicate that a spike has been received
 //! \param[in] time: The time that the spike was received at
 //! \param[in] spike: The received spike
 void synaptogenesis_spike_received(uint32_t time, spike_t spike);
 
-//! Prints a certain data object
+//! Print a certain data object
 void print_post_to_pre_entry(void);
 
 #endif // _SYNAPTOGENESIS_DYNAMICS_H_

--- a/neural_modelling/src/neuron/synapse_row.h
+++ b/neural_modelling/src/neuron/synapse_row.h
@@ -118,49 +118,49 @@ typedef uint16_t control_t;
 //! Number of header words per synaptic row
 #define N_SYNAPSE_ROW_HEADER_WORDS 3
 
-//! \brief Returns the size of the plastic region
+//! \brief Get the size of the plastic region
 //! \param[in] row: The synaptic row
 //! \return The size of the plastic region of the row
 static inline size_t synapse_row_plastic_size(address_t row) {
     return (size_t) row[0];
 }
 
-//! \brief Returns the address of the plastic region
+//! \brief Get the address of the plastic region
 //! \param[in] row: The synaptic row
 //! \return Address of the plastic region of the row
 static inline address_t synapse_row_plastic_region(address_t row) {
     return (address_t) &row[1];
 }
 
-//! \brief Returns the address of the non-plastic (or fixed) region
+//! \brief Get the address of the non-plastic (or fixed) region
 //! \param[in] row: The synaptic row
 //! \return Address of the fixed region of the row
 static inline address_t synapse_row_fixed_region(address_t row) {
     return (address_t) &row[synapse_row_plastic_size(row) + 1];
 }
 
-//! \brief The number of fixed synapses in the row
+//! \brief Get the number of fixed synapses in the row
 //! \param[in] fixed: The fixed region of the synaptic row
 //! \return Size of the fixed region of the row (in words)
 static inline size_t synapse_row_num_fixed_synapses(address_t fixed) {
     return (size_t) fixed[0];
 }
 
-//! \brief The number of plastic controls in the row
+//! \brief Get the number of plastic controls in the row
 //! \param[in] fixed: The fixed region of the synaptic row
 //! \return Size of the fixed-plastic region of the row (in _half_ words)
 static inline size_t synapse_row_num_plastic_controls(address_t fixed) {
     return (size_t) fixed[1];
 }
 
-//! \brief The array of plastic controls in the row
+//! \brief Get the array of plastic controls in the row
 //! \param[in] fixed: The fixed region of the synaptic row
 //! \return Address of the fixed-plastic region of the row
 static inline control_t* synapse_row_plastic_controls(address_t fixed) {
     return (control_t*) &fixed[2 + synapse_row_num_fixed_synapses(fixed)];
 }
 
-//! \brief The array of fixed weights in the row
+//! \brief Get the array of fixed weights in the row
 //! \param[in] fixed: The fixed region of the synaptic row
 //! \return Address of the fixed-fixed region of the row
 static inline uint32_t *synapse_row_fixed_weight_controls(address_t fixed) {

--- a/neural_modelling/src/neuron/synapse_types/synapse_types.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types.h
@@ -34,15 +34,15 @@ typedef struct synapse_param_t synapse_param_t;
 //! to a synapse type parameter struct
 typedef synapse_param_t *synapse_param_pointer_t;
 
-//! \brief decays the stuff thats sitting in the input buffers
-//! as these have not yet been processed and applied to the neuron.
-//!
-//! This is to compensate for the valve behaviour of a synapse
-//! in biology (spike goes in, synapse opens, then closes slowly).
+//! \brief Decay the stuff thats sitting in the input buffers
+//!     as these have not yet been processed and applied to the neuron.
+//! \details
+//!     This is to compensate for the valve behaviour of a synapse
+//!     in biology (spike goes in, synapse opens, then closes slowly).
 //! \param[in,out] parameters: the parameters to update
 static void synapse_types_shape_input(synapse_param_t *parameters);
 
-//! \brief adds the inputs for a give timer period to a given neuron that is
+//! \brief Add the inputs for a give timer period to a given neuron that is
 //!     being simulated by this model
 //! \param[in] synapse_type_index: the type of input that this input is to be
 //!     considered (aka excitatory or inhibitory etc)
@@ -52,37 +52,37 @@ static void synapse_types_add_neuron_input(
         index_t synapse_type_index, synapse_param_t *parameters,
         input_t input);
 
-//! \brief extracts the excitatory input buffers from the buffers available
+//! \brief Extract the excitatory input buffers from the buffers available
 //!     for a given neuron ID
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of excitatory input buffers for a given neuron ID.
 static input_t* synapse_types_get_excitatory_input(
         synapse_param_t *parameters);
 
-//! \brief extracts the inhibitory input buffers from the buffers available
+//! \brief Extract the inhibitory input buffers from the buffers available
 //!     for a given neuron ID
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of inhibitory input buffers for a given neuron ID.
 static input_t* synapse_types_get_inhibitory_input(
         synapse_param_t *parameters);
 
-//! \brief returns a human readable character for the type of synapse.
-//!
-//! Examples would be `X` = excitatory types, `I` = inhibitory types, etc.
-//!
+//! \brief Get a human readable indicator for the type of synapse.
+//! \details
+//!     Examples would be `X` = excitatory types, `I` = inhibitory types, etc.
 //! \param[in] synapse_type_index: the synapse type index
 //!     (there is a specific index interpretation in each synapse type)
-//! \return a human readable character representing the synapse type.
+//! \return a human readable short string representing the synapse type.
 static const char *synapse_types_get_type_char(index_t synapse_type_index);
 
-//! \brief prints the parameters of the synapse type
+//! \brief Print the parameters of the synapse type
 //! \param[in] parameters: the pointer to the parameters to print
 static void synapse_types_print_parameters(
         synapse_param_t *parameters);
 
-//! \brief prints the input for a neuron ID given the available inputs
-//!     currently only executed when the models are in debug mode, as the prints
-//!     are controlled from the synapses.c print_inputs() method.
+//! \brief Print the input for a neuron ID given the available inputs
+//! \details
+//!     Currently only executed when the models are in debug mode, as the
+//!     print are controlled from the synapses.c print_inputs() method.
 //! \param[in] parameters: the pointer to the parameters to print
 static void synapse_types_print_input(synapse_param_t *parameters);
 

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_alpha_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_alpha_impl.h
@@ -75,7 +75,7 @@ typedef enum {
 // Synapse shaping inline implementation
 //---------------------------------------
 
-//! \brief Applies alpha shaping to a parameter
+//! \brief Apply alpha shaping to a parameter
 //! \param[in,out] a_params: The parameter to shape
 static inline void alpha_shaping(alpha_params_t* a_params) {
     a_params->lin_buff = a_params->lin_buff + (
@@ -85,13 +85,12 @@ static inline void alpha_shaping(alpha_params_t* a_params) {
     a_params->exp_buff = decay_s1615(a_params->exp_buff, a_params->decay);
 }
 
-//! \brief decays the stuff thats sitting in the input buffers as these have not
+//! \brief Decay the stuff thats sitting in the input buffers as these have not
 //!     yet been processed and applied to the neuron.
-//!
-//! This is to compensate for the valve behaviour of a synapse in biology
-//! (spike goes in, synapse opens, then closes slowly)
-//! plus the leaky aspect of a neuron.
-//!
+//! \details
+//!     This is to compensate for the valve behaviour of a synapse in biology
+//!     (spike goes in, synapse opens, then closes slowly)
+//!     plus the leaky aspect of a neuron.
 //! \param[in,out] parameters: the parameters to update
 static inline void synapse_types_shape_input(
 		synapse_param_t *parameters) {
@@ -105,8 +104,7 @@ static inline void synapse_types_shape_input(
 #endif
 }
 
-//! \brief helper function to add input for a given timer period to a given
-//!     neuron
+//! \brief Add input for a given timer period to a given neuron
 //! \param[in] a_params: the parameter to update
 //! \param[in] input: the input to add.
 static inline void add_input_alpha(alpha_params_t *a_params, input_t input) {
@@ -120,7 +118,7 @@ static inline void add_input_alpha(alpha_params_t *a_params, input_t input) {
             * (ONE - ONE/a_params->exp_buff);
 }
 
-//! \brief adds the inputs for a give timer period to a given neuron that is
+//! \brief Add the inputs for a give timer period to a given neuron that is
 //!     being simulated by this model
 //! \details Add input from ring buffer. Zero if no spikes, otherwise one or
 //!     more weights
@@ -143,7 +141,7 @@ static inline void synapse_types_add_neuron_input(
     }
 }
 
-//! \brief extracts the excitatory input buffers from the buffers available
+//! \brief Extract the excitatory input buffers from the buffers available
 //!     for a given neuron ID
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of excitatory input buffers for a given neuron ID.
@@ -154,7 +152,7 @@ static inline input_t* synapse_types_get_excitatory_input(
     return &excitatory_response[0];
 }
 
-//! \brief extracts the inhibitory input buffers from the buffers available
+//! \brief Extract the inhibitory input buffers from the buffers available
 //!     for a given neuron ID
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of inhibitory input buffers for a given neuron ID.
@@ -165,7 +163,7 @@ static inline input_t* synapse_types_get_inhibitory_input(
     return &inhibitory_response[0];
 }
 
-//! \brief returns a human readable character for the type of synapse.
+//! \brief Get a human readable character for the type of synapse.
 //! \details Examples would be `X` = excitatory types, `I` = inhibitory types,
 //!     etc.
 //! \param[in] synapse_type_index: the synapse type index
@@ -184,7 +182,7 @@ static inline const char *synapse_types_get_type_char(
     }
 }
 
-//! \brief prints the input for a neuron ID given the available inputs
+//! \brief Print the input for a neuron ID given the available inputs
 //!     currently only executed when the models are in debug mode, as the prints
 //!     are controlled from the synapses.c print_inputs() method.
 //! \param[in] parameters: the pointer to the parameters to print
@@ -195,7 +193,7 @@ static inline void synapse_types_print_input(
             parameters->inh.lin_buff * parameters->inh.exp_buff);
 }
 
-//! \brief prints the parameters of the synapse type
+//! \brief Print the synapse type model parameters
 //! \param[in] parameters: the pointer to the parameters to print
 static inline void synapse_types_print_parameters(synapse_param_t *parameters) {
     log_debug("-------------------------------------\n");

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_delta_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_delta_impl.h
@@ -17,7 +17,7 @@
 
 /*!
  * \file
- * \brief implementation of synapse_types.h for a delta decay to synapses.
+ * \brief Implementation of synapse_types.h for a delta decay to synapses.
  *
  * If we have combined excitatory/inhibitory synapses it will be
  * because both excitatory and inhibitory synaptic time-constants
@@ -76,7 +76,7 @@ typedef enum {
 // Synapse shaping inline implementation
 //---------------------------------------
 
-//! \brief Decays the stuff thats sitting in the input buffers.
+//! \brief Decay the stuff thats sitting in the input buffers.
 //! \details
 //!     In this case, a delta shape means returning the value to zero
 //!     immediately.
@@ -85,13 +85,12 @@ static inline void delta_shaping(delta_params_t *delta_param) {
 	delta_param->synaptic_input_value = 0;
 }
 
-//! \brief decays the stuff thats sitting in the input buffers as these have not
+//! \brief Decay the stuff thats sitting in the input buffers as these have not
 //!     yet been processed and applied to the neuron.
-//!
-//! This is to compensate for the valve behaviour of a synapse in biology
-//! (spike goes in, synapse opens, then closes slowly)
-//! plus the leaky aspect of a neuron.
-//!
+//! \details
+//!     This is to compensate for the valve behaviour of a synapse in biology
+//!     (spike goes in, synapse opens, then closes slowly)
+//!     plus the leaky aspect of a neuron.
 //! \param[in,out] parameters: the pointer to the parameters to use
 static inline void synapse_types_shape_input(
         synapse_param_t *parameters) {
@@ -99,8 +98,7 @@ static inline void synapse_types_shape_input(
 	delta_shaping(&parameters->inh);
 }
 
-//! \brief helper function to add input for a given timer period to a given
-//!     neuron
+//! \brief Add input for a given timer period to a given neuron
 //! \param[in,out] delta_param: the parameter to update
 //! \param[in] input: the input to add.
 static inline void add_input_delta(
@@ -108,7 +106,7 @@ static inline void add_input_delta(
 	delta_param->synaptic_input_value += input;
 }
 
-//! \brief adds the inputs for a give timer period to a given neuron that is
+//! \brief Add the inputs for a give timer period to a given neuron that is
 //!     being simulated by this model
 //! \param[in] synapse_type_index the type of input that this input is to be
 //!     considered (aka excitatory or inhibitory etc)
@@ -127,7 +125,7 @@ static inline void synapse_types_add_neuron_input(
     }
 }
 
-//! \brief extracts the excitatory input buffers from the buffers available
+//! \brief Extract the excitatory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
@@ -137,7 +135,7 @@ static inline input_t *synapse_types_get_excitatory_input(
     return &excitatory_response[0];
 }
 
-//! \brief extracts the inhibitory input buffers from the buffers available
+//! \brief Extract the inhibitory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
@@ -147,8 +145,9 @@ static inline input_t *synapse_types_get_inhibitory_input(
     return &inhibitory_response[0];
 }
 
-//! \brief returns a human readable character for the type of synapse.
-//!     examples would be X = excitatory types, I = inhibitory types etc etc.
+//! \brief Get a human readable character for the type of synapse.
+//! \details
+//!     Examples would be `X` = excitatory types, `I` = inhibitory types, etc.
 //! \param[in] synapse_type_index: the synapse type index
 //!     (there is a specific index interpretation in each synapse type)
 //! \return a human readable character representing the synapse type.
@@ -165,7 +164,7 @@ static inline const char *synapse_types_get_type_char(
     }
 }
 
-//! \brief prints the input for a neuron ID given the available inputs
+//! \brief Print the input for a neuron ID given the available inputs
 //!     currently only executed when the models are in debug mode, as the prints
 //!     are controlled from the synapses.c print_inputs() method.
 //! \param[in] parameters: the pointer to the parameters to use
@@ -176,7 +175,7 @@ static inline void synapse_types_print_input(
             parameters->inh.synaptic_input_value);
 }
 
-//! \brief printer call
+//! \brief Print the synapse type model parameters
 //! \param[in] parameters: the pointer to the parameters to print
 static inline void synapse_types_print_parameters(
         synapse_param_t *parameters) {

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_dual_excitatory_exponential_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_dual_excitatory_exponential_impl.h
@@ -79,7 +79,7 @@ typedef enum {
 // Synapse shaping inline implementation
 //---------------------------------------
 
-//! \brief Shapes a single parameter
+//! \brief Shape a single parameter
 //! \param[in,out] exp_param: The parameter to shape
 static inline void exp_shaping(exp_params_t *exp_param) {
     // decay value according to decay constant
@@ -87,13 +87,12 @@ static inline void exp_shaping(exp_params_t *exp_param) {
 			decay_s1615(exp_param->synaptic_input_value, exp_param->decay);
 }
 
-//! \brief decays the stuff thats sitting in the input buffers as these have not
-//! yet been processed and applied to the neuron.
-//!
-//! This is to compensate for the valve behaviour of a synapse in biology (spike
-//! goes in, synapse opens, then closes slowly) plus the leaky aspect of a
-//! neuron.
-//!
+//! \brief Decay the stuff thats sitting in the input buffers as these have not
+//!     yet been processed and applied to the neuron.
+//! \details
+//!     This is to compensate for the valve behaviour of a synapse in biology
+//!     (spike goes in, synapse opens, then closes slowly) plus the leaky
+//!     aspect of a neuron.
 //! \param[in,out] parameters: the parameters to update
 static inline void synapse_types_shape_input(synapse_param_t *parameters) {
 	exp_shaping(&parameters->exc);
@@ -101,8 +100,7 @@ static inline void synapse_types_shape_input(synapse_param_t *parameters) {
 	exp_shaping(&parameters->inh);
 }
 
-//! \brief helper function to add input for a given timer period to a given
-//!     neuron
+//! \brief Add input for a given timer period to a given neuron
 //! \param[in,out] exp_param: the parameter to be updated
 //! \param[in] input: the input to add.
 static inline void add_input_exp(exp_params_t *exp_param, input_t input) {
@@ -110,7 +108,7 @@ static inline void add_input_exp(exp_params_t *exp_param, input_t input) {
 			decay_s1615(input, exp_param->init);
 }
 
-//! \brief adds the inputs for a give timer period to a given neuron that is
+//! \brief Add the inputs for a give timer period to a given neuron that is
 //!     being simulated by this model
 //! \param[in] synapse_type_index: the type of input that this input is to be
 //!     considered (aka excitatory or inhibitory etc)
@@ -132,7 +130,7 @@ static inline void synapse_types_add_neuron_input(
     }
 }
 
-//! \brief extracts the excitatory input buffers from the buffers available
+//! \brief Extract the excitatory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
@@ -143,7 +141,7 @@ static inline input_t* synapse_types_get_excitatory_input(
     return &excitatory_response[0];
 }
 
-//! \brief extracts the inhibitory input buffers from the buffers available
+//! \brief Extract the inhibitory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
@@ -153,11 +151,12 @@ static inline input_t* synapse_types_get_inhibitory_input(
     return &inhibitory_response[0];
 }
 
-//! \brief returns a human readable character for the type of synapse.
-//!     examples would be X = excitatory types, I = inhibitory types etc etc.
+//! \brief Get a human readable string for the type of synapse.
+//! \details
+//!     Examples would be `X` = excitatory types, `I` = inhibitory types, etc.
 //! \param[in] synapse_type_index: the synapse type index
 //!     (there is a specific index interpretation in each synapse type)
-//! \return a human readable character representing the synapse type.
+//! \return a human readable short string representing the synapse type.
 static inline const char *synapse_types_get_type_char(
         index_t synapse_type_index) {
     switch (synapse_type_index) {
@@ -173,7 +172,7 @@ static inline const char *synapse_types_get_type_char(
     }
 }
 
-//! \brief prints the input for a neuron ID given the available inputs
+//! \brief Print the input for a neuron ID given the available inputs
 //!     currently only executed when the models are in debug mode, as the prints
 //!     are controlled from the synapses.c print_inputs() method.
 //! \param[in] parameters: the pointer to the parameters to use
@@ -185,7 +184,7 @@ static inline void synapse_types_print_input(
             parameters->inh.synaptic_input_value);
 }
 
-//! \brief printer call
+//! \brief Print the synapse type model parameters
 //! \param[in] parameters: the pointer to the parameters to print
 static inline void synapse_types_print_parameters(
         synapse_param_t *parameters) {

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_exponential_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_exponential_impl.h
@@ -77,7 +77,7 @@ typedef enum {
 // Synapse shaping inline implementation
 //---------------------------------------
 
-//! \brief Shapes a single parameter
+//! \brief Shape a single parameter
 //! \param[in,out] exp_param: The parameter to shape
 static inline void exp_shaping(exp_params_t *exp_param) {
     // decay value according to decay constant
@@ -85,13 +85,12 @@ static inline void exp_shaping(exp_params_t *exp_param) {
 			decay_s1615(exp_param->synaptic_input_value, exp_param->decay);
 }
 
-//! \brief decays the stuff thats sitting in the input buffers as these have not
+//! \brief Decay the stuff thats sitting in the input buffers as these have not
 //!     yet been processed and applied to the neuron.
-//!
-//! This is to compensate for the valve behaviour of a synapse in biology
-//! (spike goes in, synapse opens, then closes slowly)
-//! plus the leaky aspect of a neuron.
-//!
+//! \details
+//!     This is to compensate for the valve behaviour of a synapse in biology
+//!     (spike goes in, synapse opens, then closes slowly)
+//!     plus the leaky aspect of a neuron.
 //! \param[in,out] parameters: the parameters to update
 static inline void synapse_types_shape_input(
         synapse_param_t *parameters) {
@@ -99,8 +98,7 @@ static inline void synapse_types_shape_input(
 	exp_shaping(&parameters->inh);
 }
 
-//! \brief helper function to add input for a given timer period to a given
-//!     neuron
+//! \brief Add input for a given timer period to a given neuron
 //! \param[in,out] exp_param: the pointer to the parameters to use
 //! \param[in] input: the inputs to add.
 static inline void add_input_exp(exp_params_t *exp_param, input_t input) {
@@ -108,7 +106,7 @@ static inline void add_input_exp(exp_params_t *exp_param, input_t input) {
 			decay_s1615(input, exp_param->init);
 }
 
-//! \brief adds the inputs for a give timer period to a given neuron that is
+//! \brief Add the inputs for a give timer period to a given neuron that is
 //!     being simulated by this model
 //! \param[in] synapse_type_index the type of input that this input is to be
 //!     considered (aka excitatory or inhibitory etc)
@@ -127,7 +125,7 @@ static inline void synapse_types_add_neuron_input(
     }
 }
 
-//! \brief extracts the excitatory input buffers from the buffers available
+//! \brief Extract the excitatory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
@@ -137,7 +135,7 @@ static inline input_t* synapse_types_get_excitatory_input(
     return &excitatory_response[0];
 }
 
-//! \brief extracts the inhibitory input buffers from the buffers available
+//! \brief Extract the inhibitory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
@@ -147,11 +145,12 @@ static inline input_t* synapse_types_get_inhibitory_input(
     return &inhibitory_response[0];
 }
 
-//! \brief returns a human readable character for the type of synapse.
-//!     examples would be X = excitatory types, I = inhibitory types etc etc.
+//! \brief Get a human readable string for the type of synapse.
+//! \details
+//!     Examples would be `X` = excitatory types, `I` = inhibitory types, etc.
 //! \param[in] synapse_type_index: the synapse type index
 //!     (there is a specific index interpretation in each synapse type)
-//! \return a human readable character representing the synapse type.
+//! \return a human readable short string representing the synapse type.
 static inline const char *synapse_types_get_type_char(
         index_t synapse_type_index) {
     switch (synapse_type_index) {
@@ -165,7 +164,7 @@ static inline const char *synapse_types_get_type_char(
     }
 }
 
-//! \brief prints the input for a neuron ID given the available inputs
+//! \brief Print the input for a neuron ID given the available inputs
 //!     currently only executed when the models are in debug mode, as the prints
 //!     are controlled from the synapses.c print_inputs() method.
 //! \param[in] parameters: the pointer to the parameters to use
@@ -176,7 +175,7 @@ static inline void synapse_types_print_input(
             parameters->inh.synaptic_input_value);
 }
 
-//! \brief printer call
+//! \brief Print the synapse type model parameters
 //! \param[in] parameters: the pointer to the parameters to print
 static inline void synapse_types_print_parameters(
         synapse_param_t *parameters) {

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
@@ -16,8 +16,7 @@
  */
 
 /*! \file
-*
-* \brief implementation of synapse_types.h for sEMD synapses.
+* \brief Implementation of synapse_types.h for sEMD synapses.
 *
 * \details To be filled in...
 */
@@ -82,7 +81,7 @@ typedef enum {
 // Synapse shaping inline implementation
 //---------------------------------------
 
-//! \brief Shapes a single parameter
+//! \brief Shape a single parameter
 //! \param[in,out] exp_param: The parameter to shape
 static inline void exp_shaping(exp_params_t *exp_param) {
     // decay value according to decay constant
@@ -90,13 +89,12 @@ static inline void exp_shaping(exp_params_t *exp_param) {
 			decay_s1615(exp_param->synaptic_input_value, exp_param->decay);
 }
 
-//! \brief decays the stuff thats sitting in the input buffers as these have not
-//!     yet been processed and applied to the neuron.
-//!
-//! This is to compensate for the valve behaviour of a synapse in biology
-//! (spike goes in, synapse opens, then closes slowly)
-//! plus the leaky aspect of a neuron.
-//!
+//! \brief Decay the stuff thats sitting in the input buffers as these have
+//!     not yet been processed and applied to the neuron.
+//! \details
+//!     This is to compensate for the valve behaviour of a synapse in biology
+//!     (spike goes in, synapse opens, then closes slowly)
+//!     plus the leaky aspect of a neuron.
 //! \param[in,out] parameters: the pointer to the parameters to use
 static inline void synapse_types_shape_input(synapse_param_t *parameters) {
 	exp_shaping(&parameters->exc);
@@ -104,8 +102,7 @@ static inline void synapse_types_shape_input(synapse_param_t *parameters) {
 	exp_shaping(&parameters->inh);
 }
 
-//! \brief helper function to add input for a given timer period to a given
-//!     neuron
+//! \brief Add input for a given timer period to a given neuron
 //! \param[in,out] parameter: the parameter to update
 //! \param[in] input: the input to add.
 static inline void add_input_exp(exp_params_t *parameter, input_t input) {
@@ -113,7 +110,7 @@ static inline void add_input_exp(exp_params_t *parameter, input_t input) {
 			decay_s1615(input, parameter->init);
 }
 
-//! \brief adds the inputs for a give timer period to a given neuron that is
+//! \brief Add the inputs for a give timer period to a given neuron that is
 //!     being simulated by this model
 //! \param[in] synapse_type_index: the type of input that this input is to be
 //!     considered (aka excitatory or inhibitory etc)
@@ -135,7 +132,7 @@ static inline void synapse_types_add_neuron_input(
     }
 }
 
-//! \brief extracts the excitatory input buffers from the buffers available
+//! \brief Extract the excitatory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
@@ -158,7 +155,7 @@ static inline input_t *synapse_types_get_excitatory_input(
     return &excitatory_response[0];
 }
 
-//! \brief extracts the inhibitory input buffers from the buffers available
+//! \brief Extract the inhibitory input buffers from the buffers available
 //!     for a given parameter set
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
@@ -168,11 +165,12 @@ static inline input_t *synapse_types_get_inhibitory_input(
     return &inhibitory_response[0];
 }
 
-//! \brief returns a human readable character for the type of synapse.
-//!     examples would be X = excitatory types, I = inhibitory types etc etc.
+//! \brief Get a human readable string for the type of synapse.
+//! \details
+//!     Examples would be `X` = excitatory types, `I` = inhibitory types, etc.
 //! \param[in] synapse_type_index: the synapse type index
 //!     (there is a specific index interpretation in each synapse type)
-//! \return a human readable character representing the synapse type.
+//! \return a human readable short string representing the synapse type.
 static inline const char *synapse_types_get_type_char(
         index_t synapse_type_index) {
     switch (synapse_type_index) {
@@ -188,7 +186,7 @@ static inline const char *synapse_types_get_type_char(
     }
 }
 
-//! \brief prints the input for a neuron ID given the available inputs
+//! \brief Print the input for a neuron ID given the available inputs
 //!     currently only executed when the models are in debug mode, as the prints
 //!     are controlled from the synapses.c print_inputs() method.
 //! \param[in] parameters: the parameters to print
@@ -199,7 +197,7 @@ static inline void synapse_types_print_input(synapse_param_t *parameters) {
             parameters->inh.synaptic_input_value);
 }
 
-//! \brief printer call
+//! \brief Print the synapse type model parameters
 //! \param[in] parameters: the pointer to the parameters to print
 static inline void synapse_types_print_parameters(synapse_param_t *parameters) {
     log_info("exc_decay  = %11.4k\n", parameters->exc.decay);

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -77,7 +77,7 @@ static uint32_t synapse_type_mask;
 /* PRIVATE FUNCTIONS */
 
 #if LOG_LEVEL >= LOG_DEBUG
-//! \brief get the synapse type character
+//! \brief Get the synapse type character
 //! \param[in] synapse_type: the synapse type
 //! \return a single character string describing the synapse type
 static inline const char *get_type_char(uint32_t synapse_type) {
@@ -86,8 +86,7 @@ static inline const char *get_type_char(uint32_t synapse_type) {
 #endif // LOG_LEVEL >= LOG_DEBUG
 
 //! \brief Print a synaptic row.
-//!
-//! Only does anything when debugging.
+//! \details Only does anything when debugging.
 //! \param[in] synaptic_row: The synaptic row to print
 static inline void print_synaptic_row(synaptic_row_t synaptic_row) {
 #if LOG_LEVEL >= LOG_DEBUG
@@ -142,8 +141,7 @@ static inline void print_synaptic_row(synaptic_row_t synaptic_row) {
 }
 
 //! \brief Print the contents of the ring buffers.
-//!
-//! Only does anything when debugging.
+//! \details Only does anything when debugging.
 //! \param[in] time: The current timestamp
 static inline void print_ring_buffers(uint32_t time) {
 #if LOG_LEVEL >= LOG_DEBUG
@@ -181,8 +179,7 @@ static inline void print_ring_buffers(uint32_t time) {
 }
 
 //! \brief Print the neuron inputs.
-//!
-//! Only does anything when debugging.
+//! \details Only does anything when debugging.
 static inline void print_inputs(void) {
 #if LOG_LEVEL >= LOG_DEBUG
     log_debug("Inputs\n");
@@ -192,9 +189,8 @@ static inline void print_inputs(void) {
 
 
 //! \brief This is the "inner loop" of the neural simulation.
-//!
-//! Every spike event could cause up to 256 different weights to
-//! be put into the ring buffer.
+//! \details Every spike event could cause up to 256 different weights to
+//!     be put into the ring buffer.
 //! \param[in] fixed_region_address: The fixed region of the synaptic matrix
 //! \param[in] time: The current simulation time
 static inline void process_fixed_synapses(
@@ -241,7 +237,7 @@ static inline void process_fixed_synapses(
     }
 }
 
-//! private method for doing output debug data on the synapses
+//! Print output debug data on the synapses
 static inline void print_synapse_parameters(void) {
 // only if the models are compiled in debug mode will this method contain
 // said lines.
@@ -386,16 +382,15 @@ bool synapses_process_synaptic_row(
     return true;
 }
 
-//! \brief returns the number of times the synapses have saturated their
-//!        weights.
+//! \brief Get the number of times the synapses have saturated their weights.
 //! \return the number of times the synapses have saturated.
 uint32_t synapses_get_saturation_count(void) {
     return saturation_count;
 }
 
-//! \brief returns the counters for plastic and fixed pre synaptic events
-//! based on (if the model was compiled with SYNAPSE_BENCHMARK parameter) or
-//! returns 0
+//! \brief Get the counters for plastic and fixed pre synaptic events based on
+//!     (if the model was compiled with SYNAPSE_BENCHMARK parameter) or
+//!     returns 0
 //! \return the counter for plastic and fixed pre synaptic events or 0
 uint32_t synapses_get_pre_synaptic_events(void) {
     return (num_fixed_pre_synaptic_events +
@@ -408,7 +403,7 @@ void synapses_flush_ring_buffers(void) {
     }
 }
 
-//! \brief allows clearing of DTCM used by synapses
+//! \brief Clear DTCM used by synapses
 //! \return true if successful
 bool synapses_shut_down(void) {
     sark_free(ring_buffer_to_input_left_shifts);

--- a/neural_modelling/src/neuron/synapses.h
+++ b/neural_modelling/src/neuron/synapses.h
@@ -55,7 +55,7 @@ static inline index_t synapses_get_ring_buffer_index_combined(
             | combined_synapse_neuron_index;
 }
 
-//! \brief Converts a weight stored in a synapse row to an input
+//! \brief Convert a weight stored in a synapse row to an input
 //! \param[in] weight: the weight to convert in synapse-row form
 //! \param[in] left_shift: the shift to use when decoding
 //! \return the actual input weight for the model
@@ -101,7 +101,7 @@ bool synapses_initialise(
 //! \param[in] time: the current simulation time
 void synapses_do_timestep_update(timer_t time);
 
-//! \brief process a synaptic row
+//! \brief Process a synaptic row
 //! \param[in] time: the simulated time
 //! \param[in] row: the synaptic row in question
 //! \param[out] write_back: whether to write back to SDRAM
@@ -109,21 +109,20 @@ void synapses_do_timestep_update(timer_t time);
 bool synapses_process_synaptic_row(
         uint32_t time, synaptic_row_t row, bool *write_back);
 
-//! \brief returns the number of times the synapses have saturated their
-//!        weights.
+//! \brief Get the number of times the synapses have saturated their weights.
 //! \return the number of times the synapses have saturated.
 uint32_t synapses_get_saturation_count(void);
 
-//! \brief returns the counters for plastic and fixed pre synaptic events based
+//! \brief Get the counters for plastic and fixed pre synaptic events based
 //!        on (if the model was compiled with SYNAPSE_BENCHMARK parameter) or
 //!        returns 0
 //! \return the counter for plastic and fixed pre synaptic events or 0
 uint32_t synapses_get_pre_synaptic_events(void);
 
-//! \brief flush the ring buffers
+//! \brief Flush the ring buffers
 void synapses_flush_ring_buffers(void);
 
-//! \brief allows clearing of DTCM used by synapses
+//! \brief Clear DTCM used by synapses
 //! \return true if successful, false otherwise
 bool synapses_shut_down(void);
 

--- a/neural_modelling/src/neuron/threshold_types/threshold_type.h
+++ b/neural_modelling/src/neuron/threshold_types/threshold_type.h
@@ -31,7 +31,7 @@ typedef struct threshold_type_t threshold_type_t;
 //! Pointer to a threshold type
 typedef threshold_type_t* threshold_type_pointer_t;
 
-//! \brief Determines if the value given is above the threshold value
+//! \brief Determine if the value given is above the threshold value
 //! \param[in] value: The value to determine if it is above the threshold
 //! \param[in] threshold_type: The parameters to use to determine the result
 //! \return True if the neuron should fire

--- a/neural_modelling/src/neuron/threshold_types/threshold_type_maass_stochastic.h
+++ b/neural_modelling/src/neuron/threshold_types/threshold_type_maass_stochastic.h
@@ -41,7 +41,7 @@ struct threshold_type_t {
     REAL     neg_machine_time_step_ms_div_10;
 };
 
-//! \brief Determines if the value given is above the threshold value
+//! \brief Determine if the value given is above the threshold value
 //! \param[in] value: The value to determine if it is above the threshold
 //! \param[in] threshold_type: The parameters to use to determine the result
 //! \return True if the neuron should fire

--- a/neural_modelling/src/neuron/threshold_types/threshold_type_none.h
+++ b/neural_modelling/src/neuron/threshold_types/threshold_type_none.h
@@ -25,7 +25,7 @@
 struct threshold_type_t {
 };
 
-//! \brief Determines if the value given is above the threshold value
+//! \brief Determine if the value given is above the threshold value
 //! \param[in] value: The value to determine if it is above the threshold
 //! \param[in] threshold_type: The parameters to use to determine the result
 //! \return True if the neuron should fire

--- a/neural_modelling/src/neuron/threshold_types/threshold_type_static.h
+++ b/neural_modelling/src/neuron/threshold_types/threshold_type_static.h
@@ -28,7 +28,7 @@ struct threshold_type_t {
     REAL threshold_value;
 };
 
-//! \brief Determines if the value given is above the threshold value
+//! \brief Determine if the value given is above the threshold value
 //! \param[in] value: The value to determine if it is above the threshold
 //! \param[in] threshold_type: The parameters to use to determine the result
 //! \return True if the neuron should fire

--- a/neural_modelling/src/robot_motor_control/robot_motor_control.c
+++ b/neural_modelling/src/robot_motor_control/robot_motor_control.c
@@ -120,7 +120,7 @@ static inline void send_to_motor(uint32_t direction, uint32_t the_speed) {
     }
 }
 
-//! \brief Commands the robot's motors to start doing a motion
+//! \brief Command the robot's motors to start doing a motion
 //! \param[in] direction_index: The "forward" sense of motion
 //! \param[in] opposite_index: The "reverse" sense of motion
 //! \param[in] direction: for debugging
@@ -154,7 +154,7 @@ static inline void do_motion(
     }
 }
 
-//! \brief Commands the robot's motors to continue a motion started by
+//! \brief Command the robot's motors to continue a motion started by
 //!     do_motion()
 //! \param[in] direction_index: The "forward" sense of motion
 //! \param[in] opposite_index: The "reverse" sense of motion
@@ -231,7 +231,7 @@ static void timer_callback(uint unused0, uint unused1) {
     }
 }
 
-//! \brief Reads the configuration
+//! \brief Read the configuration
 //! \param[in] config_region: Where to read the configuration from
 static void read_parameters(motor_control_config_t *config_region) {
     log_info("Reading parameters from 0x%.8x", config_region);

--- a/neural_modelling/src/spike_source/poisson/spike_source_poisson.c
+++ b/neural_modelling/src/spike_source/poisson/spike_source_poisson.c
@@ -551,7 +551,7 @@ static inline void expand_spike_recording_buffer(uint32_t n_spikes) {
     n_spike_buffers_allocated = n_spikes;
 }
 
-//! \brief records spikes as needed
+//! \brief Record emitted spikes as needed
 //! \param[in] neuron_id: the neurons to store spikes from
 //! \param[in] n_spikes: the number of times this neuron has spiked
 static inline void mark_spike(uint32_t neuron_id, uint32_t n_spikes) {
@@ -568,12 +568,12 @@ static inline void mark_spike(uint32_t neuron_id, uint32_t n_spikes) {
     }
 }
 
-//! \brief callback for completed recording
+//! \brief Callback for completed recording
 static void recording_complete_callback(void) {
     recording_in_progress = false;
 }
 
-//! \brief writing spikes to SDRAM
+//! \brief Write spikes to SDRAM
 //! \param[in] time: the time to which these spikes are being recorded
 static inline void record_spikes(uint32_t time) {
     while (recording_in_progress) {

--- a/neural_modelling/src/synapse_expander/connection_generator.h
+++ b/neural_modelling/src/synapse_expander/connection_generator.h
@@ -16,9 +16,7 @@
  */
 
 /*! \file
- *
  * \brief Connection Generator interface
- *
  */
 
 #include <stdint.h>

--- a/neural_modelling/src/synapse_expander/connection_generators/connection_generator_fixed_post.h
+++ b/neural_modelling/src/synapse_expander/connection_generators/connection_generator_fixed_post.h
@@ -96,7 +96,7 @@ static void connection_generator_fixed_post_free(void *generator) {
 }
 
 /**
- * \brief Generates a uniformly-distributed random number
+ * \brief Generate a uniformly-distributed random number
  * \param[in,out] obj: the generator containing the RNG
  * \param[in] range: the (_upper, exclusive_) limit of the range of random
  *      numbers that may be generated. Should be in range 0..65536

--- a/neural_modelling/src/synapse_expander/connection_generators/connection_generator_fixed_pre.h
+++ b/neural_modelling/src/synapse_expander/connection_generators/connection_generator_fixed_pre.h
@@ -100,7 +100,7 @@ void connection_generator_fixed_pre_free(void *generator) {
 }
 
 /**
- * \brief Generates a uniformly-distributed random number
+ * \brief Generate a uniformly-distributed random number
  * \param[in,out] obj: the generator containing the RNG
  * \param[in] range: the (_upper, exclusive_) limit of the range of random
  *      numbers that may be generated. Should be in range 0..65536

--- a/neural_modelling/src/synapse_expander/delay_expander.c
+++ b/neural_modelling/src/synapse_expander/delay_expander.c
@@ -46,15 +46,15 @@ struct delay_builder_config {
 
 /**
  * \brief Generate the data for a single connector
- * \param[in,out] in_region: The address to read the parameters from.  Should be
- *                           updated to the position just after the parameters
- *                           after calling.
- * \param[in,out] neuron_delay_stage_config: Bit fields into which to write the
- *                                           delay information
- * \param[in] post_slice_start: The start of the slice of the delay extension to
- *                              generate for
- * \param[in] post_slice_count: The number of neurons of the delay extension to
- *                              generate for
+ * \param[in,out] in_region:
+ *      The address to read the parameters from.  Should be updated to the
+ *      position just after the parameters after calling.
+ * \param[in,out] neuron_delay_stage_config:
+ *      Bit fields into which to write the delay information
+ * \param[in] post_slice_start:
+ *      The start of the slice of the delay extension to generate for
+ * \param[in] post_slice_count:
+ *      The number of neurons of the delay extension to generate for
  * \return True if the region was correctly generated, False if there was an
  *         error
  */
@@ -133,10 +133,10 @@ static bool read_delay_builder_region(address_t *in_region,
 
 /**
  * \brief Read the data for the generator
- * \param[in] delay_params_address: The address of the delay extension
- *                                  parameters
+ * \param[in] delay_params_address:
+ *      The address of the delay extension parameters
  * \param[in] params_address: The address of the expander parameters
- * \return True if the expander finished correctly, False if there was an
+ * \return True if the expander finished correctly, false if there was an
  *         error
  */
 static bool run_delay_expander(

--- a/neural_modelling/src/synapse_expander/matrix_generator.c
+++ b/neural_modelling/src/synapse_expander/matrix_generator.c
@@ -119,13 +119,13 @@ void matrix_generator_free(matrix_generator_t generator) {
  * \brief Generate a row of a synaptic matrix
  * \param[in] generator: The matrix generator
  * \param[out] synaptic_matrix: The address of the synaptic matrix to write to
- * \param[out] delayed_synaptic_matrix: The address of the synaptic matrix to
- *                                      write delayed connections to
+ * \param[out] delayed_synaptic_matrix:
+ *      The address of the synaptic matrix to write delayed connections to
  * \param[in] n_pre_neurons: The number of pre neurons to generate for
  * \param[in] pre_neuron_index: The index of the first pre neuron
  * \param[in] max_row_n_words: The maximum number of words in a normal row
- * \param[in] max_delayed_row_n_words: The maximum number of words in a
- *                                     delayed row
+ * \param[in] max_delayed_row_n_words:
+ *      The maximum number of words in a delayed row
  * \param[in] n_synapse_type_bits: The number of bits used for the synapse type
  * \param[in] n_synapse_index_bits: The number of bits used for the neuron id
  * \param[in] synapse_type: The synapse type of each connection
@@ -154,7 +154,7 @@ static void matrix_generator_write_row(
 
 // ---------------------------------------------------------------------
 
-//! \brief Rescales a delay to account for timesteps and type-converts it
+//! \brief Rescale a delay to account for timesteps and type-convert it
 //! \param[in] delay: the delay to rescale
 //! \param[in] timestep_per_delay: The timestep unit
 //! \return the rescaled delay
@@ -170,8 +170,8 @@ static inline uint16_t rescale_delay(accum delay, accum timestep_per_delay) {
     return delay_int;
 }
 
-//! \brief Rescales a weight to account for weight granularity and
-//!     type-converts it
+//! \brief Rescale a weight to account for weight granularity and
+//!     type-convert it
 //! \param[in] weight: the weight to rescale
 //! \param[in] weight_scale: The weight scaling factor
 //! \return the rescaled weight

--- a/neural_modelling/src/synapse_expander/matrix_generator.h
+++ b/neural_modelling/src/synapse_expander/matrix_generator.h
@@ -50,27 +50,27 @@ void matrix_generator_free(matrix_generator_t generator);
  * \brief Generate a matrix with a matrix generator
  * \param[in] generator: The generator to use to generate the matrix
  * \param[in] synaptic_matrix: The address of the synaptic matrix to write to
- * \param[in] delayed_synaptic_matrix: The address of the synaptic matrix to
- *                                     write delayed connections to
+ * \param[in] delayed_synaptic_matrix:
+ *      The address of the synaptic matrix to write delayed connections to
  * \param[in] max_row_n_words: The maximum number of words in a normal row
- * \param[in] max_delayed_row_n_words: The maximum number of words in a delayed
- *                                     row
+ * \param[in] max_delayed_row_n_words:
+ *      The maximum number of words in a delayed row
  * \param[in] max_row_n_synapses: The maximum number of synapses in a normal row
- * \param[in] max_delayed_row_n_synapses: The maximum number of synapses in a
- *                                        delayed row
+ * \param[in] max_delayed_row_n_synapses:
+ *      The maximum number of synapses in a delayed row
  * \param[in] n_synapse_type_bits: The number of bits used for the synapse type
  * \param[in] n_synapse_index_bits: The number of bits used for the neuron id
  * \param[in] synapse_type: The synapse type of each connection
- * \param[in] weight_scales: An array of weight scales, one for each synapse
- *                           type
- * \param[in] post_slice_start: The start of the slice of the post-population
- *                              being generated
- * \param[in] post_slice_count: The number of neurons in the slice of the
- *                              post-population being generated
- * \param[in] pre_slice_start: The start of the slice of the pre-population
- *                             being generated
- * \param[in] pre_slice_count: The number of neurons in the slice of the
- *                             pre-population being generated
+ * \param[in] weight_scales:
+ *      An array of weight scales, one for each synapse type
+ * \param[in] post_slice_start:
+ *      The start of the slice of the post-population being generated
+ * \param[in] post_slice_count:
+ *      The number of neurons in the slice of the post-population being generated
+ * \param[in] pre_slice_start:
+ *      The start of the slice of the pre-population being generated
+ * \param[in] pre_slice_count:
+ *      The number of neurons in the slice of the pre-population being generated
  * \param[in] connection_generator: The generator of connections
  * \param[in] delay_generator: The generator of delay values
  * \param[in] weight_generator: The generator of weight values

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_static.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_static.h
@@ -27,7 +27,7 @@
 #include <synapse_expander/generator_types.h>
 
 /**
- * \brief How to initialise the static synaptic matrix generator
+ * \brief Initialise the static synaptic matrix generator
  * \param[in,out] region: Region to read parameters from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -38,7 +38,7 @@ static void *matrix_generator_static_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the static synaptic matrix generator
+ * \brief Free any data for the static synaptic matrix generator
  * \param[in] generator: The data to free
  */
 static void matrix_generator_static_free(void *generator) {
@@ -106,17 +106,17 @@ static uint32_t build_static_word(
 }
 
 /**
- * \brief How to generate a row of a static synaptic matrix
- * \param[in] generator: The data for the matrix generator, returned by the
- *                       initialise function
+ * \brief How Generate a row of a static synaptic matrix
+ * \param[in] generator:
+ *      The data for the matrix generator, returned by the initialise function
  * \param[out] synaptic_matrix: The address of the synaptic matrix to write to
- * \param[out] delayed_synaptic_matrix: The address of the synaptic matrix to
- *                                      write delayed connections to
+ * \param[out] delayed_synaptic_matrix:
+ *      The address of the synaptic matrix to write delayed connections to
  * \param[in] n_pre_neurons: The number of pre neurons to generate for
  * \param[in] pre_neuron_index: The index of the first pre neuron
  * \param[in] max_row_n_words: The maximum number of words in a normal row
- * \param[in] max_delayed_row_n_words: The maximum number of words in a
- *                                     delayed row
+ * \param[in] max_delayed_row_n_words:
+ *      The maximum number of words in a delayed row
  * \param[in] synapse_type_bits: The number of bits used for the synapse type
  * \param[in] synapse_index_bits: The number of bits used for the neuron id
  * \param[in] synapse_type: The synapse type of each connection

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_stdp.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_stdp.h
@@ -69,7 +69,7 @@ struct matrix_generator_stdp {
 };
 
 /**
- * \brief How to initialise the STDP synaptic matrix generator
+ * \brief Initialise the STDP synaptic matrix generator
  * \param[in,out] region: Region to read parameters from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -87,7 +87,7 @@ void *matrix_generator_stdp_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the STDP synaptic matrix generator
+ * \brief Free any data for the STDP synaptic matrix generator
  * \param[in] generator: The generator to free
  */
 void matrix_generator_stdp_free(void *generator) {
@@ -95,7 +95,7 @@ void matrix_generator_stdp_free(void *generator) {
 }
 
 /**
- * \brief Build a fixed-plastic half-word from the components
+ * \brief Build a fixed-plastic half-word from its components
  * \param[in] delay: The delay of the synapse
  * \param[in] type: The synapse type
  * \param[in] post_index: The core-relative index of the target neuron
@@ -120,17 +120,17 @@ static uint16_t build_fixed_plastic_half_word(
 }
 
 /**
- * \brief How to generate a row of a STDP synaptic matrix
- * \param[in] generator: The data for the matrix generator, returned by the
- *                       initialise function
+ * \brief Generate a row of a STDP synaptic matrix
+ * \param[in] generator:
+ *      The data for the matrix generator, returned by the initialise function
  * \param[out] synaptic_matrix: The address of the synaptic matrix to write to
- * \param[out] delayed_synaptic_matrix: The address of the synaptic matrix to
- *                                      write delayed connections to
+ * \param[out] delayed_synaptic_matrix:
+ *      The address of the synaptic matrix to write delayed connections to
  * \param[in] n_pre_neurons: The number of pre neurons to generate for
  * \param[in] pre_neuron_index: The index of the first pre neuron
  * \param[in] max_row_n_words: The maximum number of words in a normal row
- * \param[in] max_delayed_row_n_words: The maximum number of words in a
- *                                     delayed row
+ * \param[in] max_delayed_row_n_words:
+ *      The maximum number of words in a delayed row
  * \param[in] synapse_type_bits: The number of bits used for the synapse type
  * \param[in] synapse_index_bits: The number of bits used for the neuron id
  * \param[in] synapse_type: The synapse type of each connection

--- a/neural_modelling/src/synapse_expander/param_generator.h
+++ b/neural_modelling/src/synapse_expander/param_generator.h
@@ -41,11 +41,11 @@ param_generator_t param_generator_init(
  * \brief Generate values with a parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
- * \param[in] indices: The n_indices post-neuron indices for each connection
- * \param[in,out] values: An array into which to place the values; will be
- *                        n_indices in size
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
+ * \param[in] indices: The \p n_indices post-neuron indices for each connection
+ * \param[in,out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 void param_generator_generate(
         param_generator_t generator, uint32_t n_indices,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_constant.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_constant.h
@@ -33,7 +33,7 @@ struct param_generator_constant {
 };
 
 /**
- * \brief How to initialise the constant parameter generator
+ * \brief Initialise the constant parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -52,7 +52,7 @@ static void *param_generator_constant_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the constant parameter generator
+ * \brief Free any data for the constant parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_constant_free(void *generator) {
@@ -60,14 +60,14 @@ static void param_generator_constant_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the constant parameter generator
+ * \brief Generate values with the constant parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_constant_generate(
         void *generator, uint32_t n_indices, uint32_t pre_neuron_index,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_exponential.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_exponential.h
@@ -43,7 +43,7 @@ struct param_generator_exponential {
 };
 
 /**
- * \brief How to initialise the exponential RNG parameter generator
+ * \brief Initialise the exponential RNG parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -65,7 +65,7 @@ static void *param_generator_exponential_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the exponential RNG parameter generator
+ * \brief Free any data for the exponential RNG parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_exponential_free(void *generator) {
@@ -75,14 +75,14 @@ static void param_generator_exponential_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the exponential RNG parameter generator
+ * \brief Generate values with the exponential RNG parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_exponential_generate(
         void *generator, uint32_t n_indices, uint32_t pre_neuron_index,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_kernel.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_kernel.h
@@ -76,7 +76,7 @@ struct all_kernel_params {
 };
 
 /**
- * \brief How to initialise the convolution kernel parameter generator
+ * \brief Initialise the convolution kernel parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -97,7 +97,7 @@ static void *param_generator_kernel_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the convolution kernel parameter generator
+ * \brief Free any data for the convolution kernel parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_kernel_free(void *generator) {
@@ -105,14 +105,14 @@ static void param_generator_kernel_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the convolution kernel parameter generator
+ * \brief Generate values with the convolution kernel parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_synapses: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_kernel_generate(
         void *generator, uint32_t n_synapses,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_normal.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_normal.h
@@ -44,7 +44,7 @@ struct param_generator_normal {
 };
 
 /**
- * \brief How to initialise the normal RNG parameter generator
+ * \brief Initialise the normal RNG parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -68,7 +68,7 @@ static void *param_generator_normal_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the normal RNG parameter generator
+ * \brief Free any data for the normal RNG parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_normal_free(void *generator) {
@@ -78,14 +78,14 @@ static void param_generator_normal_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the normal RNG parameter generator
+ * \brief Generate values with the normal RNG parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_normal_generate(
         void *generator, uint32_t n_indices, uint32_t pre_neuron_index,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped.h
@@ -47,7 +47,7 @@ struct param_generator_normal_clipped {
 };
 
 /**
- * \brief How to initialise the clipped normal RNG parameter generator
+ * \brief Initialise the clipped normal RNG parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -72,7 +72,7 @@ static void *param_generator_normal_clipped_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the clipped normal RNG parameter generator
+ * \brief Free any data for the clipped normal RNG parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_normal_clipped_free(void *generator) {
@@ -82,14 +82,14 @@ static void param_generator_normal_clipped_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the clipped normal RNG parameter generator
+ * \brief Generate values with the clipped normal RNG parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_normal_clipped_generate(
         void *generator, uint32_t n_indices, uint32_t pre_neuron_index,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped_to_boundary.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_normal_clipped_to_boundary.h
@@ -47,7 +47,7 @@ struct param_generator_normal_clipped_boundary {
 };
 
 /**
- * \brief How to initialise the clamped normal RNG parameter generator
+ * \brief Initialise the clamped normal RNG parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -72,7 +72,7 @@ static void *param_generator_normal_clipped_boundary_initialize(
 }
 
 /**
- * \brief How to free any data for the clamped normal RNG parameter generator
+ * \brief Free any data for the clamped normal RNG parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_normal_clipped_boundary_free(void *generator) {
@@ -82,14 +82,14 @@ static void param_generator_normal_clipped_boundary_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the clamped normal RNG parameter generator
+ * \brief Generate values with the clamped normal RNG parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_normal_clipped_boundary_generate(
         void *generator, uint32_t n_indices, uint32_t pre_neuron_index,

--- a/neural_modelling/src/synapse_expander/param_generators/param_generator_uniform.h
+++ b/neural_modelling/src/synapse_expander/param_generators/param_generator_uniform.h
@@ -44,7 +44,7 @@ struct param_generator_uniform {
 };
 
 /**
- * \brief How to initialise the uniform RNG parameter generator
+ * \brief Initialise the uniform RNG parameter generator
  * \param[in,out] region: Region to read setup from.  Should be updated
  *                        to position just after parameters after calling.
  * \return A data item to be passed in to other functions later on
@@ -68,7 +68,7 @@ static void *param_generator_uniform_initialize(address_t *region) {
 }
 
 /**
- * \brief How to free any data for the uniform RNG parameter generator
+ * \brief Free any data for the uniform RNG parameter generator
  * \param[in] generator: The generator to free
  */
 static void param_generator_uniform_free(void *generator) {
@@ -78,14 +78,14 @@ static void param_generator_uniform_free(void *generator) {
 }
 
 /**
- * \brief How to generate values with the uniform RNG parameter generator
+ * \brief Generate values with the uniform RNG parameter generator
  * \param[in] generator: The generator to use to generate values
  * \param[in] n_indices: The number of values to generate
- * \param[in] pre_neuron_index: The index of the neuron in the pre-population
- *                              being generated
+ * \param[in] pre_neuron_index:
+ *      The index of the neuron in the pre-population being generated
  * \param[in] indices: The \p n_indices post-neuron indices for each connection
- * \param[out] values: An array into which to place the values; will be
- *                     \p n_indices in size
+ * \param[out] values:
+ *      An array into which to place the values; will be \p n_indices in size
  */
 static void param_generator_uniform_generate(
         void *generator, uint32_t n_indices, uint32_t pre_neuron_index,

--- a/neural_modelling/src/synapse_expander/synapse_expander.c
+++ b/neural_modelling/src/synapse_expander/synapse_expander.c
@@ -64,17 +64,17 @@ struct expander_config {
 
 /**
  * \brief Generate the synapses for a single connector
- * \param[in,out] in_region: The address to read the parameters from. Should be
- *                           updated to the position just after the parameters
- *                           after calling.
+ * \param[in,out] in_region:
+ *      The address to read the parameters from. Should be updated to the
+ *      position just after the parameters after calling.
  * \param[in] synaptic_matrix_region: The address of the synaptic matrices
- * \param[in] post_slice_start: The start of the slice of the post-population to
- *                              generate for
+ * \param[in] post_slice_start:
+ *      The start of the slice of the post-population to generate for
  * \param[in] post_slice_count: The number of neurons to generate for
  * \param[in] n_synapse_type_bits: The number of bits in the synapse type
  * \param[in] n_synapse_index_bits: The number of bits for the neuron index id
- * \param[in] weight_scales: An array of weight scales, one for each synapse
- *                           type
+ * \param[in] weight_scales:
+ *      An array of weight scales, one for each synapse type
  * \return true on success, false on failure
  */
 static bool read_connection_builder_region(address_t *in_region,


### PR DESCRIPTION
Miscellaneous bits extracted from #857, mostly documentation tweaking to ensure that we always use the same active verb tense for brief descriptions of C functions.