### PR TITLE
read_router_compressor_with_bitfield_iobuf  no longer used.

### DIFF
--- a/spynnaker_integration_tests/test_iobuf/test_iobuf_without_during_run_flag/spynnaker.cfg
+++ b/spynnaker_integration_tests/test_iobuf/test_iobuf_without_during_run_flag/spynnaker.cfg
@@ -6,5 +6,4 @@ extract_iobuf_from_cores = ALL
 extract_iobuf_from_binary_types = None
 
 generate_bit_field_summary_report = False
-read_router_compressor_with_bitfield_iobuf = False
 generate_router_compression_with_bitfield_report = False


### PR DESCRIPTION
found another dead cfg option in tests