### PR TITLE
remove unnecessary references from neural_build.mk

### DIFF
--- a/neural_modelling/makefiles/neuron/neural_build.mk
+++ b/neural_modelling/makefiles/neuron/neural_build.mk
@@ -338,14 +338,12 @@ $(ELIMINATION_O): $(ELIMINATION_C) $(SYNAPSE_TYPE_H)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) \
 	        -include $(SYNAPSE_TYPE_H) -o $@ $<
 
-$(BUILD_DIR)neuron/neuron.o: $(MODIFIED_DIR)neuron/neuron.c $(NEURON_MODEL_H) \
-                             $(SYNAPSE_TYPE_H)
+$(BUILD_DIR)neuron/neuron.o: $(MODIFIED_DIR)neuron/neuron.c
 	# neuron.o
 	-@mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(NEURON_DEBUG) $(CFLAGS) $(NEURON_INCLUDES) -o $@ $<
 	
-$(BUILD_DIR)neuron/neuron_recording.o: $(MODIFIED_DIR)neuron/neuron_recording.c $(NEURON_MODEL_H) \
-                             $(SYNAPSE_TYPE_H)
+$(BUILD_DIR)neuron/neuron_recording.o: $(MODIFIED_DIR)neuron/neuron_recording.c
 	# neuron_recording.o
 	-@mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(NEURON_DEBUG) $(CFLAGS) $(NEURON_INCLUDES) -o $@ $<

--- a/neural_modelling/src/neuron/implementations/neuron_impl_external_devices.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_external_devices.h
@@ -368,16 +368,18 @@ static bool neuron_impl_do_timestep_update(index_t neuron_index,
         state_t soma_voltage = neuron_model_get_membrane_voltage(this_neuron);
 
         // Get the exc and inh values from the synapses
-        input_t *exc_values =
-                synapse_types_get_excitatory_input(the_synapse_type);
-        input_t *inh_values =
-                synapse_types_get_inhibitory_input(the_synapse_type);
+        input_t exc_values[NUM_EXCITATORY_RECEPTORS];
+        input_t *exc_syn_values =
+                synapse_types_get_excitatory_input(exc_values, the_synapse_type);
+        input_t inh_values[NUM_INHIBITORY_RECEPTORS];
+        input_t *inh_syn_values =
+                synapse_types_get_inhibitory_input(inh_values, the_synapse_type);
 
         // Call functions to obtain exc_input and inh_input
         input_t *exc_input_values = input_type_get_input_value(
-                exc_values, input_types, NUM_EXCITATORY_RECEPTORS);
+                exc_syn_values, input_types, NUM_EXCITATORY_RECEPTORS);
         input_t *inh_input_values = input_type_get_input_value(
-                inh_values, input_types, NUM_INHIBITORY_RECEPTORS);
+                inh_syn_values, input_types, NUM_INHIBITORY_RECEPTORS);
 
         // Sum g_syn contributions from all receptors for recording
         REAL total_exc = 0;

--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -272,16 +272,18 @@ static bool neuron_impl_do_timestep_update(index_t neuron_index,
         state_t soma_voltage = neuron_model_get_membrane_voltage(this_neuron);
 
         // Get the exc and inh values from the synapses
-        input_t *exc_values =
-                synapse_types_get_excitatory_input(the_synapse_type);
-        input_t *inh_values =
-                synapse_types_get_inhibitory_input(the_synapse_type);
+        input_t exc_values[NUM_EXCITATORY_RECEPTORS];
+        input_t *exc_syn_values =
+                synapse_types_get_excitatory_input(exc_values, the_synapse_type);
+        input_t inh_values[NUM_INHIBITORY_RECEPTORS];
+        input_t *inh_syn_values =
+                synapse_types_get_inhibitory_input(inh_values, the_synapse_type);
 
         // Call functions to obtain exc_input and inh_input
         input_t *exc_input_values = input_type_get_input_value(
-                exc_values, input_types, NUM_EXCITATORY_RECEPTORS);
+                exc_syn_values, input_types, NUM_EXCITATORY_RECEPTORS);
         input_t *inh_input_values = input_type_get_input_value(
-                inh_values, input_types, NUM_INHIBITORY_RECEPTORS);
+                inh_syn_values, input_types, NUM_INHIBITORY_RECEPTORS);
 
         // Sum g_syn contributions from all receptors for recording
         REAL total_exc = 0;

