### PR TITLE
scipy from FEC (which caps)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ SpiNNFrontEndCommon == 1!6.0.1
 numpy > 1.13, < 1.20; python_version == '3.6'
 numpy > 1.13, < 1.21; python_version == '3.7'
 numpy; python_version >= '3.8'
-scipy
 lxml
 statistics
 matplotlib < 3.4; python_version == '3.6'


### PR DESCRIPTION
Mainly a test for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/905

Removes the last direct reference to scipy