### PR TITLE
Make scaling_factor into a model parameter for sEMD

### DIFF
--- a/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
@@ -44,9 +44,6 @@
 #include <debug.h>
 #include "synapse_types.h"
 
-//! Used to scale the secondary response
-static const REAL SCALING_FACTOR = REAL_CONST(100.0);
-
 //---------------------------------------
 // Synapse parameters
 //---------------------------------------
@@ -69,6 +66,8 @@ struct synapse_param_t {
     input_t multiplicator;
     //! History storage used to reset synaptic state
     input_t exc2_old;
+    //! Scaling factor for the secondary response
+    input_t scaling_factor;
 };
 
 //! The supported synapse type indices
@@ -151,10 +150,10 @@ static inline input_t *synapse_types_get_excitatory_input(
 
 	parameters->exc2_old = parameters->exc2.synaptic_input_value;
 
-    excitatory_response[0] = 0; // I think?
+    excitatory_response[0] = 0;
     excitatory_response[1] =
     		parameters->exc2.synaptic_input_value * parameters->multiplicator
-    		* SCALING_FACTOR;
+    		* parameters->scaling_factor;
     return &excitatory_response[0];
 }
 
@@ -216,6 +215,7 @@ static inline void synapse_types_print_parameters(synapse_param_t *parameters) {
             parameters->inh.synaptic_input_value);
     log_info("multiplicator = %11.4k\n", parameters->multiplicator);
     log_info("exc2_old      = %11.4k\n", parameters->exc2_old);
+    log_info("scaling_factor = %11.4k\n", parameters->scaling_factor);
 }
 
 #endif  // _SYNAPSE_TYPES_SEMD_IMPL_H_

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_semd_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_semd_base.py
@@ -43,6 +43,7 @@ class IFCurrExpSEMDBase(AbstractPyNNNeuronModelStandard):
     :param float isyn_inh: :math:`I^{syn}_i`
     :param float multiplicator:
     :param float exc2_old:
+    :param float scaling_factor:
     """
 
     @default_initial_values({"v", "isyn_exc", "isyn_exc2", "isyn_inh",
@@ -51,12 +52,13 @@ class IFCurrExpSEMDBase(AbstractPyNNNeuronModelStandard):
             self, tau_m=20.0, cm=1.0, v_rest=-65.0, v_reset=-65.0,
             v_thresh=-50.0, tau_syn_E=5.0, tau_syn_E2=5.0, tau_syn_I=5.0,
             tau_refrac=0.1, i_offset=0.0, v=-65.0, isyn_exc=0.0,
-            isyn_exc2=0.0, isyn_inh=0.0, multiplicator=0.0, exc2_old=0.0):
+            isyn_exc2=0.0, isyn_inh=0.0, multiplicator=0.0, exc2_old=0.0,
+            scaling_factor=1.0):
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeSEMD(
             tau_syn_E, tau_syn_E2, tau_syn_I, isyn_exc, isyn_exc2, isyn_inh,
-            multiplicator, exc2_old)
+            multiplicator, exc2_old, scaling_factor)
         input_type = InputTypeCurrent()
         threshold_type = ThresholdTypeStatic(v_thresh)
 

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_semd.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_semd.py
@@ -28,6 +28,7 @@ ISYN_EXC2 = "isyn_exc2"
 ISYN_INH = "isyn_inh"
 MULTIPLICATOR = "multiplicator"
 EXC2_OLD = "exc2_old"
+SCALING_FACTOR = "scaling_factor"
 
 UNITS = {
     TAU_SYN_E: "mV",
@@ -38,6 +39,7 @@ UNITS = {
     ISYN_INH: "",
     MULTIPLICATOR: "",
     EXC2_OLD: "",
+    SCALING_FACTOR: "",
 }
 
 
@@ -50,11 +52,12 @@ class SynapseTypeSEMD(AbstractSynapseType):
         "__isyn_exc2",
         "__isyn_inh",
         "__multiplicator",
-        "__exc2_old"]
+        "__exc2_old",
+        "__scaling_factor"]
 
     def __init__(
             self, tau_syn_E, tau_syn_E2, tau_syn_I, isyn_exc, isyn_exc2,
-            isyn_inh, multiplicator, exc2_old):
+            isyn_inh, multiplicator, exc2_old, scaling_factor):
         r"""
         :param float tau_syn_E: :math:`\tau^{syn}_{e_1}`
         :param float tau_syn_E2: :math:`\tau^{syn}_{e_2}`
