### PR TITLE
Dynamic cost models fix for DSG

### DIFF
--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -312,14 +312,11 @@ class AbstractPopulationVertex(
             bit_field_utilities.exact_sdram_for_bit_field_builder_region())
         return sdram_requirement
 
-    def _reserve_memory_regions(
-            self, spec, vertex_slice, vertex, machine_graph, n_key_map):
+    def _reserve_memory_regions(self, spec, vertex, machine_graph, n_key_map):
         """ Reserve the DSG data regions.
 
         :param ~.DataSpecificationGenerator spec:
             the spec to write the DSG region to
-        :param ~pacman.model.graphs.common.Slice vertex_slice:
-            the slice of atoms from the application vertex
         :param ~.MachineVertex vertex: this vertex
         :param ~.MachineGraph machine_graph: machine graph
         :param n_key_map: nkey map
@@ -333,6 +330,7 @@ class AbstractPopulationVertex(
             size=common_constants.SIMULATION_N_BYTES,
             label='System')
 
+        vertex_slice = vertex.vertex_slice
         self._reserve_neuron_params_data_region(spec, vertex_slice)
 
         spec.reserve_memory_region(
@@ -517,15 +515,13 @@ class AbstractPopulationVertex(
         :param n_key_map: (injected)
         """
         # pylint: disable=too-many-arguments, arguments-differ
-        vertex = placement.vertex
 
         spec.comment("\n*** Spec for block of {} neurons ***\n".format(
             self.__neuron_impl.model_name))
-        vertex_slice = vertex.vertex_slice
 
         # Reserve memory regions
-        self._reserve_memory_regions(
-            spec, vertex_slice, vertex, machine_graph, n_key_map)
+        vertex = placement.vertex
+        self._reserve_memory_regions(spec, vertex, machine_graph, n_key_map)
 
         # Declare random number generators and distributions:
         # TODO add random distribution stuff
@@ -542,6 +538,7 @@ class AbstractPopulationVertex(
             time_scale_factor))
 
         # Write the neuron recording region
+        vertex_slice = vertex.vertex_slice
         self._neuron_recorder.write_neuron_recording_region(
             spec, POPULATION_BASED_REGIONS.NEURON_RECORDING.value,
             vertex_slice, data_n_time_steps)

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -560,9 +560,8 @@ class AbstractPopulationVertex(
 
         # allow the synaptic matrix to write its data spec-able data
         self.__synapse_manager.write_data_spec(
-            spec, self, vertex_slice, vertex, placement, machine_graph,
-            application_graph, routing_info,
-            weight_scale, machine_time_step)
+            spec, placement, machine_graph, application_graph,
+            routing_info, weight_scale, machine_time_step)
         vertex.set_on_chip_generatable_area(
             self.__synapse_manager.host_written_matrix_size,
             self.__synapse_manager.on_chip_written_matrix_size)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py
