### PR TITLE
spynapse_expander at the machine level

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/algorithms_metadata.xml
+++ b/spynnaker/pyNN/extra_algorithms/algorithms_metadata.xml
@@ -22,11 +22,7 @@
         <python_module>spynnaker.pyNN.extra_algorithms.synapse_expander</python_module>
         <python_function>synapse_expander</python_function>
         <input_definitions>
-            <parameter>
-                <param_name>app_graph</param_name>
-                <param_type>MemoryApplicationGraph</param_type>
-            </parameter>
-            <parameter>
+           <parameter>
                 <param_name>placements</param_name>
                 <param_type>MemoryPlacements</param_type>
             </parameter>
@@ -49,7 +45,6 @@
         </input_definitions>
         <required_inputs>
             <param_name>extract_iobuf</param_name>
-            <param_name>app_graph</param_name>
             <param_name>placements</param_name>
             <param_name>transceiver</param_name>
             <param_name>provenance_file_path</param_name>

--- a/spynnaker/pyNN/extra_algorithms/synapse_expander.py
+++ b/spynnaker/pyNN/extra_algorithms/synapse_expander.py
@@ -20,25 +20,22 @@ from spinn_front_end_common.utilities.utility_objs import ExecutableType
 from spinn_utilities.progress_bar import ProgressBar
 from spinnman.model import ExecutableTargets
 from spinnman.model.enums import CPUState
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
-from spynnaker.pyNN.models.utility_models.delays import DelayExtensionVertex
+from spynnaker.pyNN.models.abstract_models import (
+    AbstractSynapseExpandable, SYNAPSE_EXPANDER_APLX)
+from spynnaker.pyNN.models.utility_models.delays import (
+    DelayExtensionMachineVertex, DELAY_EXPANDER_APLX)
 
 logger = logging.getLogger(__name__)
 
-SYNAPSE_EXPANDER = "synapse_expander.aplx"
-DELAY_EXPANDER = "delay_expander.aplx"
-
 
 def synapse_expander(
-        app_graph, placements, transceiver, provenance_file_path,
+        placements, transceiver, provenance_file_path,
         executable_finder, extract_iobuf):
     """ Run the synapse expander.
 
     .. note::
         Needs to be done after data has been loaded.
 
-    :param ~pacman.model.graphs.application.ApplicationGraph app_graph:
-        The graph containing the vertices that might need expanding.
     :param ~pacman.model.placements.Placements placements:
         Where all vertices are on the machine.
     :param ~spinnman.transceiver.Transceiver transceiver:
@@ -50,13 +47,12 @@ def synapse_expander(
     :type executable_finder:
         ~spinn_utilities.executable_finder.ExecutableFinder
     """
-
-    synapse_bin = executable_finder.get_executable_path(SYNAPSE_EXPANDER)
-    delay_bin = executable_finder.get_executable_path(DELAY_EXPANDER)
+    synapse_bin = executable_finder.get_executable_path(SYNAPSE_EXPANDER_APLX)
+    delay_bin = executable_finder.get_executable_path(DELAY_EXPANDER_APLX)
 
     # Find the places where the synapse expander and delay receivers should run
     expander_cores, expanded_pop_vertices = _plan_expansion(
-        app_graph, placements, synapse_bin, delay_bin)
+        placements, synapse_bin, delay_bin)
 
     progress = ProgressBar(expander_cores.total_processors,
                            "Expanding Synapses")
