### PR TITLE
disable user CommandSender

### DIFF
--- a/spynnaker/pyNN/abstract_spinnaker_common.py
+++ b/spynnaker/pyNN/abstract_spinnaker_common.py
@@ -236,7 +236,9 @@ class AbstractSpiNNakerCommon(AbstractSpinnakerBase):
 
     def add_application_vertex(self, vertex):
         if isinstance(vertex, CommandSender):
-            self._command_sender = vertex
+            raise NotImplementedError(
+                "Please contact spinnker team as adding a CommandSender "
+                "currently disabled")
         super().add_application_vertex(vertex)
 
     @staticmethod


### PR DESCRIPTION
To make sure we add a CommandSender afer a hard reset we turned of caching.

This breaks the adding of a user CommandSender.

As @rowleya did not know any use case we have disabled the users ability to add one.