### PR TITLE
Fix recording for rewiring and packets to work after reset

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -68,7 +68,8 @@ class NeuronRecorder(object):
         "__events_per_core_datatypes",
         "__events_per_core_recording",
         "__events_per_ts",
-        "__region_ids"]
+        "__region_ids",
+        "__offset_added"]
 
     _N_BYTES_FOR_TIMESTAMP = BYTES_PER_WORD
     _N_BYTES_PER_RATE = BYTES_PER_WORD
@@ -162,14 +163,20 @@ class NeuronRecorder(object):
                     events_per_core_variables, per_timestep_variables)):
             self.__region_ids[variable] = region_id
 
+        self.__offset_added = False
+
     def add_region_offset(self, offset):
         """ Add an offset to the regions.  Used when there are multiple\
             recorders on a single core
 
         :param int offset: The offset to add
         """
-        self.__region_ids = dict((var, region + offset)
-                                 for var, region in self.__region_ids.items())
+        if not self.__offset_added:
+            self.__region_ids = dict(
+                (var, region + offset)
+                for var, region in self.__region_ids.items())
+
+        self.__offset_added = True
 
     def _count_recording_per_slice(
             self, variable, vertex_slice):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -189,7 +189,9 @@ class SynapseDynamicsStructuralCommon(
         spec.write_array(self.get_seeds(app_vertex))
 
         # write local seed (4 words), generated randomly!
-        spec.write_array(self.get_seeds())
+        # Note that in case of a reset, these need a key to ensure subsequent
+        # runs match the first run
+        spec.write_array(self.get_seeds(vertex_slice))
 
         # write the number of pre-populations
         spec.write_value(data=n_pre_pops)

--- a/spynnaker/pyNN/models/recorder.py
+++ b/spynnaker/pyNN/models/recorder.py
@@ -407,6 +407,10 @@ class Recorder(object):
                     data = self.get_spikes()
                     sampling_interval = self.__spike_sampling_interval
                     indexes = None
+                elif variable == REWIRING:
+                    data = self.get_events(variable)
+                    sampling_interval = None
+                    indexes = None
                 else:
                     (data, indexes, sampling_interval) = \
                         self.get_recorded_matrix(variable)

--- a/spynnaker_integration_tests/test_struct_pl/test_structural_formation_to_full.py
+++ b/spynnaker_integration_tests/test_struct_pl/test_structural_formation_to_full.py
@@ -55,6 +55,51 @@ def structural_formation_to_full():
     return conns, num_forms, num_elims, first_f
 
 
+def structural_formation_to_full_with_reset():
+    p.setup(1.0)
+    stim = p.Population(4, p.SpikeSourceArray(range(10)), label="stim")
+
+    # These populations should experience formation
+    pop = p.Population(4, p.IF_curr_exp(), label="pop")
+
+    # Formation with random selection (0 probability elimination), setting
+    # with_replacement=False means an all-to-all connection will be the result
+    proj = p.Projection(
+        stim, pop, p.FromListConnector([]), p.StructuralMechanismStatic(
+            partner_selection=p.LastNeuronSelection(),
+            formation=p.DistanceDependentFormation([2, 2], 1.0),
+            elimination=p.RandomByWeightElimination(4.0, 0, 0),
+            f_rew=1000, initial_weight=4.0, initial_delay=3.0,
+            s_max=4, seed=0, weight=0.0, delay=1.0, with_replacement=False))
+
+    pop.record("rewiring")
+
+    p.run(1000)
+
+    p.Population(4, p.IF_curr_exp(), label="pop2")
+    p.reset()
+
+    p.run(1000)
+
+    # Get the final connections
+    conns = proj.get(["weight", "delay"], "list")
+
+    rewiring = pop.get_data("rewiring")
+
+    formation_events = rewiring.segments[0].events[0]
+    formation_events2 = rewiring.segments[1].events[0]
+
+    num_forms = len(formation_events.times)
+    num_forms2 = len(formation_events2.times)
+
+    first_f = formation_events.labels[0]
+    first_f2 = formation_events2.labels[0]
+
+    p.end()
+
+    return conns, num_forms, num_forms2, first_f, first_f2
+
+
 class TestStructuralFormationToFull(BaseTestCase):
     def do_run(self):
         conns, num_forms, num_elims, first_f = structural_formation_to_full()
@@ -72,9 +117,27 @@ class TestStructuralFormationToFull(BaseTestCase):
         self.assertEqual(num_elims, 0)
         self.assertEqual(first_f, first_formation)
 
+    def do_run_with_reset(self):
+        conns, num_forms, num_forms2, first_f, first_f2 = \
+            structural_formation_to_full_with_reset()
+        # Should have built all-to-all connectivity
+        all_to_all_conns = [
+            [0, 0, 4., 3.], [0, 1, 4., 3.], [0, 2, 4., 3.], [0, 3, 4., 3.],
+            [1, 0, 4., 3.], [1, 1, 4., 3.], [1, 2, 4., 3.], [1, 3, 4., 3.],
+            [2, 0, 4., 3.], [2, 1, 4., 3.], [2, 2, 4., 3.], [2, 3, 4., 3.],
+            [3, 0, 4., 3.], [3, 1, 4., 3.], [3, 2, 4., 3.], [3, 3, 4., 3.]]
+        first_formation = "3_3_formation"
+
+        self.assertCountEqual(all_to_all_conns, conns)
+        self.assertEqual(num_forms, num_forms2)
+        self.assertEqual(first_f, first_f2)
+        self.assertEqual(first_f, first_formation)
+
     def test_structural_formation_to_full(self):
         self.runsafe(self.do_run)
 
+    def test_structural_formation_to_full_with_reset(self):
+        self.runsafe(self.do_run_with_reset)
 
 if __name__ == "__main__":
     structural_formation_to_full()

--- a/spynnaker_integration_tests/test_various/test_record_packets_per_timestep.py
+++ b/spynnaker_integration_tests/test_various/test_record_packets_per_timestep.py
@@ -85,8 +85,51 @@ class TestRecordPacketsPerTimestep(BaseTestCase):
 
         sim.end()
 
+    def do_run_with_reset(self):
+        sim.setup(timestep=1.0)
+        runtime = 500
+        n_neurons = 10
+        spikegap = 50
+
+        spike_times = list(n for n in range(0, runtime, spikegap))
+        pop_src = sim.Population(n_neurons, sim.SpikeSourceArray(spike_times),
+                                 label="src")
+
+        pop_lif = sim.Population(n_neurons, sim.IF_curr_exp(), label="lif")
+
+        weight = 5
+        delay = 5
+
+        # define the projection
+        sim.Projection(pop_src, pop_lif, sim.OneToOneConnector(),
+                       sim.StaticSynapse(weight=weight, delay=delay),
+                       receptor_type="excitatory")
+
+        pop_lif.record("all")
+
+        sim.run(runtime//2)
+
+        # add another population to ensure a hard reset
+        sim.Population(n_neurons, sim.IF_curr_exp(), label="lif2")
+        sim.reset()
+
+        sim.run(runtime//2)
+
+        pps = pop_lif.get_data()
+
+        totalpackets = sum(
+            pps.segments[0].filter(name='packets-per-timestep')[0])+ sum(
+                pps.segments[1].filter(name='packets-per-timestep')[0])
+
+        assert(totalpackets == n_neurons * (runtime // spikegap))
+
+        sim.end()
+
     def test_run(self):
         self.runsafe(self.do_run)
 
     def test_multi_run(self):
         self.runsafe(self.do_multi_run)
+
+    def test_run_with_reset(self):
+        self.runsafe(self.do_run_with_reset)


### PR DESCRIPTION
@Christian-B is currently working with what happens with the code after calls to reset() and noticed that recording may be broken for the "rewiring" variable; tested and sure enough he was correct, and in addition "packets-per-timestep" was broken too.  This is because the region offset was mistakenly being added again to the recording region IDs for these variables.

Whilst I was looking at this I also fixed the structural plasticity cases after reset so that if a user specifies the same seed pre- and post-reset then they get the same answer.