### PR TITLE
Edge saves slices

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
@@ -126,8 +126,8 @@ class ProjectionApplicationEdge(ApplicationEdge, AbstractSlicesConnect):
 
     @overrides(ApplicationEdge.remember_associated_machine_edge)
     def remember_associated_machine_edge(self, machine_edge):
-        super(ProjectionApplicationEdge, self).remember_associated_machine_edge(
-            machine_edge)
+        super(ProjectionApplicationEdge, self).\
+            remember_associated_machine_edge(machine_edge)
         if self.__slices_list_mode:
             # Unexpected but if extra remember after a get convert back to sets
             self.__pre_slices = set(self.__pre_slices)

--- a/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
@@ -38,7 +38,15 @@ class ProjectionApplicationEdge(ApplicationEdge, AbstractSlicesConnect):
     __slots__ = [
         "__delay_edge",
         "__stored_synaptic_data_from_machine",
-        "__synapse_information"]
+        "__synapse_information",
+        # Slices of the pre_vertexes of the machine_edges
+        "__pre_slices",
+
+        # Slices of the post_vertexes of the machine_edges
+        "__post_slices",
+        # True if slices have been convered to sorted lists
+        "__slices_list_mode"
+    ]
 
     def __init__(
             self, pre_vertex, post_vertex, synapse_information, label=None):
@@ -60,6 +68,10 @@ class ProjectionApplicationEdge(ApplicationEdge, AbstractSlicesConnect):
         self.__delay_edge = None
 
         self.__stored_synaptic_data_from_machine = None
+
+        self.__pre_slices = set()
+        self.__post_slices = set()
+        self.__slices_list_mode = False
 
     def add_synapse_information(self, synapse_information):
         """
@@ -111,3 +123,67 @@ class ProjectionApplicationEdge(ApplicationEdge, AbstractSlicesConnect):
                     synapse_info, pre_slice, post_slice):
                 return True
         return False
+
+    @overrides(ApplicationEdge.remember_associated_machine_edge)
+    def remember_associated_machine_edge(self, machine_edge):
+        super(ProjectionApplicationEdge, self).remember_associated_machine_edge(
+            machine_edge)
+        if self.__slices_list_mode:
+            # Unexpected but if extra remember after a get convert back to sets
+            self.__pre_slices = set(self.__pre_slices)
+            self.__post_slices = set(self.__post_slices)
+            self.__slices_list_mode = False
+        self.__pre_slices.add(machine_edge.pre_vertex.vertex_slice)
+        self.__post_slices.add(machine_edge.post_vertex.vertex_slice)
+
+    @overrides(ApplicationEdge.forget_machine_edges)
+    def forget_machine_edges(self):
+        super(ProjectionApplicationEdge, self).forget_machine_edges()
+        self.__pre_slices = set()
+        self.__post_slices = set()
+        self.__slices_list_mode = False
+
+    def __check_list_mode(self):
+        """
+        Makes sure the pre and post slices are sorted lists
+        """
+        if not self.__slices_list_mode:
+            self.__pre_slices = sorted(
+                list(self.__pre_slices), key=lambda x: x.lo_atom)
+            self.__post_slices = sorted(
+                list(self.__post_slices), key=lambda x: x.lo_atom)
+            self.__slices_list_mode = True
+
+    @property
+    def pre_slices(self):
+        """
+        Get the slices for the pre_vertexes of the MachineEdges
+
+        While the remember machine_edges remain unchanged this will return a
+        list with a consitent id. If the edges change a new list is created
+
+        The List will be sorted by lo_atom.
+        No checking is done for overlaps or gaps
+
+        :return: Ordered list of pre slices
+        :rtype list(Slice)
+        """
+        self.__check_list_mode()
+        return self.__pre_slices
+
+    @property
+    def post_slices(self):
+        """
+        Get the slices for the post_vertexes of the MachineEdges
+
+        While the remember machine_edges remain unchanged this will return a
+        list with a consitent id. If the edges change a new list is created
+
+        The List will be sorted by lo_atom.
+        No checking is done for overlaps or gaps
+
+        :return: Ordered list of post slices
+        :rtype list(Slice)
+        """
+        self.__check_list_mode()
+        return self.__post_slices

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -773,7 +773,7 @@ class SynapticManager(object):
         return next_block_start_address
 
     def _write_synaptic_matrix_and_master_population_table(
-            self, spec, post_slices, post_slice_index, machine_vertex,
+            self, spec, post_slice_index, machine_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             routing_info, machine_graph, machine_time_step):
         """ Simultaneously generates both the master population table and
@@ -820,7 +820,8 @@ class SynapticManager(object):
 
                 pre_vertex = edge.pre_vertex
                 pre_vertex_slice = pre_vertex.vertex_slice
-                pre_slices = edge.app_edge.pre_vertex.vertex_slices
+                post_slices = edge.post_slices
+                pre_slices = edge.app_edge.pre_slices
 
                 for synapse_info in edge.app_edge.synapse_information:
                     rinfo = routing_info.get_routing_info_for_edge(edge)
