### PR TITLE
Multirun packets-per-timestep fix

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -224,7 +224,7 @@ class NeuronRecorder(object):
     @staticmethod
     def _process_missing_data(
             missing_str, placement, expected_rows, n_neurons, times,
-            sampling_rate, label, placement_data):
+            sampling_rate, label, placement_data, region):
         missing_str += "({}, {}, {}); ".format(
             placement.x, placement.y, placement.p)
         # Start the fragment for this slice empty
@@ -236,10 +236,10 @@ class NeuronRecorder(object):
             if len(local_indexes[0]) == 1:
                 fragment[i] = placement_data[local_indexes[0]]
             elif len(local_indexes[0]) > 1:
-                fragment[i] = placement_data[local_indexes[0], 1:]
+                fragment[i] = placement_data[local_indexes[0][0]]
                 logger.warning(
-                    "Population {} has multiple recorded data for time {}",
-                    label, time)
+                    "Population {} has multiple recorded data for time {}"
+                    " in region {} ", label, time, region)
             else:
                 # Set row to nan
                 fragment[i] = numpy.full(n_neurons, numpy.nan)
@@ -301,7 +301,7 @@ class NeuronRecorder(object):
         # process data from core for missing data
         placement_data = self._process_missing_data(
             missing_str, placement, expected_rows, n_per_timestep, times,
-            sampling_rate, label, placement_data)
+            sampling_rate, label, placement_data, region)
         return placement_data
 
     def __read_data(

--- a/spynnaker_integration_tests/test_various/test_record_packets_per_timestep.py
+++ b/spynnaker_integration_tests/test_various/test_record_packets_per_timestep.py
@@ -51,5 +51,42 @@ class TestRecordPacketsPerTimestep(BaseTestCase):
 
         sim.end()
 
+    def do_multi_run(self):
+        sim.setup(timestep=1.0)
+        runtime = 500
+        n_neurons = 10
+        spikegap = 50
+
+        spike_times = list(n for n in range(0, runtime, spikegap))
+        pop_src = sim.Population(n_neurons, sim.SpikeSourceArray(spike_times),
+                                 label="src")
+
+        pop_lif = sim.Population(n_neurons, sim.IF_curr_exp(), label="lif")
+
+        weight = 5
+        delay = 5
+
+        # define the projection
+        sim.Projection(pop_src, pop_lif, sim.OneToOneConnector(),
+                       sim.StaticSynapse(weight=weight, delay=delay),
+                       receptor_type="excitatory")
+
+        pop_lif.record("all")
+
+        sim.run(runtime//2)
+        sim.run(runtime//2)
+
+        pps = pop_lif.get_data()
+
+        totalpackets = sum(
+            pps.segments[0].filter(name='packets-per-timestep')[0])
+
+        assert(totalpackets == n_neurons * (runtime // spikegap))
+
+        sim.end()
+
     def test_run(self):
         self.runsafe(self.do_run)
+
+    def test_multi_run(self):
+        self.runsafe(self.do_multi_run)


### PR DESCRIPTION
Discovered while running other code that packets-per-timestep recording was broken for multi-run; this fixes it and adds a test for multi-run recording with packets-per-timestep.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/95