### PR TITLE
Use outgoing_edge_partitions to find edge

### DIFF
--- a/spynnaker/pyNN/models/projection.py
+++ b/spynnaker/pyNN/models/projection.py
@@ -442,13 +442,15 @@ class Projection(object):
         :rtype: ~.ApplicationEdge
         """
         # Find edges ending at the postsynaptic vertex
-        graph_edges = get_simulator().original_application_graph.\
-            get_edges_ending_at_vertex(post_synaptic_vertex)
+        partitions = get_simulator().original_application_graph.\
+            get_outgoing_edge_partitions_starting_at_vertex(pre_synaptic_vertex)
 
-        # Search the edges for any that start at the presynaptic vertex
-        for edge in graph_edges:
-            if edge.pre_vertex == pre_synaptic_vertex:
-                return edge
+        # Partitions and Partition.edges will be OrderedSet but may be empty
+        for partition in partitions:
+            for edge in partition.edges:
+                if edge.post_vertex == post_synaptic_vertex:
+                    return edge
+
         return None
 
     def _get_synaptic_data(


### PR DESCRIPTION
ApplicationGraph currently track _outgoing_edge_partitions_by_pre_vertex and _incoming_edges

the partitions are used in several places.

The edges only by the method
graph.get_edges_ending_at_vertex

This removes the only know use of get_edges_ending_at_vertex (other than tests)

This allows the removal of a defaultdict(OrderedSet) in Graph which is filled in even for none PyNN usages.


