### PR TITLE
These globals are no longer used in this impl

### DIFF
--- a/neural_modelling/src/neuron/implementations/neuron_impl_external_devices.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_external_devices.h
@@ -111,12 +111,6 @@ static synapse_param_t *neuron_synapse_shaping_params;
 static uint n_steps_per_timestep;
 
 //! setup from c_main
-static uint32_t n_neurons;
-
-//! setup from c_main
-static uint32_t timer_period;
-
-//! setup from c_main
 extern uint global_timer_count;
 
 #ifndef SOMETIMES_UNUSED


### PR DESCRIPTION
A couple of global parameters are no longer used in the external devices impl (caught by the compiler), so this PR removes them.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/24