### PR TITLE
allow for mutliple send_sync

### DIFF
--- a/spynnaker_integration_tests/test_external_devices/test_live_sync.py
+++ b/spynnaker_integration_tests/test_external_devices/test_live_sync.py
@@ -77,6 +77,10 @@ def test_live_sync():
     sim_finished = True
     p.end()
 
+    # On slow connections send_sync is sent more often
+    n_spikes = [x for x in n_spikes if x > 0]
+    assert 5 == len(n_spikes)
+
     # 20 spikes should be in each range, but some could get lost, so check
     # for a range
     for i in range(5):


### PR DESCRIPTION
On master from home with spalloc
and on on executor jenkins

There where times when the send_syn fired twice between recv calls