### PR TITLE
Slice index is not vertex index

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -464,8 +464,7 @@ class AbstractConnector(with_metaclass(AbstractBase, object)):
 
     @abstractmethod
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices,
-            post_slice_index, pre_vertex_slice, post_vertex_slice,
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
             synapse_type, synapse_info):
         """ Create a synaptic block from the data.
 
@@ -476,9 +475,7 @@ class AbstractConnector(with_metaclass(AbstractBase, object)):
         :type delays: ~numpy.ndarray or ~pyNN.random.NumpyRNG or int or float
             or list(int) or list(float)
         :param list(~pacman.model.graphs.common.Slice) pre_slices:
-        :param int pre_slice_index:
         :param list(~pacman.model.graphs.common.Slice) post_slices:
-        :param int post_slice_index:
         :param ~pacman.model.graphs.common.Slice pre_vertex_slice:
         :param ~pacman.model.graphs.common.Slice post_vertex_slice:
         :param AbstractSynapseType synapse_type:

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
@@ -283,15 +283,12 @@ class AbstractGenerateConnectorOnMachine(with_metaclass(
         """
 
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices,
-            post_slice_index, pre_vertex_slice, post_vertex_slice,
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
             synapse_type, synapse_info):
         """ Get the parameters of the on machine generation.
 
         :param list(~pacman.model.graphs.common.Slice) pre_slices:
-        :param int pre_slice_index:
         :param list(~pacman.model.graphs.common.Slice) post_slices:
-        :param int post_slice_index:
         :param ~pacman.model.graphs.common.Slice pre_vertex_slice:
         :param ~pacman.model.graphs.common.Slice post_vertex_slice:
         :param AbstractSynapseType synapse_type:

--- a/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/all_to_all_connector.py
@@ -105,8 +105,8 @@ class AllToAllConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         n_connections = pre_vertex_slice.n_atoms * post_vertex_slice.n_atoms
         if (not self.__allow_self_connections and
@@ -164,8 +164,8 @@ class AllToAllConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractGenerateConnectorOnMachine.gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         params = self._basic_connector_params(synapse_info)
         params.append(self.__allow_self_connections)
         return numpy.array(params, dtype="uint32")

--- a/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/array_connector.py
@@ -89,8 +89,8 @@ class ArrayConnector(AbstractConnector):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         pre_neurons = []
         post_neurons = []
         n_connections = 0

--- a/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/csa_connector.py
@@ -119,8 +119,8 @@ class CSAConnector(AbstractConnector):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         n_connections, pair_list = self._get_n_connections(
             pre_vertex_slice, post_vertex_slice, synapse_info)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
@@ -158,8 +158,8 @@ class DistanceDependentProbabilityConnector(AbstractConnector):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         probs = self.__probs[
             pre_vertex_slice.as_slice, post_vertex_slice.as_slice].reshape(-1)
         n_items = pre_vertex_slice.n_atoms * post_vertex_slice.n_atoms

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -231,8 +231,8 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         # Get lo and hi for the pre vertex
         lo = pre_vertex_slice.lo_atom
@@ -287,8 +287,8 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine,
     @overrides(AbstractGenerateConnectorOnMachine.
                gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         params = self._basic_connector_params(synapse_info)
 
         # The same seed needs to be sent to each of the slices

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -233,8 +233,8 @@ class FixedNumberPreConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
 
         # Get lo and hi for the post vertex
@@ -290,8 +290,8 @@ class FixedNumberPreConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractGenerateConnectorOnMachine.gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         params = self._basic_connector_params(synapse_info)
 
         # The same seed needs to be sent to each of the slices

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_probability_connector.py
@@ -110,8 +110,8 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         n_items = pre_vertex_slice.n_atoms * post_vertex_slice.n_atoms
         items = self._rng.next(n_items)
@@ -149,8 +149,8 @@ class FixedProbabilityConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractGenerateConnectorOnMachine.gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         params = self._basic_connector_params(synapse_info)
         params.append(self.__allow_self_connections)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -222,8 +222,8 @@ class FromListConnector(AbstractConnector):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         if not len(self.__sources):
             return numpy.zeros(0, dtype=self.NUMPY_SYNAPSES_DTYPE)

--- a/spynnaker/pyNN/models/neural_projections/connectors/index_based_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/index_based_probability_connector.py
@@ -125,8 +125,8 @@ class IndexBasedProbabilityConnector(AbstractConnector):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # setup probs here
         self._update_probs_from_index_expression(synapse_info)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -344,8 +344,8 @@ class KernelConnector(AbstractGenerateConnectorOnMachine):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         (n_connections, all_post, all_pre_in_range, all_pre_in_range_delays,
          all_pre_in_range_weights) = self.__compute_statistics(
             synapse_info.weights, synapse_info.delays, pre_vertex_slice,
@@ -441,8 +441,8 @@ class KernelConnector(AbstractGenerateConnectorOnMachine):
 
     @overrides(AbstractGenerateConnectorOnMachine.gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         return numpy.array(self._kernel_properties, dtype="uint32")
 
     @property

--- a/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/multapse_connector.py
@@ -176,10 +176,13 @@ class MultapseConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         # update the synapses as required, and get the number of connections
+
+        pre_slice_index = pre_slices.index(pre_vertex_slice)
+        post_slice_index = post_slices.index(post_vertex_slice)
         self._update_synapses_per_post_vertex(pre_slices, post_slices)
         n_connections = self._get_n_connections(
             pre_slice_index, post_slice_index)
@@ -279,8 +282,11 @@ class MultapseConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractGenerateConnectorOnMachine.gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
+        pre_slice_index = pre_slices.index(pre_vertex_slice)
+        post_slice_index = post_slices.index(post_vertex_slice)
+
         params = []
 
         if synapse_info.prepop_is_view:

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -85,8 +85,8 @@ class OneToOneConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         pre_lo, post_lo, pre_hi, post_hi = self._get_pre_post_limits(
             pre_vertex_slice, post_vertex_slice, synapse_info)
@@ -168,8 +168,8 @@ class OneToOneConnector(AbstractGenerateConnectorOnMachine,
 
     @overrides(AbstractGenerateConnectorOnMachine.gen_connector_params)
     def gen_connector_params(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         params = self._basic_connector_params(synapse_info)
         return numpy.array(params, dtype="uint32")
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
@@ -123,8 +123,8 @@ class SmallWorldConnector(AbstractConnector):
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(
-            self, pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_type, synapse_info):
+            self, pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_type, synapse_info):
         # pylint: disable=too-many-arguments
         ids = numpy.where(self.__mask[
             pre_vertex_slice.as_slice, post_vertex_slice.as_slice])

--- a/spynnaker/pyNN/models/neuron/generator_data.py
+++ b/spynnaker/pyNN/models/neuron/generator_data.py
@@ -30,10 +30,8 @@ class GeneratorData(object):
         "__max_row_n_synapses",
         "__max_row_n_words",
         "__max_stage",
-        "__post_slice_index",
         "__post_slices",
         "__post_vertex_slice",
-        "__pre_slice_index",
         "__pre_slices",
         "__pre_vertex_slice",
         "__synapse_information",
@@ -44,9 +42,9 @@ class GeneratorData(object):
     def __init__(
             self, synaptic_matrix_offset, delayed_synaptic_matrix_offset,
             max_row_n_words, max_delayed_row_n_words, max_row_n_synapses,
-            max_delayed_row_n_synapses, pre_slices, pre_slice_index,
-            post_slices, post_slice_index, pre_vertex_slice, post_vertex_slice,
-            synapse_information, max_stage, machine_time_step):
+            max_delayed_row_n_synapses, pre_slices, post_slices,
+            pre_vertex_slice, post_vertex_slice, synapse_information,
+            max_stage, machine_time_step):
         self.__synaptic_matrix_offset = synaptic_matrix_offset
         self.__delayed_synaptic_matrix_offset = delayed_synaptic_matrix_offset
         self.__max_row_n_words = max_row_n_words
@@ -54,9 +52,7 @@ class GeneratorData(object):
         self.__max_row_n_synapses = max_row_n_synapses
         self.__max_delayed_row_n_synapses = max_delayed_row_n_synapses
         self.__pre_slices = pre_slices
-        self.__pre_slice_index = pre_slice_index
         self.__post_slices = post_slices
-        self.__post_slice_index = post_slice_index
         self.__pre_vertex_slice = pre_vertex_slice
         self.__post_vertex_slice = post_vertex_slice
         self.__synapse_information = synapse_information
@@ -109,8 +105,7 @@ class GeneratorData(object):
             dtype="uint32"))
         items.append(synapse_dynamics.gen_matrix_params)
         items.append(connector.gen_connector_params(
-            self.__pre_slices, self.__pre_slice_index, self.__post_slices,
-            self.__post_slice_index, self.__pre_vertex_slice,
+            self.__pre_slices, self.__post_slices, self.__pre_vertex_slice,
             self.__post_vertex_slice, self.__synapse_information.synapse_type,
             self.__synapse_information))
         items.append(connector.gen_weights_params(

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -298,8 +298,7 @@ class SynapseIORowBased(object):
         return max_row_length, row_data
 
     def get_synapses(
-            self, synapse_info, pre_slices, pre_slice_index,
-            post_slices, post_slice_index, pre_vertex_slice,
+            self, synapse_info, pre_slices, post_slices, pre_vertex_slice,
             post_vertex_slice, n_delay_stages, population_table,
             n_synapse_types, weight_scales, machine_time_step,
             app_edge, machine_edge):
@@ -309,9 +308,7 @@ class SynapseIORowBased(object):
 
         :param SynapseInformation synapse_info:
         :param list(~pacman.model.graphs.common.Slice) pre_slices:
-        :param int pre_slice_index:
         :param list(~pacman.model.graphs.common.Slice) post_slices:
-        :param int post_slice_index:
         :param ~pacman.model.graphs.common.Slice pre_vertex_slice:
         :param ~pacman.model.graphs.common.Slice post_vertex_slice:
         :param int n_delay_stages:
@@ -336,9 +333,8 @@ class SynapseIORowBased(object):
 
         # Get the actual connections
         connections = synapse_info.connector.create_synaptic_block(
-            pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_info.synapse_type,
-            synapse_info)
+            pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_info.synapse_type, synapse_info)
 
         # Convert delays to timesteps
         connections["delay"] = numpy.rint(

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -837,11 +837,10 @@ class SynapticManager(object):
                         continue
 
                     block_addr, single_addr, index = self.__write_block(
-                        spec, synapse_info, pre_slices, pre_vertex.index,
-                        post_slices, pre_vertex_slice,
-                        post_vertex_slice, edge.app_edge, single_synapses,
-                        weight_scales, machine_time_step, rinfo,
-                        all_syn_block_sz, block_addr, single_addr,
+                        spec, synapse_info, pre_slices, post_slices,
+                        pre_vertex_slice, post_vertex_slice, edge.app_edge,
+                        single_synapses, weight_scales, machine_time_step,
+                        rinfo, all_syn_block_sz, block_addr, single_addr,
                         machine_edge=edge)
                     self.__synapse_indices[
                         synapse_info, pre_vertex_slice.lo_atom] = index

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -66,7 +66,7 @@ _ONE_WORD = struct.Struct("<I")
 
 # Information about a connector to be generated on machine
 _Gen = namedtuple(
-    "_Gen", "synapse_info, pre_slices, pre_slice, pre_index, app_edge, rinfo")
+    "_Gen", "synapse_info, pre_slices, pre_slice, app_edge, rinfo")
 
 
 class SynapticManager(object):
@@ -773,7 +773,7 @@ class SynapticManager(object):
         return next_block_start_address
 
     def _write_synaptic_matrix_and_master_population_table(
-            self, spec, post_slices, post_slice_index, machine_vertex,
+            self, spec, post_slices, machine_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             routing_info, machine_graph, machine_time_step):
         """ Simultaneously generates both the master population table and
