### PR TITLE
strip out max_delay as it was based on an INCONSTENT PyNN 

### DIFF
--- a/spynnaker/pyNN/abstract_spinnaker_common.py
+++ b/spynnaker/pyNN/abstract_spinnaker_common.py
@@ -47,7 +47,6 @@ class AbstractSpiNNakerCommon(
         "__id_counter",
         "__live_spike_recorder",
         "__min_delay",
-        "__max_delay",
         "__neurons_per_core_set",
         "_populations",
         "_projections"]
@@ -63,7 +62,7 @@ class AbstractSpiNNakerCommon(
 
     def __init__(
             self, graph_label, database_socket_addresses, n_chips_required,
-            n_boards_required, timestep, max_delay, min_delay, hostname,
+            n_boards_required, timestep, min_delay, hostname,
             user_extra_algorithm_xml_path=None, user_extra_mapping_inputs=None,
             user_extra_algorithms_pre_run=None, time_scale_factor=None,
             extra_post_run_algorithms=None, extra_mapping_algorithms=None,
@@ -78,7 +77,6 @@ class AbstractSpiNNakerCommon(
         :param n_boards_required:
         :type n_boards_required: int or None
         :param int timestep:
-        :param float max_delay:
         :param float min_delay:
         :param str hostname:
         :param user_extra_algorithm_xml_path:
@@ -126,7 +124,6 @@ class AbstractSpiNNakerCommon(
 
         # timing parameters
         self.__min_delay = None
-        self.__max_delay = max_delay
 
         self.__neurons_per_core_set = set()
 
@@ -144,9 +141,6 @@ class AbstractSpiNNakerCommon(
             n_boards_required=n_boards_required,
             default_config_paths=[self.extended_config_path()],
             front_end_versions=versions)
-
-        # update inputs needed by the machine level calls.
-        self.update_extra_inputs({'UserDefinedMaxDelay': self.__max_delay})
 
         extra_mapping_inputs = dict()
         extra_mapping_inputs['CreateAtomToEventIdMapping'] = \

--- a/spynnaker/pyNN/extra_algorithms/algorithms_metadata.xml
+++ b/spynnaker/pyNN/extra_algorithms/algorithms_metadata.xml
@@ -30,15 +30,10 @@
                 <param_name>machine_time_step</param_name>
                 <param_type>MachineTimeStep</param_type>
             </parameter>
-            <parameter>
-                <param_name>user_max_delay</param_name>
-                <param_type>UserDefinedMaxDelay</param_type>
-            </parameter>
         </input_definitions>
         <required_inputs>
             <param_name>app_graph</param_name>
             <param_name>machine_time_step</param_name>
-            <param_name>user_max_delay</param_name>
             <token part="MAIN">SplitterObjectsAllocated</token>
         </required_inputs>
         <outputs>

--- a/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
+++ b/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
@@ -35,7 +35,6 @@ class DelaySupportAdder(object):
 
     :param ApplicationGraph app_graph: the app graph
     :param int machine_time_step: the machine time step
-    :param int user_max_delay: the user defined max delay
     :rtype: None
     """
 
@@ -62,9 +61,6 @@ class DelaySupportAdder(object):
         "finally implement the code to allow multiple delay extensions. "
         "good luck.")
 
-    END_USER_MAX_DELAY_DEFILING_ERROR_MESSAGE = (
-        "The end user entered a max delay for which the projection breaks")
-
     APP_DELAY_PROGRESS_BAR_TEXT = "Adding delay extensions as required"
 
     def __init__(self):
@@ -72,14 +68,13 @@ class DelaySupportAdder(object):
         self._delay_post_edge_map = dict()
         self._delay_pre_edges = list()
 
-    def __call__(self, app_graph, machine_time_step, user_max_delay):
+    def __call__(self, app_graph, machine_time_step):
         """ adds the delay extensions to the app graph, now that all the\
             splitter objects have been set.
 
         :param ~pacman.model.graphs.application.ApplicationGraph app_graph:
             the app graph
         :param int machine_time_step: the machine time step
-        :param int user_max_delay: the user defined max delay
         """
 
         # progress abr and data holders
@@ -97,8 +92,7 @@ class DelaySupportAdder(object):
                     synapse_infos = app_edge.synapse_information
                     (max_delay_needed, post_vertex_max_delay,
                      need_delay_extension) = self._check_delay_values(
-                        app_edge, user_max_delay, machine_time_step,
-                        synapse_infos)
+                        app_edge, machine_time_step, synapse_infos)
 
                     # if we need a delay, add it to the app graph.
                     if need_delay_extension:
@@ -200,12 +194,11 @@ class DelaySupportAdder(object):
         return delay_app_vertex
 
     def _check_delay_values(
-            self, app_edge, user_max_delay, machine_time_step, synapse_infos):
+            self, app_edge, machine_time_step, synapse_infos):
         """ checks the delay required from the user defined max, the max delay\
             supported by the post vertex splitter and the delay Extensions.
 
         :param ApplicationEdge app_edge: the undelayed app edge
-        :param int user_max_delay: user max delay of the sim.
         :param int machine_time_step: machine time step of the sim.
         :param iterable[SynapseInfo] synapse_infos: iterable of synapse infos
         :return:tuple of max_delay_needed, post_vertex_max_delay, bool.
@@ -216,10 +209,6 @@ class DelaySupportAdder(object):
             synapse_info.synapse_dynamics.get_delay_maximum(
                 synapse_info.connector, synapse_info)
             for synapse_info in synapse_infos)
-
-        # check max delay works
-        if max_delay_needed > user_max_delay:
-            logger.warning(self.END_USER_MAX_DELAY_DEFILING_ERROR_MESSAGE)
 
         # get if the post vertex needs a delay extension
         post_splitter = app_edge.post_vertex.splitter

--- a/spynnaker8/__init__.py
+++ b/spynnaker8/__init__.py
@@ -327,6 +327,7 @@ def setup(timestep=_pynn_control.DEFAULT_TIMESTEP,
         ``n_boards_required`` are used.
     """
     # Check for "auto" values
+    a = _pynn_control
     if timestep == "auto":
         timestep = SPYNNAKER_AUTO_TIMESTEP
     if min_delay == "auto":
@@ -363,7 +364,7 @@ def setup(timestep=_pynn_control.DEFAULT_TIMESTEP,
         extra_post_run_algorithms=extra_post_run_algorithms,
         extra_load_algorithms=extra_load_algorithms,
         time_scale_factor=time_scale_factor, timestep=timestep,
-        min_delay=min_delay, max_delay=max_delay, graph_label=graph_label,
+        min_delay=min_delay, graph_label=graph_label,
         n_chips_required=n_chips_required,
         n_boards_required=n_boards_required)
 

--- a/spynnaker8/spinnaker.py
+++ b/spynnaker8/spinnaker.py
@@ -44,7 +44,7 @@ class SpiNNaker(AbstractSpiNNakerCommon, pynn_control.BaseState,
             extra_algorithm_xml_paths, extra_mapping_inputs,
             extra_mapping_algorithms, extra_pre_run_algorithms,
             extra_post_run_algorithms, extra_load_algorithms,
-            time_scale_factor, min_delay, max_delay, graph_label,
+            time_scale_factor, min_delay, graph_label,
             n_chips_required=None, n_boards_required=None, timestep=0.1,
             hostname=None):
         # pylint: disable=too-many-arguments, too-many-locals
@@ -97,7 +97,7 @@ class SpiNNaker(AbstractSpiNNakerCommon, pynn_control.BaseState,
             graph_label=graph_label, n_chips_required=n_chips_required,
             n_boards_required=n_boards_required,
             hostname=hostname, min_delay=min_delay,
-            max_delay=max_delay, timestep=timestep,
+            timestep=timestep,
             time_scale_factor=time_scale_factor,
             front_end_versions=front_end_versions)
 


### PR DESCRIPTION
strip out max_delay as it was based on an INCONSTENT PyNN value and only used for an incorrect warning

tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/36