### PR TITLE
add_application_entry should return a value

### DIFF
--- a/spynnaker/pyNN/models/neuron/master_pop_table.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table.py
@@ -446,7 +446,7 @@ class MasterPopTableAsBinarySearch(object):
                 "The core mask of {} is too big (maximum {})".format(
                     core_mask, _MAX_CORE_MASK))
 
-        self.__update_master_population_table(
+        return self.__update_master_population_table(
             block_start_addr, row_length, key_and_mask, core_mask, core_shift,
             n_neurons, False)
 


### PR DESCRIPTION
Found when running a structural plasticity example (working on adding examples to cover the remaining binaries in https://github.com/SpiNNakerManchester/sPyNNaker8/issues/484) that for some reason catches that this function isn't returning the index when it should be (I don't know why the current tests/examples aren't catching this...).

Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/513