@@ -70,33 +66,29 @@ def synapse_expander(
     _fill_in_connection_data(expanded_pop_vertices, transceiver)
 
 
-def _plan_expansion(app_graph, placements, synapse_expander_bin,
+def _plan_expansion(placements, synapse_expander_bin,
                     delay_expander_bin):
     expander_cores = ExecutableTargets()
     expanded_pop_vertices = list()
 
-    progress = ProgressBar(len(app_graph.vertices),
-                           "Preparing to Expand Synapses")
-    for vertex in progress.over(app_graph.vertices):
+    progress = ProgressBar(len(placements), "Preparing to Expand Synapses")
+    for placement in progress.over(placements):
         # Add all machine vertices of the population vertex to ones
         # that need synapse expansion
-        if isinstance(vertex, AbstractPopulationVertex):
-            for m_vertex in vertex.machine_vertices:
-                if vertex.gen_on_machine(m_vertex.vertex_slice):
-                    placement = placements.get_placement_of_vertex(m_vertex)
-                    expander_cores.add_processor(
-                        synapse_expander_bin,
-                        placement.x, placement.y, placement.p,
-                        executable_type=ExecutableType.SYSTEM)
-                    expanded_pop_vertices.append((vertex, placement))
-        elif isinstance(vertex, DelayExtensionVertex):
-            for m_vertex in vertex.machine_vertices:
-                if vertex.gen_on_machine(m_vertex.vertex_slice):
-                    placement = placements.get_placement_of_vertex(m_vertex)
-                    expander_cores.add_processor(
-                        delay_expander_bin,
-                        placement.x, placement.y, placement.p,
-                        executable_type=ExecutableType.SYSTEM)
+        vertex = placement.vertex
+        if isinstance(vertex, AbstractSynapseExpandable):
+            if vertex.gen_on_machine():
+                expander_cores.add_processor(
+                    synapse_expander_bin,
+                    placement.x, placement.y, placement.p,
+                    executable_type=ExecutableType.SYSTEM)
+                expanded_pop_vertices.append((vertex, placement))
+        elif isinstance(vertex, DelayExtensionMachineVertex):
+            if vertex.gen_on_machine():
+                expander_cores.add_processor(
+                    delay_expander_bin,
+                    placement.x, placement.y, placement.p,
+                    executable_type=ExecutableType.SYSTEM)
 
     return expander_cores, expanded_pop_vertices
 

--- a/spynnaker/pyNN/models/abstract_models/__init__.py
+++ b/spynnaker/pyNN/models/abstract_models/__init__.py
@@ -29,4 +29,4 @@ __all__ = ["AbstractAcceptsIncomingSynapses", "AbstractContainsUnits",
            "AbstractMaxSpikes", "AbstractPopulationInitializable",
            "AbstractPopulationSettable", "AbstractReadParametersBeforeSet",
            "AbstractSettable", "AbstractSynapseExpandable",
-           "AbstractWeightUpdatable", SYNAPSE_EXPANDER_APLX]
+           "AbstractWeightUpdatable", "SYNAPSE_EXPANDER_APLX"]

--- a/spynnaker/pyNN/models/abstract_models/__init__.py
+++ b/spynnaker/pyNN/models/abstract_models/__init__.py
@@ -21,9 +21,12 @@ from .abstract_population_settable import AbstractPopulationSettable
 from .abstract_read_parameters_before_set import (
     AbstractReadParametersBeforeSet)
 from .abstract_settable import AbstractSettable
+from .abstract_synapse_expandable import (
+    AbstractSynapseExpandable, SYNAPSE_EXPANDER_APLX)
 from .abstract_weight_updatable import AbstractWeightUpdatable
 
 __all__ = ["AbstractAcceptsIncomingSynapses", "AbstractContainsUnits",
            "AbstractMaxSpikes", "AbstractPopulationInitializable",
            "AbstractPopulationSettable", "AbstractReadParametersBeforeSet",
-           "AbstractSettable", "AbstractWeightUpdatable"]
+           "AbstractSettable", "AbstractSynapseExpandable",
+           "AbstractWeightUpdatable", SYNAPSE_EXPANDER_APLX]

--- a/spynnaker/pyNN/models/abstract_models/abstract_synapse_expandable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_synapse_expandable.py
@@ -18,6 +18,7 @@ from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 SYNAPSE_EXPANDER_APLX = "synapse_expander.aplx"
 
