### PR TITLE
cap matplotlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,8 @@ pynn >= 0.9.1, < 0.10
 lazyarray >= 0.2.9, <= 0.4.0
 appdirs >= 1.4.2 , < 2.0.0
 neo >= 0.5.2, < 0.10.0
-matplotlib
+matplotlib < 3.4; python_version == '3.6'
+matplotlib; python_version >= '3.7'
 quantities >= 0.12.1
 # csa  # needed but excluded due to readthedocs
 # spinnaker_tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,13 +26,13 @@ numpy; python_version >= '3.8'
 scipy
 lxml
 statistics
+matplotlib < 3.4; python_version == '3.6'
+matplotlib; python_version >= '3.7'
 quantities >= 0.12.1
 pynn >= 0.9.1, < 0.10
 lazyarray >= 0.2.9, <= 0.4.0
 appdirs >= 1.4.2 , < 2.0.0
 neo >= 0.5.2, < 0.10.0
-matplotlib < 3.4; python_version == '3.6'
-matplotlib; python_version >= '3.7'
 quantities >= 0.12.1
 # csa  # needed but excluded due to readthedocs
 # spinnaker_tools

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ install_requires = [
     "numpy > 1.13, < 1.21; python_version == '3.7'",
     "numpy; python_version >= '3.8'",
     'lxml',
+    # We need to install matplotlib before quantities which has it uncapped
+    "matplotlib < 3.4; python_version == '3.6'",
+    "matplotlib; python_version >= '3.7'",
     'quantities >= 0.12.1',
     'pynn >= 0.9.1, < 0.10.0 ',
     'lazyarray >= 0.2.9, <= 0.4.0',


### PR DESCRIPTION
Beginning with Matplotlib 3.4, Python 3.7 or above is required.