### PR TITLE
all or nothing for machinevertex.appvertex

### DIFF
--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -223,7 +223,6 @@ def test_write_data_spec():
     graph.add_edge(machine_edge, partition_name)
     graph.add_edge(delay_machine_edge, partition_name)
 
-    app_graph = ApplicationGraph("Test")
     app_graph.add_vertex(pre_app_vertex)
     app_graph.add_vertex(post_app_vertex)
     app_graph.add_vertex(delay_app_vertex)

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -215,7 +215,8 @@ def test_write_data_spec():
         delay_vertex, post_vertex, label=None)
     partition_name = "TestPartition"
 
-    graph = MachineGraph("Test")
+    app_graph = ApplicationGraph("Test")
+    graph = MachineGraph("Test", app_graph)
     graph.add_vertex(pre_vertex)
     graph.add_vertex(post_vertex)
     graph.add_vertex(delay_vertex)


### PR DESCRIPTION
With https://github.com/SpiNNakerManchester/PACMAN/pull/312
It now matters if the app grpah not passed to the machine graph