@@ -1220,7 +1221,6 @@ class SynapticManager(object):
                                        m_edge.pre_vertex.vertex_slice] = \
                     routing_info.get_routing_info_for_edge(m_edge)
 
-        post_slices = application_vertex.vertex_slices
         post_slice_idx = machine_vertex.index
 
         # Reserve the memory
@@ -1239,7 +1239,7 @@ class SynapticManager(object):
             spec, ring_buffer_shifts, weight_scale)
 
         gen_data = self._write_synaptic_matrix_and_master_population_table(
-            spec, post_slices, post_slice_idx, machine_vertex,
+            spec, post_slice_idx, machine_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             routing_info, machine_graph, machine_time_step)
 

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -820,7 +820,7 @@ class SynapticManager(object):
 
                 pre_vertex = edge.pre_vertex
                 pre_vertex_slice = pre_vertex.vertex_slice
-                post_slices = edge.post_slices
+                post_slices = edge.app_edge.post_slices
                 pre_slices = edge.app_edge.pre_slices
 
                 for synapse_info in edge.app_edge.synapse_information:

--- a/unittests/model_tests/neuron/test_projection_application_edge.py
+++ b/unittests/model_tests/neuron/test_projection_application_edge.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pacman.model.graphs.common import Slice
+from pacman.model.graphs.machine import MachineEdge
+from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
+from pacman.model.graphs.machine import SimpleMachineVertex
+
+def test_slices():
+    app_edge = ProjectionApplicationEdge(None, None, None)
+    mv0_2 = SimpleMachineVertex(None, None, None, None, Slice(0, 1))
+    mv2_4 = SimpleMachineVertex(None, None, None, None, Slice(2, 3))
+    mv4_6 = SimpleMachineVertex(None, None, None, None, Slice(4, 5))
+    app_edge.remember_associated_machine_edge(MachineEdge(mv0_2, mv2_4))
+    app_edge.remember_associated_machine_edge(MachineEdge(mv4_6, mv0_2))
+    app_edge.remember_associated_machine_edge(MachineEdge(mv0_2, mv2_4))
+    assert app_edge.pre_slices == [Slice(0, 1), Slice(4, 5)]
+    post1 = app_edge.post_slices
+    assert post1 ==  [Slice(0, 1), Slice(2, 3)]
+    app_edge.remember_associated_machine_edge(MachineEdge(mv0_2, mv0_2))
+    app_edge.remember_associated_machine_edge(MachineEdge(mv2_4, mv2_4))
+    assert app_edge.pre_slices == [Slice(0, 1), Slice(2, 3), Slice(4, 5)]
+    post2 = app_edge.post_slices
+    assert post1 == post2
+    assert id(post1) != id(post2)
+

--- a/unittests/model_tests/neuron/test_projection_application_edge.py
+++ b/unittests/model_tests/neuron/test_projection_application_edge.py
@@ -18,6 +18,7 @@ from pacman.model.graphs.machine import MachineEdge
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 from pacman.model.graphs.machine import SimpleMachineVertex
 
+
 def test_slices():
     app_edge = ProjectionApplicationEdge(None, None, None)
     mv0_2 = SimpleMachineVertex(None, None, None, None, Slice(0, 1))
@@ -28,11 +29,10 @@ def test_slices():
     app_edge.remember_associated_machine_edge(MachineEdge(mv0_2, mv2_4))
     assert app_edge.pre_slices == [Slice(0, 1), Slice(4, 5)]
     post1 = app_edge.post_slices
-    assert post1 ==  [Slice(0, 1), Slice(2, 3)]
+    assert post1 == [Slice(0, 1), Slice(2, 3)]
     app_edge.remember_associated_machine_edge(MachineEdge(mv0_2, mv0_2))
     app_edge.remember_associated_machine_edge(MachineEdge(mv2_4, mv2_4))
     assert app_edge.pre_slices == [Slice(0, 1), Slice(2, 3), Slice(4, 5)]
     post2 = app_edge.post_slices
     assert post1 == post2
     assert id(post1) != id(post2)
-

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -292,7 +292,7 @@ class TestSynapticManager(unittest.TestCase):
         synaptic_manager._direct_matrix_region = direct_region
 
         synaptic_manager._write_synaptic_matrix_and_master_population_table(
-            spec, [post_vertex_slice], post_slice_index, post_vertex,
+            spec, post_slice_index, post_vertex,
             post_vertex_slice, all_syn_block_sz, weight_scales,
             routing_info, graph, machine_time_step)
         spec.end_specification()


### PR DESCRIPTION
In the past the slices came from the Applcation Vertex to be used in the SynampticManager calls.

But an ApplicationVertex could have multiple types of Vertexes with multiple sets of slices so wrong.

This saves the slice in the edge next to to SynampticManager 

Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/463