### PR TITLE
Remove unused OVERSCALE multipliers

### DIFF
--- a/spynnaker/pyNN/models/neuron/master_pop_table.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table.py
@@ -153,9 +153,6 @@ _EXTRA_INFO_ENTRY_SIZE_BYTES = ctypes.sizeof(_ExtraInfoCType)
 # Base size - 2 words for size of table and address list
 _BASE_SIZE_BYTES = 8
 
-# Over-scale of estimate for safety
-_OVERSCALE = 2
-
 # A ctypes pointer to a uint32
 _UINT32_PTR = ctypes.POINTER(ctypes.c_uint32)
 

--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -33,9 +33,6 @@ from .key_space_tracker import KeySpaceTracker
 from .synaptic_matrix_app import SynapticMatrixApp
 
 
-# Amount to scale synapse SDRAM estimate by to make sure the synapses fit
-_SYNAPSE_SDRAM_OVERSCALE = 1.1
-
 # 1 for n_edges
 # 2 for post_vertex_slice.lo_atom, post_vertex_slice.n_atoms
 # 1 for n_synapse_types


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/892 (well, technically, it was already fixed, but this removes the fudge factors that are no longer being used after recent merges of master pop table updates, so this should close that issue).

Tested by https://github.com/SpiNNakerManchester/sPyNNaker8/pull/528