@@ -781,7 +781,6 @@ class SynapticManager(object):
 
         :param ~.DataSpecificationGenerator spec:
         :param list(~pacman.model.graphs.common.Slice) post_slices:
-        :param int post_slice_index:
         :param .MachineVertex machine_vertex:
         :param ~pacman.model.graphs.common.Slice post_vertex_slice:
         :param all_syn_block_sz:
@@ -833,13 +832,13 @@ class SynapticManager(object):
                         # We will process this a little later
                         generate_on_machine.append(_Gen(
                             synapse_info, pre_slices, pre_vertex_slice,
-                            pre_vertex.index, edge.app_edge, rinfo))
+                            edge.app_edge, rinfo))
                         spec.comment("Will generate on machine")
                         continue
 
                     block_addr, single_addr, index = self.__write_block(
                         spec, synapse_info, pre_slices, pre_vertex.index,
-                        post_slices, post_slice_index, pre_vertex_slice,
+                        post_slices, pre_vertex_slice,
                         post_vertex_slice, edge.app_edge, single_synapses,
                         weight_scales, machine_time_step, rinfo,
                         all_syn_block_sz, block_addr, single_addr,
@@ -855,7 +854,7 @@ class SynapticManager(object):
         # numpy.random.shuffle(order)
         for gen in generate_on_machine:
             block_addr, index = self.__generate_on_chip_data(
-                gen, post_slices, post_slice_index, post_vertex_slice,
+                gen, post_slices, post_vertex_slice,
                 all_syn_block_sz, block_addr, machine_time_step,
                 generator_data)
             self.__synapse_indices[
@@ -909,13 +908,12 @@ class SynapticManager(object):
                 synapse_info))
 
     def __generate_on_chip_data(
-            self, gen, post_slices, post_slice_index, post_vertex_slice,
+            self, gen, post_slices, post_vertex_slice,
             all_syn_block_sz, block_addr, machine_time_step, generator_data):
         """ Generate data for the synapse expander
 
         :param _Gen gen:
         :param list(.Slice) post_slices:
-        :param int post_slice_index:
         :param .Slice post_vertex_slice:
         :param int all_syn_block_sz:
         :param int block_addr:
@@ -936,7 +934,7 @@ class SynapticManager(object):
             gen.app_edge.delay_edge.pre_vertex.add_generator_data(
                 max_row_info.undelayed_max_n_synapses,
                 max_row_info.delayed_max_n_synapses, gen.pre_slices,
-                gen.pre_index, post_slices, post_slice_index, gen.pre_slice,
+                post_slices, gen.pre_slice,
                 post_vertex_slice, gen.synapse_info,
                 gen.app_edge.n_delay_stages + 1, machine_time_step)
         elif max_row_info.delayed_max_n_synapses != 0:
@@ -1003,8 +1001,8 @@ class SynapticManager(object):
             synaptic_matrix_offset, delayed_synaptic_matrix_offset,
             max_row_info.undelayed_max_words, max_row_info.delayed_max_words,
             max_row_info.undelayed_max_n_synapses,
-            max_row_info.delayed_max_n_synapses, gen.pre_slices, gen.pre_index,
-            post_slices, post_slice_index, gen.pre_slice, post_vertex_slice,
+            max_row_info.delayed_max_n_synapses, gen.pre_slices,
+            post_slices, gen.pre_slice, post_vertex_slice,
             gen.synapse_info, n_delay_stages + 1, machine_time_step))
         self.__gen_on_machine[post_vertex_slice] = True
 
@@ -1016,7 +1014,7 @@ class SynapticManager(object):
 
     def __write_block(
             self, spec, synapse_info, pre_slices,
-            pre_slice_index, post_slices, post_slice_index, pre_vertex_slice,
+            post_slices, pre_vertex_slice,
             post_vertex_slice, app_edge, single_synapses,
             weight_scales, machine_time_step, rinfo, all_syn_block_sz,
             block_addr, single_addr, machine_edge):
@@ -1024,9 +1022,7 @@ class SynapticManager(object):
         :param ~.DataSpecificationGenerator spec:
         :param SynapseInformation synapse_info:
         :param list(.Slice) pre_slices:
-        :param int pre_slice_index:
         :param list(.Slice) post_slices:
-        :param int post_slice_index:
         :param .Slice pre_vertex_slice:
         :param .Slice post_vertex_slice:
         :param ProjectionApplicationEdge app_edge:
@@ -1042,9 +1038,8 @@ class SynapticManager(object):
         """
         (row_data, row_length, delayed_row_data, delayed_row_length,
          delayed_source_ids, delay_stages) = self.__synapse_io.get_synapses(
-             synapse_info, pre_slices, pre_slice_index, post_slices,
-             post_slice_index, pre_vertex_slice, post_vertex_slice,
-             app_edge.n_delay_stages, self.__poptable_type,
+             synapse_info, pre_slices, post_slices, pre_vertex_slice,
+            post_vertex_slice, app_edge.n_delay_stages, self.__poptable_type,
              self.__n_synapse_types, weight_scales, machine_time_step,
              app_edge=app_edge, machine_edge=machine_edge)
 
