### PR TITLE
Remove functions that aren't implemented so don't return anything

### DIFF
--- a/spynnaker/pyNN/models/projection.py
+++ b/spynnaker/pyNN/models/projection.py
@@ -497,20 +497,6 @@ class Projection(object):
 
     # -----------------------------------------------------------------
 
-    def __len__(self):
-        """
-        .. warning::
-            Not implemented.
-        """
-        _we_dont_do_this_now()
-
-    def __iter__(self):
-        """
-        .. warning::
-            Not implemented.
-        """
-        _we_dont_do_this_now()
-
     def set(self, **attributes):  # @UnusedVariable
         # pylint: disable=unused-argument
         """


### PR DESCRIPTION
Fix for master: new pylint version does not appear to like including functions that aren't implemented when they should return values / objects.