### PR TITLE
use svg for big files in SpYNNakerNeuronGraphNetworkSpecificationReport

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/extra_algorithms/spynnaker_neuron_network_specification_report.py
@@ -20,6 +20,8 @@ from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.models.neural_projections import ProjectionApplicationEdge
 logger = FormatAdapter(logging.getLogger(__name__))
 
+CUTOFF = 100
+
 
 class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
     """ Produces a report describing the graph created from the neural \
@@ -29,7 +31,8 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
     _GRAPH_TITLE = "The graph of the network in graphical form"
     _GRAPH_NAME = "network_graph.gv"
     _NODE_LABEL = "{} ({} neurons)"
-    _GRAPH_FORMAT = "png"
+    _GRAPH_FORMAT_NORMAL = "png"
+    _GRAPH_FORMAT_LARGE = "svg"
 
     @staticmethod
     def _get_diagram(label):
@@ -74,8 +77,13 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
         # write dot file and generate pdf
         file_to_output = os.path.join(report_folder, self._GRAPH_NAME)
         try:
-            dot_diagram.render(file_to_output, view=False,
-                               format=self._GRAPH_FORMAT)
+            if (application_graph.n_vertices +
+                application_graph.n_outgoing_edge_partitions) > CUTOFF:
+                dot_diagram.render(file_to_output, view=False,
+                                   format=self._GRAPH_FORMAT_LARGE)
+            else:
+                dot_diagram.render(file_to_output, view=False,
+                                   format=self._GRAPH_FORMAT_NORMAL)
         except exeNotFoundExn:
             logger.exception("could not render diagram in {}", file_to_output)
         progress.update()

--- a/spynnaker/pyNN/extra_algorithms/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/extra_algorithms/spynnaker_neuron_network_specification_report.py
@@ -78,7 +78,7 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
         file_to_output = os.path.join(report_folder, self._GRAPH_NAME)
         try:
             if (application_graph.n_vertices +
-                application_graph.n_outgoing_edge_partitions) > CUTOFF:
+                    application_graph.n_outgoing_edge_partitions) > CUTOFF:
                 dot_diagram.render(file_to_output, view=False,
                                    format=self._GRAPH_FORMAT_LARGE)
             else:

--- a/spynnaker/pyNN/extra_algorithms/spynnaker_neuron_network_specification_report.py
+++ b/spynnaker/pyNN/extra_algorithms/spynnaker_neuron_network_specification_report.py
@@ -31,7 +31,7 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
     _GRAPH_TITLE = "The graph of the network in graphical form"
     _GRAPH_NAME = "network_graph.gv"
     _NODE_LABEL = "{} ({} neurons)"
-    _GRAPH_FORMAT_NORMAL = "png"
+    _GRAPH_FORMAT = "png"
     _GRAPH_FORMAT_LARGE = "svg"
 
     @staticmethod
@@ -83,7 +83,7 @@ class SpYNNakerNeuronGraphNetworkSpecificationReport(object):
                                    format=self._GRAPH_FORMAT_LARGE)
             else:
                 dot_diagram.render(file_to_output, view=False,
-                                   format=self._GRAPH_FORMAT_NORMAL)
+                                   format=self._GRAPH_FORMAT)
         except exeNotFoundExn:
             logger.exception("could not render diagram in {}", file_to_output)
         progress.update()

--- a/spynnaker/pyNN/spynnaker.cfg
+++ b/spynnaker/pyNN/spynnaker.cfg
@@ -3,6 +3,9 @@
 writeSynapticReport = False
 # Note: graphviz is required to draw the graph
 write_network_graph = False
+# Unless specified write_network_graph is ignored for large graphs
+# For small graph the default format is used
+network_graph_format = None
 # Set to > 0 to allow profiler to gather samples (assuming enabled in the compiled aplx)
 n_profile_samples = 0
 generate_bit_field_report = False

--- a/unittests/test_using_virtual_board/test_debug_mode/spynnaker.cfg
+++ b/unittests/test_using_virtual_board/test_debug_mode/spynnaker.cfg
@@ -11,3 +11,6 @@ version = 5
 # mode = Production or Debug
 # In Debug mode all report boolean config values are automatically overwritten to True
 mode = Debug
+
+[Reports]
+network_graph_format = svg

--- a/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
+++ b/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
@@ -75,8 +75,8 @@ class TestDebug(BaseTestCase):
             # write_data_speed_up_report not on a virtual board
             # DataSpeedUpPacketGatherMachineVertex.REPORT_NAME
             SpYNNakerNeuronGraphNetworkSpecificationReport._GRAPH_NAME,
-            SpYNNakerNeuronGraphNetworkSpecificationReport._GRAPH_NAME + "." +
-            SpYNNakerNeuronGraphNetworkSpecificationReport._GRAPH_FORMAT,
+            SpYNNakerNeuronGraphNetworkSpecificationReport._GRAPH_NAME
+            + ".svg",
             ]
         sim.setup(1.0)
         pop = sim.Population(100, sim.IF_curr_exp, {}, label="pop")


### PR DESCRIPTION
When using png on large files it reports
"graph is too large for cairo-renderer bitmaps"

The resulting svg file is USELESS. In the extreme cases just some gray shading.

Not sure about the cutoff