### PR TITLE
Deal with cases with mixed list and RandomDistribution, add tests

### DIFF
--- a/p8_integration_tests/quick_test/test_connectors/test_from_list_connector_mixed.py
+++ b/p8_integration_tests/quick_test/test_connectors/test_from_list_connector_mixed.py
@@ -47,9 +47,7 @@ class TestFromListConnectorMixed(BaseTestCase):
         sim.end()
 
         target1 = [(0, 0, 2.1, 8), (0, 1, 2.6, 6), (1, 1, 3.2, 4)]
-        target2 = [(0, 0, 1.786, 2), (0, 1, 2.082, 6), (1, 1, 2.499, 3)]
-
-        print(conns1, conns2)
+        target2 = [(0, 0, 1.7864, 2), (0, 1, 2.0823, 6), (1, 1, 2.4995, 3)]
 
         # assertAlmostEqual doesn't work on lists, so loop required
         for i in range(3):

--- a/p8_integration_tests/quick_test/test_connectors/test_from_list_connector_mixed.py
+++ b/p8_integration_tests/quick_test/test_connectors/test_from_list_connector_mixed.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import spynnaker8 as sim
+from p8_integration_tests.base_test_case import BaseTestCase
+
+
+class TestFromListConnectorMixed(BaseTestCase):
+
+    def do_run(self):
+        sim.setup(1.0)
+        pre = sim.Population(2, sim.IF_curr_exp())
+        post = sim.Population(2, sim.IF_curr_exp())
+        nrng = sim.NumpyRNG(seed=1)
+
+        # Test case where weights are in list and delays given by random dist
+        list1 = [(0, 0, 2.1), (0, 1, 2.6), (1, 1, 3.2)]
+        proj1 = sim.Projection(
+            pre, post, sim.FromListConnector(list1, column_names=["weight"]),
+            sim.StaticSynapse(
+                weight=0.5,
+                delay=sim.RandomDistribution('uniform', [1, 10], rng=nrng)))
+
+        # Test case where delays are in list and weights given by random dist
+        list2 = [(0, 0, 2), (0, 1, 6), (1, 1, 3)]
+        proj2 = sim.Projection(
+            pre, post, sim.FromListConnector(list2, column_names=["delay"]),
+            sim.StaticSynapse(
+                weight=sim.RandomDistribution('uniform', [1.5, 3.5], rng=nrng),
+                delay=4))
+
+        sim.run(1)
+        conns1 = proj1.get(["weight", "delay"], "list")
+        conns2 = proj2.get(["weight", "delay"], "list")
+        sim.end()
+
+        target1 = [(0, 0, 2.1, 8), (0, 1, 2.6, 6), (1, 1, 3.2, 4)]
+        target2 = [(0, 0, 1.786, 2), (0, 1, 2.082, 6), (1, 1, 2.499, 3)]
+
+        print(conns1, conns2)
+
+        # assertAlmostEqual doesn't work on lists, so loop required
+        for i in range(3):
+            for j in range(2):
+                self.assertAlmostEqual(
+                    conns1[i][j+2], target1[i][j+2], places=3)
+                self.assertAlmostEqual(
+                    conns2[i][j+2], target2[i][j+2], places=3)
+
+    def test_from_list_connector_mixed(self):
+        self.runsafe(self.do_run)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -88,23 +88,18 @@ class FromListConnector(AbstractConnector):
     @overrides(AbstractConnector.get_delay_maximum)
     def get_delay_maximum(self, synapse_info):
         if self.__delays is None:
-            return numpy.max(synapse_info.delays)
+            return self._get_delay_maximum(
+                synapse_info.delays, len(self.__targets))
         else:
             return numpy.max(self.__delays)
 
     @overrides(AbstractConnector.get_delay_minimum)
     def get_delay_minimum(self, synapse_info):
         if self.__delays is None:
-            return numpy.min(synapse_info.delays)
+            return self._get_delay_minimum(
+                synapse_info.delays, len(self.__targets))
         else:
             return numpy.min(self.__delays)
-
-    @overrides(AbstractConnector.get_delay_variance)
-    def get_delay_variance(self, delays):
-        if self.__delays is None:
-            return numpy.var(delays)
-        else:
-            return numpy.var(self.__delays)
 
     def _split_connections(self, pre_slices, post_slices):
         """
@@ -209,28 +204,14 @@ class FromListConnector(AbstractConnector):
         return numpy.max(numpy.bincount(
             self.__targets.astype('int64', copy=False)))
 
-    @overrides(AbstractConnector.get_weight_mean)
-    def get_weight_mean(self, weights):
-        if self.__weights is None:
-            return numpy.mean(weights)
-        else:
-            return numpy.mean(numpy.abs(self.__weights))
-
     @overrides(AbstractConnector.get_weight_maximum)
     def get_weight_maximum(self, synapse_info):
         # pylint: disable=too-many-arguments
         if self.__weights is None:
-            return numpy.amax(synapse_info.weights)
+            return self._get_weight_maximum(
+                synapse_info.weights, len(self.__targets))
         else:
             return numpy.amax(numpy.abs(self.__weights))
-
-    @overrides(AbstractConnector.get_weight_variance)
-    def get_weight_variance(self, weights):
-        # pylint: disable=too-many-arguments
-        if self.__weights is None:
-            return numpy.var(weights)
-        else:
-            return numpy.var(numpy.abs(self.__weights))
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -101,6 +101,13 @@ class FromListConnector(AbstractConnector):
         else:
             return numpy.min(self.__delays)
 
+    @overrides(AbstractConnector.get_delay_variance)
+    def get_delay_variance(self, delays):
+        if self.__delays is None:
+            return AbstractConnector.get_delay_variance(self, delays)
+        else:
+            return numpy.var(self.__delays)
+
     def _split_connections(self, pre_slices, post_slices):
         """
         :param list(~pacman.model.graphs.commmon.Slice) pre_slices:
@@ -204,6 +211,13 @@ class FromListConnector(AbstractConnector):
         return numpy.max(numpy.bincount(
             self.__targets.astype('int64', copy=False)))
 
+    @overrides(AbstractConnector.get_weight_mean)
+    def get_weight_mean(self, weights):
+        if self.__weights is None:
+            return AbstractConnector.get_weight_mean(self, weights)
+        else:
+            return numpy.mean(numpy.abs(self.__weights))
+
     @overrides(AbstractConnector.get_weight_maximum)
     def get_weight_maximum(self, synapse_info):
         # pylint: disable=too-many-arguments
@@ -212,6 +226,14 @@ class FromListConnector(AbstractConnector):
                 synapse_info.weights, len(self.__targets))
         else:
             return numpy.amax(numpy.abs(self.__weights))
+
+    @overrides(AbstractConnector.get_weight_variance)
+    def get_weight_variance(self, weights):
+        # pylint: disable=too-many-arguments
+        if self.__weights is None:
+            return AbstractConnector.get_weight_variance(self, weights)
+        else:
+            return numpy.var(numpy.abs(self.__weights))
 
     @overrides(AbstractConnector.create_synaptic_block)
     def create_synaptic_block(


### PR DESCRIPTION
Deal with the case where weights / delays are not given in a FromListConnector and are specified using RandomDistribution in the StaticSynapse.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/22