### PR TITLE
Cache slices at MachineEdge creation time

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/__init__.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/__init__.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from .abstract_cache_slices import AbstractCachesSlices
 from .abstract_connector import AbstractConnector
 from .abstract_generate_connector_on_machine import (
     AbstractGenerateConnectorOnMachine)
@@ -33,7 +34,8 @@ from .one_to_one_connector import OneToOneConnector
 from .small_world_connector import SmallWorldConnector
 from .kernel_connector import KernelConnector
 
-__all__ = ["AbstractConnector", "AbstractGenerateConnectorOnMachine",
+__all__ = ["AbstractCachesSlices",
+           "AbstractConnector", "AbstractGenerateConnectorOnMachine",
            "AbstractConnectorSupportsViewsOnMachine", "AllToAllConnector",
            "ArrayConnector", "CSAConnector",
            "DistanceDependentProbabilityConnector", "FixedNumberPostConnector",

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_cache_slices.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_cache_slices.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
+
+
+class AbstractCachesSlices(object):
+    """ Connector that caches slices
+    """
+
+    __slots__ = ()
+
+    def cache_slices(self, pre_slice, post_slice):
+        """ Caches a pre and post slice.
+
+        The method allows the connector to build up a set of all the
+            pre and post slices that it needs to handle
+
+        Note: the same pre or post slice may be used in multiple calls
+        :param Slice pre_slice: Slice of the pre machine vertex
+        :param Slice post_slice: Slice of the application machine vertex
+        """

--- a/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_machine_edge.py
@@ -43,7 +43,10 @@ class ProjectionMachineEdge(
             pre_vertex, post_vertex, label=label, app_edge=app_edge,
             traffic_weight=traffic_weight)
 
+        for synapse_info in synapse_information:
+            synapse_info.cache_slices(pre_vertex, post_vertex)
         self.__synapse_information = synapse_information
+
 
     @property
     def synapse_information(self):

--- a/spynnaker/pyNN/models/neural_projections/synapse_information.py
+++ b/spynnaker/pyNN/models/neural_projections/synapse_information.py
@@ -15,7 +15,7 @@
 
 from pyNN.random import NumpyRNG
 from spynnaker.pyNN.models.neural_projections.connectors import (
-    AbstractGenerateConnectorOnMachine)
+    AbstractCachesSlices, AbstractGenerateConnectorOnMachine)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     AbstractGenerateOnMachine)
 
@@ -183,3 +183,14 @@ class SynapseInformation(object):
         synapse_gen = isinstance(
             self.synapse_dynamics, AbstractGenerateOnMachine)
         return connector_gen and synapse_gen
+
+    def cache_slices(self, pre_vertex, post_vertex):
+        """
+        Passes the pre and post slice to the connector if interested.
+
+        :param MachineVertex pre_vertex:
+        :param MachineVertexpost_vertex:
+        """
+        if isinstance(self.__connector, AbstractCachesSlices):
+            self.__connector.cache_slices(
+                pre_vertex.vertex_slice, post_vertex.vertex_slice)


### PR DESCRIPTION
This code caches all slices in the connector if required.

It then asserts that they are the same as what is currently passed in by create_synaptic_block
 and gen_connector_params

Then once the test in .... pass

The slices params will be removed from create_synaptic_block
 and gen_connector_params