@@ -1221,7 +1216,6 @@ class SynapticManager(object):
                     routing_info.get_routing_info_for_edge(m_edge)
 
         post_slices = application_vertex.vertex_slices
-        post_slice_idx = machine_vertex.index
 
         # Reserve the memory
         in_edges = application_graph.get_edges_ending_at_vertex(
@@ -1239,7 +1233,7 @@ class SynapticManager(object):
             spec, ring_buffer_shifts, weight_scale)
 
         gen_data = self._write_synaptic_matrix_and_master_population_table(
-            spec, post_slices, post_slice_idx, machine_vertex,
+            spec, post_slices, machine_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             routing_info, machine_graph, machine_time_step)
 

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
@@ -178,18 +178,15 @@ class DelayExtensionVertex(
             self.__delay_blocks[vertex_slice].add_delay(source_id, stage)
 
     def add_generator_data(
-            self, max_row_n_synapses, max_delayed_row_n_synapses,
-            pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_information,
-            max_stage, machine_time_step):
+            self, max_row_n_synapses, max_delayed_row_n_synapses, pre_slices,
+            post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_information, max_stage, machine_time_step):
         """ Add delays for a connection to be generated
 
         :param int max_row_n_synapses:
         :param int max_delayed_row_n_synapses:
         :param list(~pacman.model.graphs.common.Slice) pre_slices:
-        :param int pre_slice_index:
         :param list(~pacman.model.graphs.common.Slice) post_slices:
-        :param int post_slice_index:
         :param ~pacman.model.graphs.common.Slice pre_vertex_slice:
         :param ~pacman.model.graphs.common.Slice post_vertex_slice:
         :param ~spynnaker.pyNN.models.neural_projections.SynapseInformation \
@@ -200,8 +197,7 @@ class DelayExtensionVertex(
         self.__delay_generator_data[pre_vertex_slice].append(
             DelayGeneratorData(
                 max_row_n_synapses, max_delayed_row_n_synapses,
-                pre_slices, pre_slice_index, post_slices, post_slice_index,
-                pre_vertex_slice, post_vertex_slice,
+                pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
                 synapse_information, max_stage, machine_time_step))
 
     @inject_items({

--- a/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
@@ -37,9 +37,8 @@ class DelayGeneratorData(object):
 
     def __init__(
             self, max_row_n_synapses, max_delayed_row_n_synapses,
-            pre_slices, pre_slice_index, post_slices, post_slice_index,
-            pre_vertex_slice, post_vertex_slice, synapse_information,
-            max_stage, machine_time_step):
+            pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
+            synapse_information, max_stage, machine_time_step):
         """
         :param int max_row_n_synapses:
         :param int max_delayed_row_n_synapses:

