### PR TITLE
input_type is not always const in this function (see example in NMT)

### DIFF
--- a/neural_modelling/src/neuron/input_types/input_type.h
+++ b/neural_modelling/src/neuron/input_types/input_type.h
@@ -57,7 +57,7 @@ typedef input_type_t *input_type_pointer_t;
 //! \return Pointer to array of values of the receptor-based input after
 //!     scaling
 static input_t *input_type_get_input_value(
-        input_t *restrict value, const input_type_t *input_type,
+        input_t *restrict value, input_type_t *input_type,
         uint16_t num_receptors);
 
 //! \brief Converts an excitatory input into an excitatory current

--- a/neural_modelling/src/neuron/input_types/input_type_conductance.h
+++ b/neural_modelling/src/neuron/input_types/input_type_conductance.h
@@ -39,7 +39,7 @@ typedef struct input_type_t {
 //! \return Pointer to array of values of the receptor-based input after
 //!     scaling
 static inline input_t *input_type_get_input_value(
-        input_t *restrict value, UNUSED const input_type_t *input_type,
+        input_t *restrict value, UNUSED input_type_t *input_type,
         uint16_t num_receptors) {
     for (int i = 0; i < num_receptors; i++) {
         value[i] = value[i] >> 10;

--- a/neural_modelling/src/neuron/input_types/input_type_current.h
+++ b/neural_modelling/src/neuron/input_types/input_type_current.h
@@ -37,7 +37,7 @@ static const REAL INPUT_SCALE_FACTOR = ONE;
 //! \return Pointer to array of values of the receptor-based input after
 //!     scaling
 static inline input_t *input_type_get_input_value(
-        input_t *restrict value, UNUSED const input_type_t *input_type,
+        input_t *restrict value, UNUSED input_type_t *input_type,
         uint16_t num_receptors) {
     for (int i = 0; i < num_receptors; i++) {
         value[i] = value[i] * INPUT_SCALE_FACTOR;

--- a/neural_modelling/src/neuron/input_types/input_type_delta.h
+++ b/neural_modelling/src/neuron/input_types/input_type_delta.h
@@ -39,7 +39,7 @@ static const REAL INPUT_SCALE_FACTOR = ONE;
 //! \return Pointer to array of values of the receptor-based input after
 //!     scaling
 static inline input_t *input_type_get_input_value(
-        input_t *restrict value, UNUSED const input_type_t *input_type,
+        input_t *restrict value, UNUSED input_type_t *input_type,
         uint16_t num_receptors) {
     for (int i = 0; i < num_receptors; i++) {
         value[i] = value[i] * INPUT_SCALE_FACTOR;

--- a/neural_modelling/src/neuron/input_types/input_type_none.h
+++ b/neural_modelling/src/neuron/input_types/input_type_none.h
@@ -44,7 +44,7 @@ struct input_type_t {
 //! \return Pointer to array of values of the receptor-based input after
 //!     scaling
 static inline input_t *input_type_get_input_value(
-        UNUSED input_t *restrict value, UNUSED const input_type_t *input_type,
+        UNUSED input_t *restrict value, UNUSED input_type_t *input_type,
         UNUSED uint16_t num_receptors) {
     return 0;
 }


### PR DESCRIPTION
More cleaning up of compiler warnings - in this case, an example in the NewModelTemplate requires this struct parameter to be non-const as it allows it to be modified.

Merge alongside https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate/pull/64
Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/525