+
 @add_metaclass(AbstractBase)
 class AbstractSynapseExpandable(object):
     """ Indicates a class (most likely a MachineVertex) that has may need to

--- a/spynnaker/pyNN/models/abstract_models/abstract_synapse_expandable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_synapse_expandable.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2017-2020 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from six import add_metaclass
+from spinn_utilities.abstract_base import AbstractBase, abstractmethod
+
+SYNAPSE_EXPANDER_APLX = "synapse_expander.aplx"
+
+@add_metaclass(AbstractBase)
+class AbstractSynapseExpandable(object):
+    """ Indicates a class (most likely a MachineVertex) that has may need to
+        run the SYNAPSE_EXPANDER aplx
+
+        Cores that do not use the synapse_manager should not implement this
+        api even though their app vertex may hold a synapse_manager
+
+        Note: This is NOT implemented by the DelayExtensionMachineVertex
+        which needs a different expander aplx
+    """
+
+    __slots__ = ()
+
+    @abstractmethod
+    def gen_on_machine(self):
+
+        """
+        True if the synapses of a the slice of this vertex should be generated
+        on the machine.
+
+        Note: The typical implementation for this method will be to ask the
+        app_vertex's synapse_manager
+        """
+
+    @abstractmethod
+    def read_generated_connection_holders(self, transceiver, placement):
+        """ Fill in the connection holders
+
+
+        Note: The typical implementation for this method will be to ask the
+        app_vertex's synapse_manager
+
+        :param Transceiver transceiver: How the data is to be read
+        :param Placement placement: Where the data is on the machine
+        """
+        self.__synapse_manager.read_generated_connection_holders(
+            transceiver, placement)

--- a/spynnaker/pyNN/models/abstract_models/abstract_synapse_expandable.py
+++ b/spynnaker/pyNN/models/abstract_models/abstract_synapse_expandable.py
@@ -55,5 +55,3 @@ class AbstractSynapseExpandable(object):
         :param Transceiver transceiver: How the data is to be read
         :param Placement placement: Where the data is on the machine
         """