--- a/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_generator_data.py
@@ -28,10 +28,8 @@ class DelayGeneratorData(object):
         "__max_row_n_synapses",
         "__max_stage",
         "__post_slices",
-        "__post_slice_index",
         "__post_vertex_slice",
         "__pre_slices",
-        "__pre_slice_index",
         "__pre_vertex_slice",
         "__synapse_information")
 
@@ -46,9 +44,7 @@ class DelayGeneratorData(object):
         :param int max_row_n_synapses:
         :param int max_delayed_row_n_synapses:
         :param list(~pacman.model.graphs.common.Slice) pre_slices:
-        :param int pre_slice_index:
         :param list(~pacman.model.graphs.common.Slice) post_slices:
-        :param int post_slice_index:
         :param ~pacman.model.graphs.common.Slicepre_vertex_slice:
         :param ~pacman.model.graphs.common.Slicepost_vertex_slice:
         :param SynapseInformation synapse_information:
@@ -58,9 +54,7 @@ class DelayGeneratorData(object):
         self.__max_row_n_synapses = max_row_n_synapses
         self.__max_delayed_row_n_synapses = max_delayed_row_n_synapses
         self.__pre_slices = pre_slices
-        self.__pre_slice_index = pre_slice_index
         self.__post_slices = post_slices
