### PR TITLE
No need for current_file_path as BaseTestCase cd into it

### DIFF
--- a/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_200n_100pc_with_delays_all_recording.py
+++ b/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_200n_100pc_with_delays_all_recording.py
@@ -33,10 +33,9 @@ runtime = 5000
 neurons_per_core = n_neurons/2
 placement_constraint = (0, 0)
 expected_spikes = 263
-current_file_path = os.path.dirname(os.path.abspath(__file__))
-spike_file = os.path.join(current_file_path, "200_17_spikes.csv")
-v_file = os.path.join(current_file_path, "200_17_v.csv")
-gysn_file = os.path.join(current_file_path, "200_17_gsyn.csv")
+spike_file = "200_17_spikes.csv"
+v_file = "200_17_v.csv"
+gysn_file = "200_17_gsyn.csv"
 
 
 class Synfire20n20pcDelaysDelayExtensionsAllRecording(BaseTestCase):

--- a/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_20n_20pc_delays_delay_extensions_all_recording.py
+++ b/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_20n_20pc_delays_delay_extensions_all_recording.py
@@ -33,10 +33,9 @@ runtime = 500
 neurons_per_core = None
 placement_constraint = (0, 0)
 expected_spikes = 27
-current_file_path = os.path.dirname(os.path.abspath(__file__))
-spike_file = os.path.join(current_file_path, "20_17_spikes.csv")
-v_file = os.path.join(current_file_path, "20_17_v.csv")
-gysn_file = os.path.join(current_file_path, "20_17_gsyn.csv")
+spike_file = "20_17_spikes.csv"
+v_file = "20_17_v.csv"
+gysn_file = "20_17_gsyn.csv"
 
 
 class Synfire20n20pcDelaysDelayExtensionsAllRecording(BaseTestCase):

--- a/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_20n_20pc_delays_no_delay_extension_all_recording.py
+++ b/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_20n_20pc_delays_no_delay_extension_all_recording.py
@@ -33,10 +33,9 @@ runtime = 200
 neurons_per_core = None
 placement_constraint = (0, 0)
 expected_spikes = 22
-current_file_path = os.path.dirname(os.path.abspath(__file__))
-spike_file = os.path.join(current_file_path, "20_7_spikes.csv")
-v_file = os.path.join(current_file_path, "20_7_v.csv")
-gysn_file = os.path.join(current_file_path, "20_7_gsyn.csv")
+spike_file = "20_7_spikes.csv"
+v_file = "20_7_v.csv"
+gysn_file = "20_7_gsyn.csv"
 
 
 class Synfire20n20pcDelaysDelayExtensionsAllRecording(BaseTestCase):

--- a/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_20n_20pc_no_delays_all_recording.py
+++ b/p8_integration_tests/quick_test/test_param_vertex_retrieval_from_board_after_1_run/test_synfire_20n_20pc_no_delays_all_recording.py
@@ -32,11 +32,10 @@ runtime = 100
 neurons_per_core = None
 placement_constraint = (0, 0)
 expected_spikes = 33
-current_file_path = os.path.dirname(os.path.abspath(__file__))
-spike_file = os.path.join(current_file_path, "20_1_spikes.csv")
-v_file = os.path.join(current_file_path, "20_1_v.csv")
-gysn_file = os.path.join(current_file_path, "20_1_gsyn.csv")
-gysn_exc_file = os.path.join(current_file_path, "20_1_gsyn_exc.csv")
+spike_file = "20_1_spikes.csv"
+v_file = "20_1_v.csv"
+gysn_file = "20_1_gsyn.csv"
+gysn_exc_file = "20_1_gsyn_exc.csv"
 
 
 class Synfire20n20pcDelaysDelayExtensionsAllRecording(BaseTestCase):

--- a/p8_integration_tests/quick_test/test_selective_recording/test_recording_on_off.py
+++ b/p8_integration_tests/quick_test/test_selective_recording/test_recording_on_off.py
@@ -20,8 +20,7 @@ import spynnaker8 as sim
 from spynnaker.pyNN.utilities import neo_compare
 from spinnaker_testbase import BaseTestCase
 
-current_file_path = os.path.dirname(os.path.abspath(__file__))
-pickle_path = os.path.join(current_file_path, "data.pickle")
+pickle_path = "data.pickle"
 
 
 class TestRecordingOnOff(BaseTestCase):


### PR DESCRIPTION
No need to do os.path.join(current_file_path....
as BasteTestCase setup() changes directory into the current directory so the paths can be relative.