### PR TITLE
removed private property

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
@@ -785,6 +785,8 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
         # Pick the smallest between the two, so that not too many bits are used
         final_n_delay_bits = min(n_delay_bits, max_delay_bits)
         self.__max_delay = 2 ** final_n_delay_bits
+        if self.__allow_delay_extension is None:
+            self.__allow_delay_extension = max_delay_bits > final_n_delay_bits
 
     @overrides(AbstractSpynnakerSplitterDelay.max_support_delay)
     def max_support_delay(self):


### PR DESCRIPTION
removed the private property  __get_max_delay
added __update_max_delay method
for get use using already existing and required max_support_delay() method instead.

Note: There where two different ways to calculate self.__allow_delay_extension

from init
 if (self.__max_delay is not None and
                self.__allow_delay_extension is None):
            self.__allow_delay_extension = True

from __get_max_delay/__update_max_delay
if self.__allow_delay_extension is None:
            self.__allow_delay_extension = max_delay_bits > final_n_delay_bits


Issue was that after a reset the first was not called so the second would apply.

Which is correct if the USER supplies a max_delay and no allow_delay_extension
