### PR TITLE
Put doc builds in parallel with other validation

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -122,6 +122,41 @@ jobs:
       uses: ./support/actions/validate-xml
       with:
         base-path: spynnaker
+
+  doc-check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.6, 3.7, 3.8]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Checkout SupportScripts
+      uses: actions/checkout@v2
+      with:
+        repository: SpiNNakerManchester/SupportScripts
+        path: support
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install pip, etc
+      uses: ./support/actions/python-tools
+    - name: Install Spinnaker Dependencies
+      uses: ./support/actions/checkout-spinn-deps
+      with:
+        repositories: >
+          SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
+          SpiNNFrontEndCommon
+        install: true
+        preinstall: ${{ matrix.python-version == 2.7 }}
+    - name: Setup
+      uses: ./support/actions/run-setup
+      with:
+        preinstall: ${{ matrix.python-version == 2.7 }}
+
     - name: Build documentation with sphinx
       uses: ./support/actions/sphinx
       with:

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -125,10 +125,7 @@ jobs:
 
   doc-check:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
-
+    # Only runs with 3.6
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -137,11 +134,10 @@ jobs:
       with:
         repository: SpiNNakerManchester/SupportScripts
         path: support
-
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.6
     - name: Install pip, etc
       uses: ./support/actions/python-tools
     - name: Install Spinnaker Dependencies
@@ -151,12 +147,8 @@ jobs:
           SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
           SpiNNFrontEndCommon
         install: true
-        preinstall: ${{ matrix.python-version == 2.7 }}
     - name: Setup
       uses: ./support/actions/run-setup
-      with:
-        preinstall: ${{ matrix.python-version == 2.7 }}
-
     - name: Build documentation with sphinx
       uses: ./support/actions/sphinx
       with:


### PR DESCRIPTION
Documentation building is taking a long time (due to details of how `sphinx-apidoc` works). Split it into its own workflow so that we more clearly get the flake8/pylint results back in the GitHub UI.