### PR TITLE
Clear cache

### DIFF
--- a/spynnaker/pyNN/abstract_spinnaker_common.py
+++ b/spynnaker/pyNN/abstract_spinnaker_common.py
@@ -378,6 +378,8 @@ class AbstractSpiNNakerCommon(
                 ["RedundantPacketCountReport"])
 
         super().run(run_time, sync_time)
+        for projection in self._projections:
+            projection._clear_cache()
 
     @staticmethod
     def register_binary_search_path(search_path):

--- a/spynnaker/pyNN/models/neuron/synaptic_matrix_app.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrix_app.py
@@ -687,6 +687,7 @@ class SynapticMatrixApp(object):
                 connections = numpy.concatenate(connections)
                 for holder in self.__synapse_info.pre_run_connection_holders:
                     holder.add_connections(connections)
+            self.clear_connection_cache()
 
     def __read_connections(self, transceiver, placement, synapses_address):
         """ Read connections from an address on the machine


### PR DESCRIPTION
doing projection get weight both before and after run cause the before run to be returned both times.

This was due to SynapticMatrix caching the read values.

Fix 1. Clear the cache after reading pre data
Fix 2. Clear all caches after run so get reads in fresh data

Implemented both to be safe.