### PR TITLE
Reorder bitfield loading

### DIFF
--- a/neural_modelling/src/bit_field_expander/bit_field_expander.c
+++ b/neural_modelling/src/bit_field_expander/bit_field_expander.c
@@ -221,8 +221,7 @@ bool initialise(void) {
     log_info("Pop table init");
     if (!population_table_initialise(
             master_pop_base_address, synaptic_matrix_base_address,
-            direct_synapses_address, bit_field_base_address,
-            &row_max_n_words)) {
+            direct_synapses_address, &row_max_n_words)) {
         log_error("Failed to init the master pop table. failing");
         return false;
     }

--- a/neural_modelling/src/neuron/c_main.c
+++ b/neural_modelling/src/neuron/c_main.c
@@ -217,9 +217,7 @@ static bool initialise(void) {
     if (!population_table_initialise(
             data_specification_get_region(POPULATION_TABLE_REGION, ds_regions),
             data_specification_get_region(SYNAPTIC_MATRIX_REGION, ds_regions),
-            direct_synapses_address,
-            data_specification_get_region(BIT_FIELD_FILTER_REGION, ds_regions),
-            &row_max_n_words)) {
+            direct_synapses_address, &row_max_n_words)) {
         return false;
     }
     // Set up the synapse dynamics
@@ -247,6 +245,12 @@ static bool initialise(void) {
 
     // Setup profiler
     profiler_init(data_specification_get_region(PROFILER_REGION, ds_regions));
+
+    // Do bitfield configuration last to only use any unused memory
+    if (!population_table_load_bitfields(
+            data_specification_get_region(BIT_FIELD_FILTER_REGION, ds_regions))) {
+        return false;
+    }
 
     print_post_to_pre_entry();
 

--- a/neural_modelling/src/neuron/population_table/population_table.h
+++ b/neural_modelling/src/neuron/population_table/population_table.h
@@ -45,14 +45,17 @@ extern uint32_t bit_field_filtered_packets;
 //!                                  data
 //! \param[in] direct_rows_address: The address of the start of the direct
 //!                                 synapse data
-//! \param[in] bitfield_address: The address of the start of the bitfield data
 //! \param[out] row_max_n_words: Updated with the maximum length of any row in
 //!                              the table in words
 //! \return True if the table was initialised successfully, False otherwise
 bool population_table_initialise(
         address_t table_address, address_t synapse_rows_address,
-        address_t direct_rows_address, filter_region_t *bitfield_address,
-        uint32_t *row_max_n_words);
+        address_t direct_rows_address, uint32_t *row_max_n_words);
+
+//! \brief Initialise the bitfield filtering system.
+//! \param[in] filter_region: Where the bitfield configuration is
+//! \return True on success
+bool population_table_load_bitfields(filter_region_t *filter_region);
 
 //! \brief Get the first row data for the given input spike
 //! \param[in] spike: The spike received

--- a/neural_modelling/src/neuron/population_table/population_table_binary_search_impl.c
+++ b/neural_modelling/src/neuron/population_table/population_table_binary_search_impl.c
@@ -292,10 +292,7 @@ static inline void print_bitfields(uint32_t mp_i, uint32_t start,
 #endif
 }
 
-//! \brief Initialise the bitfield filtering system.
-//! \param[in] filter_region: Where the bitfield configuration is
-//! \return True on success
-static inline bool bit_field_filter_initialise(filter_region_t *filter_region) {
+bool population_table_load_bitfields(filter_region_t *filter_region) {
 
     // try allocating DTCM for starting array for bitfields
     connectivity_bit_field =
@@ -412,8 +409,7 @@ static inline bool population_table_position_in_the_master_pop_array(
 
 bool population_table_initialise(
         address_t table_address, address_t synapse_rows_address,
-        address_t direct_rows_address, filter_region_t *bitfield_address,
-        uint32_t *row_max_n_words) {
+        address_t direct_rows_address, uint32_t *row_max_n_words) {
     log_debug("Population_table_initialise: starting");
 
     master_population_table_length = table_address[0];
@@ -467,11 +463,6 @@ bool population_table_initialise(
     direct_rows_base_address = (uint32_t) direct_rows_address;
 
     *row_max_n_words = 0xFF + N_SYNAPSE_ROW_HEADER_WORDS;
-
-    // Initialise bitfields
-    if (!bit_field_filter_initialise(bitfield_address)) {
-        return false;
-    }
 
     print_master_population_table();
     return true;


### PR DESCRIPTION
Reorder the loading of bitfields to be last.  This is needed because the pop_based_master_pop_table work accidentally reordered this, causing some scripts (e.g. microcircuit) to fail unexpectedly.

Tested by SpiNNakerManchester/sPyNNaker8#483