### PR TITLE
Error when too many redraws are requested in a clipped distribution

### DIFF
--- a/spynnaker_integration_tests/test_various/test_synaptic_expander.py
+++ b/spynnaker_integration_tests/test_various/test_synaptic_expander.py
@@ -159,6 +159,7 @@ def check_fixed_prob(n, prob, n_per_core, conns):
 def check_fixed_total(n, total, conns):
     assert(len(conns) == total)
 
+
 def run_bad_normal_clipping():
     p.setup(timestep=1.0)
 
@@ -168,9 +169,8 @@ def run_bad_normal_clipping():
     delays = p.RandomDistribution(
         "normal_clipped", mu=20, sigma=1, low=1, high=6)
 
-    input_proj = p.Projection(input, pop_1, p.AllToAllConnector(),
-                              synapse_type=p.StaticSynapse(
-                                  weight=5, delay=delays))
+    p.Projection(input, pop_1, p.AllToAllConnector(),
+                 synapse_type=p.StaticSynapse(weight=5, delay=delays))
 
     p.run(10)
 

--- a/spynnaker_integration_tests/test_various/test_synaptic_expander.py
+++ b/spynnaker_integration_tests/test_various/test_synaptic_expander.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import spynnaker8 as p
+from spinnman.exceptions import SpiNNManCoresNotInStateException
 from spynnaker8 import RandomDistribution
 import functools
 from spinnaker_testbase import BaseTestCase
@@ -158,11 +159,32 @@ def check_fixed_prob(n, prob, n_per_core, conns):
 def check_fixed_total(n, total, conns):
     assert(len(conns) == total)
 
+def run_bad_normal_clipping():
+    p.setup(timestep=1.0)
+
+    pop_1 = p.Population(4, p.IF_curr_exp(), label="pop_1")
+    input = p.Population(4, p.SpikeSourceArray(spike_times=[0]), label="input")
+
+    delays = p.RandomDistribution(
+        "normal_clipped", mu=20, sigma=1, low=1, high=6)
+
+    input_proj = p.Projection(input, pop_1, p.AllToAllConnector(),
+                              synapse_type=p.StaticSynapse(
+                                  weight=5, delay=delays))
+
+    p.run(10)
+
+    p.end()
+
 
 class TestSynapticExpander(BaseTestCase):
 
     def test_script(self):
         self.runsafe(run_script)
+
+    def test_bad_normal_clipping(self):
+        with self.assertRaises(SpiNNManCoresNotInStateException):
+            self.runsafe(run_bad_normal_clipping)
 
 
 if __name__ == "__main__":

--- a/spynnaker_integration_tests/test_various/test_synaptic_expander.py
+++ b/spynnaker_integration_tests/test_various/test_synaptic_expander.py
@@ -184,7 +184,7 @@ class TestSynapticExpander(BaseTestCase):
 
     def test_bad_normal_clipping(self):
         with self.assertRaises(SpiNNManCoresNotInStateException):
-            self.runsafe(run_bad_normal_clipping)
+            run_bad_normal_clipping()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/1044

Adds a test to check that an error is thrown based on the example given in the issue.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/56