### PR TITLE
Fix progress bar "error"

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/on_chip_bit_field_generator.py
+++ b/spynnaker/pyNN/extra_algorithms/on_chip_bit_field_generator.py
@@ -103,7 +103,7 @@ class OnChipBitFieldGenerator(object):
 
         # progress bar
         progress = ProgressBar(
-            len(app_graph.vertices) * 2 + 1,
+            len(app_graph.vertices) + len(machine_graph.vertices) + 1,
             "Running bitfield generation on chip")
 
         # get data


### PR DESCRIPTION
Jobs where there are more machine graph vertices than application graph vertices were showing the following "error":

```
Running bitfield generation on chip
|0%                          50%                         100%|
 ===========================================================2020-09-07 09:36:17 ERROR: Too many update steps in progress bar! This may be a sign that something else has gone wrong!
=
```

which this hopefully fixes.

Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/451