@@ -64,6 +67,7 @@ class SynapseTypeSEMD(AbstractSynapseType):
         :param float isyn_inh: :math:`I^{syn}_i`
         :param float multiplicator:
         :param float exc2_old:
+        :param float scaling_factor:
         """
         super(SynapseTypeSEMD, self).__init__(
             [DataType.U032,    # decay_E
@@ -76,7 +80,8 @@ class SynapseTypeSEMD(AbstractSynapseType):
              DataType.U032,    # init_I
              DataType.S1615,   # isyn_inh
              DataType.S1615,   # multiplicator
-             DataType.S1615])  # exc2_old
+             DataType.S1615,   # exc2_old
+             DataType.S1615])  # scaling_factor
         self.__tau_syn_E = tau_syn_E
         self.__tau_syn_E2 = tau_syn_E2
         self.__tau_syn_I = tau_syn_I
@@ -85,6 +90,7 @@ class SynapseTypeSEMD(AbstractSynapseType):
         self.__isyn_inh = isyn_inh
         self.__multiplicator = multiplicator
         self.__exc2_old = exc2_old
+        self.__scaling_factor = scaling_factor
 
     @overrides(AbstractSynapseType.get_n_cpu_cycles)
     def get_n_cpu_cycles(self, n_neurons):
@@ -96,6 +102,7 @@ class SynapseTypeSEMD(AbstractSynapseType):
         parameters[TAU_SYN_E2] = self.__tau_syn_E2
         parameters[TAU_SYN_I] = self.__tau_syn_I
         parameters[MULTIPLICATOR] = self.__multiplicator
+        parameters[SCALING_FACTOR] = self.__scaling_factor
 
     @overrides(AbstractSynapseType.add_state_variables)
     def add_state_variables(self, state_variables):
@@ -137,14 +144,16 @@ class SynapseTypeSEMD(AbstractSynapseType):
                 parameters[TAU_SYN_I].apply_operation(init),
                 state_variables[ISYN_INH],
                 parameters[MULTIPLICATOR],
-                state_variables[EXC2_OLD]]
+                state_variables[EXC2_OLD],
+                parameters[SCALING_FACTOR]]
 
     @overrides(AbstractSynapseType.update_values)
     def update_values(self, values, parameters, state_variables):
 
         # Read the data
         (_decay_E, _init_E, isyn_exc, _decay_E2, _init_E2, isyn_exc2,
-         _decay_I, _init_I, isyn_inh, _multiplicator, exc2_old) = values
+         _decay_I, _init_I, isyn_inh, _multiplicator, exc2_old,
+         _scaling_factor) = values
 
         state_variables[ISYN_EXC] = isyn_exc
         state_variables[ISYN_EXC2] = isyn_exc2
@@ -232,3 +241,11 @@ class SynapseTypeSEMD(AbstractSynapseType):
     @exc2_old.setter
     def exc2_old(self, exc2_old):
         self.__exc2_old = exc2_old
+
+    @property
+    def scaling_factor(self):
+        return self.__scaling_factor
+
+    @scaling_factor.setter
+    def scaling_factor(self, scaling_factor):
+        self.__scaling_factor = scaling_factor


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/946.

Changes scaling_factor from a hard-coded value in C to a model parameter for sEMD.

Merge alongside https://github.com/SpiNNakerManchester/PyNN8Examples/pull/53
Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/522

