### PR TITLE
Much faster documentation building

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -91,35 +91,7 @@ jobs:
       with:
         base-path: spynnaker
 
-  doc-check:
-    runs-on: ubuntu-latest
-    # Only runs with 3.8
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Checkout SupportScripts
-      uses: actions/checkout@v2
-      with:
-        repository: SpiNNakerManchester/SupportScripts
-        path: support
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install pip, etc
-      uses: ./support/actions/python-tools
-    - name: Install Spinnaker Dependencies
-      uses: ./support/actions/checkout-spinn-deps
-      with:
-        repositories: >
-          SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
-          SpiNNFrontEndCommon
-        install: true
-    - name: Install matplotlib
-      uses: ./support/actions/install-matplotlib
-    - name: Setup
-      uses: ./support/actions/run-setup
-    - name: Build documentation with sphinx
+    - name: Build documentation with sphinx (3.8 only)
       uses: ./support/actions/sphinx
       with:
         directory: doc/source

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -393,16 +393,12 @@ autodoc_default_options = {
 }
 
 
-def filtered_files(base, excludes=None, exclude_dir=None):
-    if not excludes:
-        excludes = []
+def filtered_files(base, excludes=()):
     excludes = set(base + "/" + e for e in excludes)
     for root, _dirs, files in os.walk(base):
         for filename in files:
             full = root + "/" + filename
-            if exclude_dir and exclude_dir in root:
-                yield full
-            elif filename.endswith(".py") and not filename.startswith("_"):
+            if filename.endswith(".py") and not filename.startswith("_"):
                 if full not in excludes:
                     yield full
 
@@ -450,6 +446,9 @@ explicit_wanted_files = [
     "spynnaker8/spynnaker_plotting.py",
     "spynnaker8/utilities/neo_convertor.py",
     "spynnaker8/utilities/neo_compare.py"]
-options = ['-o', output_dir, "."]
-options.extend(filtered_files(".", explicit_wanted_files, "tests"))
+options = ['-o', output_dir, ".",
+           # Exclude test and setup code
+           "p8_integration_tests/*", "unittests/*", "setup.py"]
+options.extend(filtered_files("spynnaker", explicit_wanted_files))
+options.extend(filtered_files("spynnaker8", explicit_wanted_files))
 apidoc.main(options)


### PR DESCRIPTION
The problem with the slow documentation building was because the apidoc preparation code was finding lots of irrelevant files (notably in the `.git` directory!) that was hugely extending the list of things to filter out unnecessarily.

Once some other minor issues are sorted, this will enable merging the doc building into the main workflows.