### PR TITLE
Replace %s with {} when using formatadapter during logging

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/spynnaker_synaptic_matrix_report.py
+++ b/spynnaker/pyNN/extra_algorithms/spynnaker_synaptic_matrix_report.py
@@ -81,4 +81,4 @@ class SpYNNakerSynapticMatrixReport(object):
                     f.write("{}".format(connection_holder[edge, info]))
         except IOError:
             logger.exception("Generate_placement_reports: Can't open file"
-                             " %s for writing.", file_name)
+                             " {} for writing.".format(file_name))


### PR DESCRIPTION
Can't use %s any more in logging messages, switching to "... {} .. ".format(..) instead.