-        self.__synapse_manager.read_generated_connection_holders(
-            transceiver, placement)

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -192,6 +192,10 @@ class AbstractPopulationVertex(
     def _neuron_recorder(self):  # for testing only
         return self.__neuron_recorder
 
+    @property
+    def synapse_manager(self):
+        return self.__synapse_manager
+
     @inject_items({
         "graph": "MemoryApplicationGraph"
     })
@@ -876,14 +880,6 @@ class AbstractPopulationVertex(
     def __repr__(self):
         return self.__str__()
 
-    def gen_on_machine(self, vertex_slice):
-        """ True if the synapses of a particular slice of this population \
-            should be generated on the machine.
-
-        :param ~pacman.model.graphs.common.Slice vertex_slice:
-        """
-        return self.__synapse_manager.gen_on_machine(vertex_slice)
-
     @overrides(AbstractCanReset.reset_to_first_timestep)
     def reset_to_first_timestep(self):
         # Mark that reset has been done, and reload state variables
@@ -894,12 +890,3 @@ class AbstractPopulationVertex(
         if self.__synapse_manager.changes_during_run:
             self.__change_requires_data_generation = True
             self.__change_requires_neuron_parameters_reload = False
-
-    def read_generated_connection_holders(self, transceiver, placement):
-        """ Fill in the connection holders
-
-        :param Transceiver transceiver: How the data is to be read
-        :param Placement placement: Where the data is on the machine
-        """
-        self.__synapse_manager.read_generated_connection_holders(
-            transceiver, placement)

--- a/spynnaker/pyNN/models/neuron/population_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_vertex.py
@@ -31,6 +31,7 @@ from spinn_front_end_common.interface.profiling import AbstractHasProfileData
 from spinn_front_end_common.interface.profiling.profile_utils import (
     get_profiling_data)
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
+from spynnaker.pyNN.models.abstract_models import AbstractSynapseExpandable
 from spynnaker.pyNN.utilities.constants import POPULATION_BASED_REGIONS
 
 
@@ -39,7 +40,7 @@ class PopulationMachineVertex(
         AbstractHasAssociatedBinary, ProvidesProvenanceDataFromMachineImpl,
         AbstractRecordable, AbstractHasProfileData,
         AbstractSupportsBitFieldGeneration,
-        AbstractSupportsBitFieldRoutingCompression):
+        AbstractSupportsBitFieldRoutingCompression, AbstractSynapseExpandable):
 
     __slots__ = [
         "__binary_file_name",
@@ -382,3 +383,13 @@ class PopulationMachineVertex(
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
         return ExecutableType.USES_SIMULATION_INTERFACE
+
+    @overrides(AbstractSynapseExpandable.gen_on_machine)
+    def gen_on_machine(self):
+        return self.app_vertex.synapse_manager.gen_on_machine(
+            self.vertex_slice)
+
+    @overrides(AbstractSynapseExpandable.read_generated_connection_holders)
+    def read_generated_connection_holders(self, transceiver, placement):
+         self._app_vertex.synapse_manager.read_generated_connection_holders(
+            transceiver, placement)

--- a/spynnaker/pyNN/models/neuron/population_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_vertex.py
@@ -391,5 +391,5 @@ class PopulationMachineVertex(
 
     @overrides(AbstractSynapseExpandable.read_generated_connection_holders)
     def read_generated_connection_holders(self, transceiver, placement):
-         self._app_vertex.synapse_manager.read_generated_connection_holders(
+        self._app_vertex.synapse_manager.read_generated_connection_holders(
             transceiver, placement)

--- a/spynnaker/pyNN/models/utility_models/delays/__init__.py
+++ b/spynnaker/pyNN/models/utility_models/delays/__init__.py
@@ -14,8 +14,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .delay_block import DelayBlock
-from .delay_extension_machine_vertex import DelayExtensionMachineVertex
+from .delay_extension_machine_vertex import (
+    DelayExtensionMachineVertex, DELAY_EXPANDER_APLX)
 from .delay_extension_vertex import DelayExtensionVertex
 
 __all__ = ["DelayBlock", "DelayExtensionMachineVertex",
-           "DelayExtensionVertex"]
+           "DelayExtensionVertex", "DELAY_EXPANDER_APLX"]

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -23,6 +23,8 @@ from spinn_front_end_common.abstract_models import (
 from spinn_front_end_common.utilities.utility_objs import ProvenanceDataItem
 from spinn_front_end_common.utilities.utility_objs import ExecutableType
 
+DELAY_EXPANDER_APLX = "delay_expander.aplx"
+
 
 class DelayExtensionMachineVertex(
         MachineVertex, ProvidesProvenanceDataFromMachineImpl,
@@ -166,3 +168,14 @@ class DelayExtensionMachineVertex(
     @overrides(AbstractHasAssociatedBinary.get_binary_start_type)
     def get_binary_start_type(self):
         return ExecutableType.USES_SIMULATION_INTERFACE
+
+    def gen_on_machine(self):
+        """ Determine if the given slice needs to be generated on the machine
+
+        :param ~pacman.model.graphs.common.Slice vertex_slice:
+        :rtype: bool
+        """
+        if self.app_vertex.delay_generator_data(self.vertex_slice):
+            return True
+        else:
+            return False

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
@@ -438,10 +438,8 @@ class DelayExtensionVertex(
     def get_outgoing_partition_constraints(self, partition):
         return [ContiguousKeyRangeContraint()]
 
-    def gen_on_machine(self, vertex_slice):
-        """ Determine if the given slice needs to be generated on the machine
-
-        :param ~pacman.model.graphs.common.Slice vertex_slice:
-        :rtype: bool
-        """
-        return vertex_slice in self.__delay_generator_data
+    def delay_generator_data(self, vertex_slice):
+        if vertex_slice in self.__delay_generator_data:
+            return self.__delay_generator_data[vertex_slice]
+        else:
+            return None


### PR DESCRIPTION
Changed synapse_expander to work at the machine level.

Created AbstractSynapseExpandable with the methods
gen_on_machine
read_generated_connection_holders

PopulationMachineVertex now has this api and methods
AbstractPopulationVertex no longer does

gen_on_machine moved from app to delay Machine level

aplx constants moved to the api, delay machine to highlight the relationship

BitField router compressor updated to only re expand when required.

tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/478