-        self.__post_slice_index = post_slice_index
         self.__pre_vertex_slice = pre_vertex_slice
         self.__post_vertex_slice = post_vertex_slice
         self.__synapse_information = synapse_information
@@ -100,8 +94,7 @@ class DelayGeneratorData(object):
             connector.gen_delays_id(self.__synapse_information.delays)],
             dtype="uint32"))
         items.append(connector.gen_connector_params(
-            self.__pre_slices, self.__pre_slice_index, self.__post_slices,
-            self.__post_slice_index, self.__pre_vertex_slice,
+            self.__pre_slices, self.__post_slices, self.__pre_vertex_slice,
             self.__post_vertex_slice, self.__synapse_information.synapse_type,
             self.__synapse_information))
         items.append(connector.gen_delay_params(

--- a/unittests/connector_tests/test_csa_connector.py
+++ b/unittests/connector_tests/test_csa_connector.py
@@ -34,8 +34,8 @@ def test_csa_one_to_one_connector():
     pre_vertex_slice = Slice(0, 10)
     post_vertex_slice = Slice(0, 10)
     block = connector.create_synaptic_block(
-        [pre_vertex_slice], 0, [post_vertex_slice], 0,
-        pre_vertex_slice, post_vertex_slice, 0, mock_synapse_info)
+        [pre_vertex_slice], [post_vertex_slice], pre_vertex_slice,
+        post_vertex_slice, 0, mock_synapse_info)
     assert(len(block) > 0)
     assert(all(item["source"] == item["target"] for item in block))
     assert(all(item["weight"] == 1.0 for item in block))
@@ -55,7 +55,7 @@ def test_csa_from_list_connector():
     pre_vertex_slice = Slice(0, 10)
     post_vertex_slice = Slice(0, 10)
     block = connector.create_synaptic_block(
-        [pre_vertex_slice], 0, [post_vertex_slice], 0,
+        [pre_vertex_slice], [post_vertex_slice],
         pre_vertex_slice, post_vertex_slice, 0, mock_synapse_info)
     assert(len(block) > 0)
     assert(all(item["source"] == conn[0]
@@ -78,8 +78,8 @@ def test_csa_random_connector():
     pre_vertex_slice = Slice(0, 10)
     post_vertex_slice = Slice(0, 10)
     block = connector.create_synaptic_block(
-        [pre_vertex_slice], 0, [post_vertex_slice], 0,
-        pre_vertex_slice, post_vertex_slice, 0, mock_synapse_info)
+        [pre_vertex_slice], [post_vertex_slice], pre_vertex_slice,
+        post_vertex_slice, 0, mock_synapse_info)
     assert(len(block) >= 0)
     assert(all(item["weight"] == 1.0 for item in block))
     assert(all(item["delay"] == 2.0 for item in block))

--- a/unittests/connector_tests/test_from_list_connector.py
+++ b/unittests/connector_tests/test_from_list_connector.py
@@ -78,8 +78,7 @@ def test_connector(
                                         MockPopulation(10, "Post"),
                                         weights, delays)
     block = connector.create_synaptic_block(
-        [pre_slice], 0, [post_slice], 0,
-        pre_slice, post_slice, 1, mock_synapse_info)
+        [pre_slice], [post_slice], pre_slice, post_slice, 1, mock_synapse_info)
     assert(numpy.array_equal(block["weight"], numpy.array(expected_weights)))
     assert(numpy.array_equal(block["delay"], numpy.array(expected_delays)))
 
@@ -124,11 +123,11 @@ def test_connector_split():
     has_block = set()
     try:
         # Check each connection is in the right place
-        for i, pre_slice in enumerate(pre_slices):
-            for j, post_slice in enumerate(post_slices):
+        for pre_slice in pre_slices:
+            for post_slice in post_slices:
                 block = connector.create_synaptic_block(
-                    pre_slices, i, post_slices, j,
-                    pre_slice, post_slice, 1, mock_synapse_info)
+                    pre_slices, post_slices, pre_slice, post_slice, 1,
+                    mock_synapse_info)
                 for source in block["source"]:
                     assert(pre_slice.lo_atom <= source <= pre_slice.hi_atom)
                 for target in block["target"]:

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -292,7 +292,7 @@ class TestSynapticManager(unittest.TestCase):
         synaptic_manager._direct_matrix_region = direct_region
 
         synaptic_manager._write_synaptic_matrix_and_master_population_table(
-            spec, [post_vertex_slice], post_slice_index, post_vertex,
+            spec, [post_vertex_slice], post_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             routing_info, graph, machine_time_step)
         spec.end_specification()

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -229,7 +229,6 @@ class TestSynapticManager(unittest.TestCase):
         post_vertex_slice = Slice(0, 9)
         post_vertex = post_app_vertex.create_machine_vertex(
             post_vertex_slice, None)