--- a/neural_modelling/src/neuron/synapse_types/synapse_types.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types.h
@@ -57,14 +57,14 @@ static void synapse_types_add_neuron_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of excitatory input buffers for a given neuron ID.
 static input_t* synapse_types_get_excitatory_input(
-        synapse_param_t *parameters);
+        input_t *excitatory_response, synapse_param_t *parameters);
 
 //! \brief extracts the inhibitory input buffers from the buffers available
 //!     for a given neuron ID
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of inhibitory input buffers for a given neuron ID.
 static input_t* synapse_types_get_inhibitory_input(
-        synapse_param_t *parameters);
+        input_t *inhibitory_response, synapse_param_t *parameters);
 
 //! \brief returns a human readable character for the type of synapse.
 //!

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_alpha_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_alpha_impl.h
@@ -45,11 +45,6 @@
 //---------------------------------------
 // Synapse parameters
 //---------------------------------------
-//! Buffer used for result of synapse_types_get_excitatory_input()
-input_t excitatory_response[NUM_EXCITATORY_RECEPTORS];
-//! Buffer used for result of synapse_types_get_inhibitory_input()
-input_t inhibitory_response[NUM_INHIBITORY_RECEPTORS];
-
 //! Internal structure of an alpha-shaped synaptic input
 typedef struct alpha_params_t {
     input_t lin_buff;           //!< buffer for linear term
@@ -148,7 +143,7 @@ static inline void synapse_types_add_neuron_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of excitatory input buffers for a given neuron ID.
 static inline input_t* synapse_types_get_excitatory_input(
-        synapse_param_t *parameters) {
+        input_t *excitatory_response, synapse_param_t *parameters) {
     excitatory_response[0] =
             parameters->exc.lin_buff * parameters->exc.exp_buff;
     return &excitatory_response[0];
@@ -159,7 +154,7 @@ static inline input_t* synapse_types_get_excitatory_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return Pointer to array of inhibitory input buffers for a given neuron ID.
 static inline input_t* synapse_types_get_inhibitory_input(
-        synapse_param_t *parameters) {
+        input_t *inhibitory_response, synapse_param_t *parameters) {
     inhibitory_response[0] =
             parameters->inh.lin_buff * parameters->inh.exp_buff;
     return &inhibitory_response[0];

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_delta_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_delta_impl.h
@@ -49,11 +49,6 @@
 //---------------------------------------
 // Synapse parameters
 //---------------------------------------
-//! Buffer used for result of synapse_types_get_excitatory_input()
-input_t excitatory_response[NUM_EXCITATORY_RECEPTORS];
-//! Buffer used for result of synapse_types_get_inhibitory_input()
-input_t inhibitory_response[NUM_INHIBITORY_RECEPTORS];
-
 //! A synaptic input shaped as a Dirac delta
 typedef struct delta_params_t {
     //! The synaptic input value
@@ -132,7 +127,7 @@ static inline void synapse_types_add_neuron_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
 static inline input_t *synapse_types_get_excitatory_input(
-        synapse_param_t *parameters) {
+        input_t *excitatory_response, synapse_param_t *parameters) {
     excitatory_response[0] = parameters->exc.synaptic_input_value;
     return &excitatory_response[0];
 }
@@ -142,7 +137,7 @@ static inline input_t *synapse_types_get_excitatory_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
 static inline input_t *synapse_types_get_inhibitory_input(
-        synapse_param_t *parameters) {
+        input_t *inhibitory_response, synapse_param_t *parameters) {
     inhibitory_response[0] = parameters->inh.synaptic_input_value;
     return &inhibitory_response[0];
 }

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_dual_excitatory_exponential_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_dual_excitatory_exponential_impl.h
@@ -50,11 +50,6 @@
 //---------------------------------------
 // Synapse parameters
 //---------------------------------------
-//! Buffer used for result of synapse_types_get_excitatory_input()
-input_t excitatory_response[NUM_EXCITATORY_RECEPTORS];
-//! Buffer used for result of synapse_types_get_inhibitory_input()
-input_t inhibitory_response[NUM_INHIBITORY_RECEPTORS];
-
 //! Parameters for an exponential decay
 typedef struct exp_params_t {
     decay_t decay;                  //!< Decay multiplier per timestep
@@ -137,7 +132,7 @@ static inline void synapse_types_add_neuron_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
 static inline input_t* synapse_types_get_excitatory_input(
-        synapse_param_t *parameters) {
+        input_t *excitatory_response, synapse_param_t *parameters) {
     excitatory_response[0] = parameters->exc.synaptic_input_value;
     excitatory_response[1] = parameters->exc2.synaptic_input_value;
     return &excitatory_response[0];
@@ -148,7 +143,7 @@ static inline input_t* synapse_types_get_excitatory_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
 static inline input_t* synapse_types_get_inhibitory_input(
-        synapse_param_t *parameters) {
+        input_t *inhibitory_response, synapse_param_t *parameters) {
     inhibitory_response[0] = parameters->inh.synaptic_input_value;
     return &inhibitory_response[0];
 }

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_exponential_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_exponential_impl.h
@@ -51,11 +51,6 @@
 //---------------------------------------
 // Synapse parameters
 //---------------------------------------
-//! Buffer used for result of synapse_types_get_excitatory_input()
-input_t excitatory_response[NUM_EXCITATORY_RECEPTORS];
-//! Buffer used for result of synapse_types_get_inhibitory_input()
-input_t inhibitory_response[NUM_INHIBITORY_RECEPTORS];
-
 typedef struct exp_params_t {
     decay_t decay;                  //!< Decay multiplier per timestep
     decay_t init;                   //!< Initial decay factor
@@ -132,7 +127,7 @@ static inline void synapse_types_add_neuron_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
 static inline input_t* synapse_types_get_excitatory_input(
-        synapse_param_t *parameters) {
+        input_t *excitatory_response, synapse_param_t *parameters) {
     excitatory_response[0] = parameters->exc.synaptic_input_value;
     return &excitatory_response[0];
 }
@@ -142,7 +137,7 @@ static inline input_t* synapse_types_get_excitatory_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
 static inline input_t* synapse_types_get_inhibitory_input(
-        synapse_param_t *parameters) {
+        input_t *inhibitory_response, synapse_param_t *parameters) {
     inhibitory_response[0] = parameters->inh.synaptic_input_value;
     return &inhibitory_response[0];
 }

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
@@ -47,11 +47,6 @@
 //---------------------------------------
 // Synapse parameters
 //---------------------------------------
-//! Buffer used for result of synapse_types_get_excitatory_input()
-input_t excitatory_response[NUM_EXCITATORY_RECEPTORS];
-//! Buffer used for result of synapse_types_get_inhibitory_input()
-input_t inhibitory_response[NUM_INHIBITORY_RECEPTORS];
-
 typedef struct exp_params_t {
     decay_t decay;                  //!< Decay multiplier per timestep
     decay_t init;                   //!< Initial decay factor
@@ -139,7 +134,7 @@ static inline void synapse_types_add_neuron_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the excitatory input buffers for a given neuron ID.
 static inline input_t *synapse_types_get_excitatory_input(
-        synapse_param_t *parameters) {
+        input_t *excitatory_response, synapse_param_t *parameters) {
 	if (parameters->exc2.synaptic_input_value >= 0.001
 	        && parameters->multiplicator == 0
 			&& parameters->exc2_old == 0) {
@@ -162,7 +157,7 @@ static inline input_t *synapse_types_get_excitatory_input(
 //! \param[in] parameters: the pointer to the parameters to use
 //! \return the inhibitory input buffers for a given neuron ID.
 static inline input_t *synapse_types_get_inhibitory_input(
-        synapse_param_t *parameters) {
+        input_t *inhibitory_response, synapse_param_t *parameters) {
     inhibitory_response[0] = parameters->inh.synaptic_input_value;
     return &inhibitory_response[0];
 }


### PR DESCRIPTION
Fix https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/757

I guess this turned into something else on further inspection - the global variables used in synapse_types.h etc. are unnecessary and can be turned into pass-through variables instead.

Merge with https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate/pull/69

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/21