### PR TITLE
Return false after logging error

### DIFF
--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -296,6 +296,7 @@ bool synapses_initialise(
     if (ring_buffers == NULL) {
         log_error("Could not allocate %u entries for ring buffers",
                 ring_buffer_size);
+        return false;
     }
     for (uint32_t i = 0; i < ring_buffer_size; i++) {
         ring_buffers[i] = 0;


### PR DESCRIPTION
Discovered this on the CurrentSource branch - an error is logged but then no return takes place, so the code tries to carry on and hangs.