### PR TITLE
We need to use today's new special matplotlib trickery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,8 @@ jobs:
             spinnaker_tools SpiNNUtils SpiNNMachine SpiNNMan PACMAN
             DataSpecification spalloc SpiNNFrontEndCommon
           install: true
+      - name: Install matplotlib
+        uses: ./support/actions/install-matplotlib
       - name: Read tags
         run: make doxysetup
         working-directory: neural_modelling

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -23,10 +23,6 @@
 name: Python Actions
 on: [push]
 
-env:
-  # Magic to make matplotlib behave nicely
-  MPLBACKEND: module://matplotlib.backends.backend_agg
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -56,6 +52,8 @@ jobs:
           SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
           SpiNNFrontEndCommon
         install: true
+    - name: Install matplotlib
+      uses: ./support/actions/install-matplotlib
     - name: Setup
       uses: ./support/actions/run-setup
     - name: Checkout Spinnaker Test Cases
@@ -117,6 +115,8 @@ jobs:
           SpiNNUtils SpiNNMachine SpiNNMan PACMAN DataSpecification spalloc
           SpiNNFrontEndCommon
         install: true
+    - name: Install matplotlib
+      uses: ./support/actions/install-matplotlib
     - name: Setup
       uses: ./support/actions/run-setup
     - name: Build documentation with sphinx


### PR DESCRIPTION
Because “`Beginning with Matplotlib 3.4, Python 3.7 or above is required.`” and it is a transitive dependency of pynn, which doesn't version its requirement there.