### PR TITLE
Allow Neo9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ quantities >= 0.12.1
 pynn >= 0.9.1, < 0.10
 lazyarray >= 0.2.9, <= 0.4.0
 appdirs >= 1.4.2 , < 2.0.0
-neo >= 0.5.2, < 0.9.0
+neo >= 0.5.2, < 0.10.0
 matplotlib
 quantities >= 0.12.1
 # csa  # needed but excluded due to readthedocs

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ install_requires = [
     'pynn >= 0.9.1, < 0.10.0 ',
     'lazyarray >= 0.2.9, <= 0.4.0',
     'appdirs >= 1.4.2 , < 2.0.0',
-    'neo >= 0.5.2, < 0.9.0']
+    'neo >= 0.5.2, < 0.10.0']
 if os.environ.get('READTHEDOCS', None) != 'True':
     # scipy must be added in config.py as a mock
     # csa is a badly written package


### PR DESCRIPTION
We can allow neo 9 as Channel index is still there.

another wart way improvement for https://github.com/NeuralEnsemble/PyNN/issues/708

tested with 
https://github.com/SpiNNakerManchester/IntegrationTests/tree/neo9
which has passed tests