-        post_slice_index = 0
 
         one_to_one_connector_1 = OneToOneConnector(None)
         direct_synapse_information_1 = SynapseInformation(

--- a/unittests/model_tests/test_connectors.py
+++ b/unittests/model_tests/test_connectors.py
@@ -131,8 +131,7 @@ def test_connectors(
             assert(max_col_length == connector.
                    get_n_connections_to_post_vertex_maximum(mock_synapse_info))
         synaptic_block = connector.create_synaptic_block(
-            pre_slices, pre_slice_index, post_slices,
-            post_slice_index, pre_vertex_slice, post_vertex_slice,
+            pre_slices, post_slices, pre_vertex_slice, post_vertex_slice,
             synapse_type, mock_synapse_info)
         source_histogram = numpy.histogram(
             synaptic_block["source"], pre_range)[0]
@@ -149,8 +148,7 @@ def test_connectors(
         if len(post_slices) > post_slice_index + 1:
             test_post_slice = post_slices[post_slice_index + 1]
             test_synaptic_block = connector.create_synaptic_block(
-                pre_slices, pre_slice_index, post_slices,
-                post_slice_index + 1, pre_vertex_slice, test_post_slice,
+                pre_slices, post_slices, pre_vertex_slice, test_post_slice,
                 synapse_type, mock_synapse_info)
             if len(test_synaptic_block) > 0:
                 assert not numpy.array_equal(
@@ -158,8 +156,7 @@ def test_connectors(
         if len(pre_slices) > pre_slice_index + 1:
             test_pre_slice = pre_slices[pre_slice_index + 1]
             test_synaptic_block = connector.create_synaptic_block(
-                pre_slices, pre_slice_index + 1, post_slices,
-                post_slice_index, test_pre_slice, post_vertex_slice,
+                pre_slices, post_slices, test_pre_slice, post_vertex_slice,
                 synapse_type, mock_synapse_info)
             if len(test_synaptic_block) > 0:
                 assert not numpy.array_equal(


### PR DESCRIPTION
The assumption that machine_vertex.app_vertex.vertex_slices[machine_vertex.index] == machine_vertex.vertex_slice will not hold when we move to splitter models that partition by different types of machine vertexes. Example synapse and neuron cores

This slightly slows down the MultapseConnector if there are a lot of machine vertexes but speeds up everything else as there are less parameters to pass around.

Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/461