@@ -23,20 +23,19 @@ class AbstractSynapseDynamicsStructural(object):
 
     @abstractmethod
     def get_actual_structural_parameters_sdram_usage_in_bytes(
-            self, machine_graph, machine_vertex, n_synapse_types):
+            self, machine_graph, machine_vertex):
         """ Get the size of the structural parameters
 
         :param ~pacman.model.graphs.machine.MachineGraph \
                 application_graph:
         :param _pacman.model.graphs.machine.MachineVertex.py machine_vertex:
-        :param int n_synapse_types: currently not used
         :return: the size of the parameters, in bytes
         :rtype: int
         """
 
     @abstractmethod
     def get_estimated_structural_parameters_sdram_usage_in_bytes(
-            self, application_graph, app_vertex, n_neurons, n_synapse_types):
+            self, application_graph, app_vertex, n_neurons):
         """ Get the size of the structural parameters
 
         :param ~pacman.model.graphs.application.ApplicationGraph \
@@ -44,7 +43,6 @@ class AbstractSynapseDynamicsStructural(object):
         :param ~spynnaker.pyNN.models.neuron.AbstractPopulationVertex \
                 app_vertex:
         :param int n_neurons:
-        :param int n_synapse_types:
         :return: the size of the parameters, in bytes
         :rtype: int
         """

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py
@@ -22,7 +22,20 @@ from spinn_utilities.abstract_base import (
 class AbstractSynapseDynamicsStructural(object):
 
     @abstractmethod
-    def get_structural_parameters_sdram_usage_in_bytes(
+    def get_actual_structural_parameters_sdram_usage_in_bytes(
+            self, machine_graph, machine_vertex, n_synapse_types):
+        """ Get the size of the structural parameters
+
+        :param ~pacman.model.graphs.machine.MachineGraph \
+                application_graph:
+        :param _pacman.model.graphs.machine.MachineVertex.py machine_vertex:
+        :param int n_synapse_types: currently not used
+        :return: the size of the parameters, in bytes
+        :rtype: int
+        """
+
+    @abstractmethod
+    def get_estimated_structural_parameters_sdram_usage_in_bytes(
             self, application_graph, app_vertex, n_neurons, n_synapse_types):
         """ Get the size of the structural parameters
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -239,8 +239,8 @@ class SynapseDynamicsStructuralCommon(object):
                                   AbstractSynapseDynamicsStructural):
                         if found:
                             raise SynapticConfigurationException(
-                                "Only one SynapseInfo on an edge "
-                                "can use structural plasticity")
+                                "Only one Projection between each pair of "
+                                "Populations can use structural plasticity")
                         found = True
                         structural_edges.append((app_edge, synapse_info))
         return structural_edges
@@ -448,8 +448,8 @@ class SynapseDynamicsStructuralCommon(object):
                         if found_synapse_info and \
                                 found_synapse_info != synapse_info:
                             raise SynapticConfigurationException(
-                                "Only one SynapseInfo on each edge "
-                                "can use structural plasticity")
+                                "Only one Projection between each pair of "
+                                "Populations can use structural plasticity")
                         found_synapse_info = synapse_info
                 if found_synapse_info:
                     n_infos += 1

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -20,7 +20,8 @@ from data_specification.enums.data_type import DataType
 from spinn_front_end_common.utilities.constants import (
     MICRO_TO_MILLISECOND_CONVERSION, MICRO_TO_SECOND_CONVERSION,
     BYTES_PER_WORD, BYTES_PER_SHORT)
-from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
+from spynnaker.pyNN.models.neural_projections import (
+    ProjectionApplicationEdge, ProjectionMachineEdge)
 from .abstract_synapse_dynamics_structural import (
     AbstractSynapseDynamicsStructural)
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
@@ -238,8 +239,8 @@ class SynapseDynamicsStructuralCommon(object):
                                   AbstractSynapseDynamicsStructural):
                         if found:
                             raise SynapticConfigurationException(
-                                "Only one Projection between each pair of "
-                                "Populations can use structural plasticity")
+                                "Only one SynapseInfo on an edge "
+                                "can use structural plasticity")
                         found = True
                         structural_edges.append((app_edge, synapse_info))
         return structural_edges
@@ -418,7 +419,53 @@ class SynapseDynamicsStructuralCommon(object):
             numpy.concatenate(padded_rows).T, formats="u1, u1, u2").view("u4")
         spec.write_array(post_to_pre)
 
-    def get_parameters_sdram_usage_in_bytes(
+    def get_actual_parameters_sdram_usage_in_bytes(
+            self, machine_graph, machine_vertex):
+        """ Get SDRAM usage
+
+        :param ~pacman.model.graphs.machine.MachineGraph machine_graph:
+        :param _pacman.model.graphs.machine.MachineVertex.py machine_vertex:
+        :return: SDRAM usage
+        :rtype: int
+        """
+        # Keep track of the parameter sizes
+        param_sizes = self.__partner_selection\
+            .get_parameters_sdram_usage_in_bytes()
+        n_neurons = machine_vertex.vertex_slice.n_atoms
+
+        # Work out how many sub-edges we will end up with, as this is used
+        # for key_atom_info
+        n_sub_edges = 0
+        n_infos = 0
+        for machine_edge in machine_graph.get_edges_ending_at_vertex(
+                machine_vertex):
+            found_synapse_info = None
+            if isinstance(machine_edge, ProjectionMachineEdge):
+                for synapse_info in machine_edge.synapse_information:
+                    if isinstance(synapse_info.synapse_dynamics,
+                                  AbstractSynapseDynamicsStructural):
+                        n_sub_edges += 1
+                        if found_synapse_info and \
+                                found_synapse_info != synapse_info:
+                            raise SynapticConfigurationException(
+                                "Only one SynapseInfo on each edge "
+                                "can use structural plasticity")
+                        found_synapse_info = synapse_info
+                if found_synapse_info:
+                    n_infos += 1
+                    dynamics = synapse_info.synapse_dynamics
+                    param_sizes += dynamics.formation\
+                        .get_parameters_sdram_usage_in_bytes()
+                    param_sizes += dynamics.elimination\
+                        .get_parameters_sdram_usage_in_bytes()
+
+        return int((self._REWIRING_DATA_SIZE +
+                   (self._PRE_POP_INFO_BASE_SIZE * n_infos) +
+                   (self._KEY_ATOM_INFO_SIZE * n_sub_edges) +
+                   (self._POST_TO_PRE_ENTRY_SIZE * n_neurons * self.__s_max) +
+                   param_sizes))
+
+    def get_estimated_parameters_sdram_usage_in_bytes(
             self, application_graph, app_vertex, n_neurons):
         """ Get SDRAM usage
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -126,14 +126,14 @@ class SynapseDynamicsStructuralStatic(
     @overrides(AbstractSynapseDynamicsStructural
                .get_actual_structural_parameters_sdram_usage_in_bytes)
     def get_actual_structural_parameters_sdram_usage_in_bytes(
-            self, machine_graph, machine_vertex, n_synapse_types):
+            self, machine_graph, machine_vertex):
         return self.__common_sp.get_actual_parameters_sdram_usage_in_bytes(
             machine_graph, machine_vertex)
 
     @overrides(AbstractSynapseDynamicsStructural
                .get_estimated_structural_parameters_sdram_usage_in_bytes)
     def get_estimated_structural_parameters_sdram_usage_in_bytes(
-            self, application_graph, app_vertex, n_neurons, n_synapse_types):
+            self, application_graph, app_vertex, n_neurons):
         return self.__common_sp.get_estimated_parameters_sdram_usage_in_bytes(
             application_graph, app_vertex, n_neurons)
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -124,10 +124,17 @@ class SynapseDynamicsStructuralStatic(
         return name
 
     @overrides(AbstractSynapseDynamicsStructural
-               .get_structural_parameters_sdram_usage_in_bytes)
-    def get_structural_parameters_sdram_usage_in_bytes(
+               .get_actual_structural_parameters_sdram_usage_in_bytes)
+    def get_actual_structural_parameters_sdram_usage_in_bytes(
+            self, machine_graph, machine_vertex, n_synapse_types):
+        return self.__common_sp.get_actual_parameters_sdram_usage_in_bytes(
+            machine_graph, machine_vertex)
+
+    @overrides(AbstractSynapseDynamicsStructural
+               .get_estimated_structural_parameters_sdram_usage_in_bytes)
+    def get_estimated_structural_parameters_sdram_usage_in_bytes(
             self, application_graph, app_vertex, n_neurons, n_synapse_types):
-        return self.__common_sp.get_parameters_sdram_usage_in_bytes(
+        return self.__common_sp.get_estimated_parameters_sdram_usage_in_bytes(
             application_graph, app_vertex, n_neurons)
 
     @overrides(SynapseDynamicsStatic.get_n_words_for_static_connections)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -130,14 +130,14 @@ class SynapseDynamicsStructuralSTDP(
     @overrides(AbstractSynapseDynamicsStructural
                .get_actual_structural_parameters_sdram_usage_in_bytes)
     def get_actual_structural_parameters_sdram_usage_in_bytes(
-            self, machine_graph, machine_vertex, n_synapse_types):
+            self, machine_graph, machine_vertex):
         return self.__common_sp.get_actual_parameters_sdram_usage_in_bytes(
             machine_graph, machine_vertex)
 
     @overrides(AbstractSynapseDynamicsStructural
                .get_estimated_structural_parameters_sdram_usage_in_bytes)
     def get_estimated_structural_parameters_sdram_usage_in_bytes(
-            self, application_graph, app_vertex, n_neurons, n_synapse_types):
+            self, application_graph, app_vertex, n_neurons):
         return self.__common_sp.get_estimated_parameters_sdram_usage_in_bytes(
             application_graph, app_vertex, n_neurons)
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -128,10 +128,17 @@ class SynapseDynamicsStructuralSTDP(
         return name
 
     @overrides(AbstractSynapseDynamicsStructural
-               .get_structural_parameters_sdram_usage_in_bytes)
-    def get_structural_parameters_sdram_usage_in_bytes(
+               .get_actual_structural_parameters_sdram_usage_in_bytes)
+    def get_actual_structural_parameters_sdram_usage_in_bytes(
+            self, machine_graph, machine_vertex, n_synapse_types):
+        return self.__common_sp.get_actual_parameters_sdram_usage_in_bytes(
+            machine_graph, machine_vertex)
+
+    @overrides(AbstractSynapseDynamicsStructural
+               .get_estimated_structural_parameters_sdram_usage_in_bytes)
+    def get_estimated_structural_parameters_sdram_usage_in_bytes(
             self, application_graph, app_vertex, n_neurons, n_synapse_types):
-        return self.__common_sp.get_parameters_sdram_usage_in_bytes(
+        return self.__common_sp.get_estimated_parameters_sdram_usage_in_bytes(
             application_graph, app_vertex, n_neurons)
 
     @overrides(SynapseDynamicsSTDP.get_n_words_for_plastic_connections)

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -1165,8 +1165,8 @@ class SynapticManager(object):
         return self.__ring_buffer_shifts
 
     def write_data_spec(
-            self, spec, placement, machine_graph, application_graph, routing_info,
-            weight_scale, machine_time_step):
+            self, spec, placement, machine_graph, application_graph,
+            routing_info, weight_scale, machine_time_step):
         """
         :param ~data_specification.DataSpecificationGenerator spec:
             The data specification to write to

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -438,8 +438,7 @@ class SynapticManager(object):
                       AbstractSynapseDynamicsStructural):
             return self.__synapse_dynamics\
                 .get_estimated_structural_parameters_sdram_usage_in_bytes(
-                     app_graph, app_vertex, vertex_slice.n_atoms,
-                     self.__n_synapse_types)
+                     app_graph, app_vertex, vertex_slice.n_atoms)
         else:
             return self.__synapse_dynamics.get_parameters_sdram_usage_in_bytes(
                 vertex_slice.n_atoms, self.__n_synapse_types)
@@ -509,7 +508,7 @@ class SynapticManager(object):
             synapse_structural_dynamics_sz = (
                 self.__synapse_dynamics.
                 get_actual_structural_parameters_sdram_usage_in_bytes(
-                    machine_graph, machine_vertex, self.__n_synapse_types))
+                    machine_graph, machine_vertex))
 
             if synapse_structural_dynamics_sz != 0:
                 spec.reserve_memory_region(

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -467,10 +467,10 @@ class SynapticManager(object):
     def _reserve_memory_regions(
             self, spec, machine_vertex, machine_graph, all_syn_block_sz):
         """
-        :param ~.DataSpecificationGenerator spec:
-        :param ~.MachineVertex machine_vertex:
-        :param ~.MachineGraph machine_graph:
-        :param int all_syn_block_sz:
+        :param ~.DataSpecificationGenerator spec: data spec
+        :param ~.MachineVertex machine_vertex: machine vertex
+        :param ~.MachineGraph machine_graph: machine graph
+        :param int all_syn_block_sz: size all synaptic blocks take up.
         """
         spec.reserve_memory_region(
             region=self._synapse_params_region,
@@ -1181,13 +1181,12 @@ class SynapticManager(object):
         :param float weight_scale: How to scale the weights of the synapses
         :param int machine_time_step:
         """
-        machine_vertex = placement.vertex
-        application_vertex = machine_vertex.app_vertex
         # reset for this machine vertex
         self._host_generated_block_addr = 0
         self._on_chip_generated_block_addr = 0
 
         # Create an index of delay keys into this vertex
+        machine_vertex = placement.vertex
         for m_edge in machine_graph.get_edges_ending_at_vertex(machine_vertex):
             app_edge = m_edge.app_edge
             if isinstance(app_edge.pre_vertex, DelayExtensionVertex):
@@ -1195,6 +1194,7 @@ class SynapticManager(object):
                                        m_edge.pre_vertex.vertex_slice] = \
                     routing_info.get_routing_info_for_edge(m_edge)
 
+        application_vertex = machine_vertex.app_vertex
         post_slices = application_vertex.vertex_slices
         post_slice_idx = machine_vertex.index
 


### PR DESCRIPTION
tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/440

Fix to make sure cost models use actual number of incoming machine_vertexes rather than an estimate based on max atom per core when reserving memory regions.

Question.
In https://github.com/SpiNNakerManchester/sPyNNaker/blob/9b6c0b700cc9834870a378bfb94c52baed2e816f/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py#L226
method __get_structural_edges
The check if for multiple  AbstractSynapseDynamicsStructural on each EDGE but the error message is
 "Only one Projection between each pair of Populations can use structural plasticity"
So what is the actual limits.
1. One Dynamic per destination Population
2. One between source /destination pairs
3. One per edge
@pabogdan Do you know?

Also:
https://github.com/SpiNNakerManchester/sPyNNaker/blob/9b6c0b700cc9834870a378bfb94c52baed2e816f/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py#L25
method get_structural_parameters_sdram_usage_in_bytes  has a parameter n_synapse_types which none of the known implementations use.  Is this parameter still needed and why?




