### PR TITLE
Switch scaling to using u3232 instead of s1615

### DIFF
--- a/neural_modelling/src/synapse_expander/matrix_generator.c
+++ b/neural_modelling/src/synapse_expander/matrix_generator.c
@@ -175,15 +175,15 @@ static inline uint16_t rescale_delay(accum delay, accum timestep_per_delay) {
 //! \param[in] weight: the weight to rescale
 //! \param[in] weight_scale: The weight scaling factor
 //! \return the rescaled weight
-static inline uint16_t rescale_weight(accum weight, accum weight_scale) {
+static inline uint16_t rescale_weight(accum weight, unsigned long accum weight_scale) {
     if (weight < 0) {
         weight = -weight;
     }
-    weight = weight * weight_scale;
-    uint16_t weight_int = (uint16_t) weight;
-    if (weight != weight_int) {
+    accum weight_scaled = weight * weight_scale;
+    uint16_t weight_int = (uint16_t) weight_scaled;
+    if (weight_scaled != weight_int) {
         log_debug("Rounded weight %k to %u (scale is %k)",
-                weight, weight_int, weight_scale);
+                weight_scaled, weight_int, weight_scale);
     }
     return weight_int;
 }
@@ -194,7 +194,7 @@ bool matrix_generator_generate(
         uint32_t max_row_n_words, uint32_t max_delayed_row_n_words,
         uint32_t max_row_n_synapses, uint32_t max_delayed_row_n_synapses,
         uint32_t n_synapse_type_bits, uint32_t n_synapse_index_bits,
-        uint32_t synapse_type, accum *weight_scales,
+        uint32_t synapse_type, unsigned long accum *weight_scales,
         uint32_t post_slice_start, uint32_t post_slice_count,
         uint32_t pre_slice_start, uint32_t pre_slice_count,
         connection_generator_t connection_generator,

--- a/neural_modelling/src/synapse_expander/matrix_generator.h
+++ b/neural_modelling/src/synapse_expander/matrix_generator.h
@@ -84,7 +84,7 @@ bool matrix_generator_generate(
         uint32_t max_row_n_words, uint32_t max_delayed_row_n_words,
         uint32_t max_row_n_synapses, uint32_t max_delayed_row_n_synapses,
         uint32_t n_synapse_type_bits, uint32_t n_synapse_index_bits,
-        uint32_t synapse_type, accum *weight_scales,
+        uint32_t synapse_type, unsigned long accum *weight_scales,
         uint32_t post_slice_start, uint32_t post_slice_count,
         uint32_t pre_slice_start, uint32_t pre_slice_count,
         connection_generator_t connection_generator,

--- a/neural_modelling/src/synapse_expander/synapse_expander.c
+++ b/neural_modelling/src/synapse_expander/synapse_expander.c
@@ -80,7 +80,7 @@ struct expander_config {
 static bool read_connection_builder_region(address_t *in_region,
         address_t synaptic_matrix_region, uint32_t post_slice_start,
         uint32_t post_slice_count, uint32_t n_synapse_type_bits,
-        uint32_t n_synapse_index_bits, accum *weight_scales) {
+        uint32_t n_synapse_index_bits, unsigned long accum *weight_scales) {
     address_t region = *in_region;
     struct connection_builder_config config;
     fast_memcpy(&config, region, sizeof(config));
@@ -166,10 +166,10 @@ static bool run_synapse_expander(
             config.n_in_edges, config.post_slice_count, config.post_slice_start);
 
     // Read in the weight scales, one per synapse type
-    accum weight_scales[config.n_synapse_types];
+    unsigned long accum weight_scales[config.n_synapse_types];
     fast_memcpy(weight_scales, params_address,
-            sizeof(accum) * config.n_synapse_types);
-    params_address += config.n_synapse_types;
+            sizeof(unsigned long accum) * config.n_synapse_types);
+    params_address += 2 * config.n_synapse_types;
 
     // Go through each connector and generate
     for (uint32_t edge = 0; edge < config.n_in_edges; edge++) {

--- a/spynnaker/pyNN/models/neuron/synaptic_manager.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_manager.py
@@ -1548,7 +1548,7 @@ class SynapticManager(object):
 
         n_bytes = (
             _SYNAPSES_BASE_GENERATOR_SDRAM_USAGE_IN_BYTES +
-            (self.__n_synapse_types * BYTES_PER_WORD))
+            (self.__n_synapse_types * 2 * BYTES_PER_WORD))
         for data in generator_data:
             n_bytes += data.size
 
@@ -1567,8 +1567,9 @@ class SynapticManager(object):
         for w in weight_scales:
             # if the weights are high enough and the population size large
             # enough, then weight_scales < 1 will result in a zero scale
-            # if converted to an int, so this needs to be an S1615
-            dtype = DataType.S1615
+            # if converted to an int, so we use U3232 here instead (as there
+            # can be scales larger than U1616.max in conductance-based models)
+            dtype = DataType.U3232
             spec.write_value(data=min(w, dtype.max), data_type=dtype)
 
         for data in generator_data:


### PR DESCRIPTION
Found an example (thanks to @such-a-git) that doesn't work when using S1615 for scaling, so this switches to using U3232 instead.

Tested by (& merge with) https://github.com/SpiNNakerManchester/sPyNNaker8/pull/466