### PR TITLE
cap matplotlib and remove duplicate quantites

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,12 +26,12 @@ numpy; python_version >= '3.8'
 scipy
 lxml
 statistics
+matplotlib < 3.4; python_version == '3.6'
+matplotlib; python_version >= '3.7'
 quantities >= 0.12.1
 pynn >= 0.9.1, < 0.10
 lazyarray >= 0.2.9, <= 0.4.0
 appdirs >= 1.4.2 , < 2.0.0
 neo >= 0.5.2, < 0.10.0
-matplotlib
-quantities >= 0.12.1
 # csa  # needed but excluded due to readthedocs
 # spinnaker_tools


### PR DESCRIPTION
replaces previous Pr that tried this.

Matplotlib not added to setup.py as that has caused more issues than it fixed in the past.