### PR TITLE
app vertex max_atoms_per_core

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_slice.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_slice.py
@@ -15,7 +15,7 @@
 from spinn_utilities.overrides import overrides
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.constraints.partitioner_constraints import (
-    MaxVertexAtomsConstraint, AbstractPartitionerConstraint)
+    AbstractPartitionerConstraint)
 from pacman.model.graphs.machine import MachineEdge
 from pacman.model.resources import (
     ResourceContainer, DTCMResource, CPUCyclesPerTickResource,
@@ -316,7 +316,7 @@ class SplitterAbstractPopulationVertexSlice(
     def check_supported_constraints(self):
         utility_calls.check_algorithm_can_support_constraints(
             constrained_vertices=[self._governed_app_vertex],
-            supported_constraints=[MaxVertexAtomsConstraint],
+            supported_constraints=[],
             abstract_constraint_type=AbstractPartitionerConstraint)
 
     @overrides(AbstractSplitterSlice.reset_called)

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_slice.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_slice.py
@@ -15,8 +15,7 @@
 from spinn_utilities.overrides import overrides
 from pacman.exceptions import PacmanConfigurationException
 from pacman.model.constraints.partitioner_constraints import (
-    MaxVertexAtomsConstraint, FixedVertexAtomsConstraint,
-    AbstractPartitionerConstraint)
+    MaxVertexAtomsConstraint, AbstractPartitionerConstraint)
 from pacman.model.graphs.machine import MachineEdge
 from pacman.model.resources import (
     ResourceContainer, DTCMResource, CPUCyclesPerTickResource,
@@ -317,8 +316,7 @@ class SplitterAbstractPopulationVertexSlice(
     def check_supported_constraints(self):
         utility_calls.check_algorithm_can_support_constraints(
             constrained_vertices=[self._governed_app_vertex],
-            supported_constraints=[
-                MaxVertexAtomsConstraint, FixedVertexAtomsConstraint],
+            supported_constraints=[MaxVertexAtomsConstraint],
             abstract_constraint_type=AbstractPartitionerConstraint)
 
     @overrides(AbstractSplitterSlice.reset_called)

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_delay_vertex_slice.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_delay_vertex_slice.py
@@ -18,8 +18,7 @@ from pacman.exceptions import (
     PacmanConfigurationException, PacmanInvalidParameterException)
 from pacman.executor.injection_decorator import inject_items
 from pacman.model.constraints.partitioner_constraints import (
-    MaxVertexAtomsConstraint, FixedVertexAtomsConstraint,
-    AbstractPartitionerConstraint)
+    MaxVertexAtomsConstraint, AbstractPartitionerConstraint)
 from pacman.model.graphs.machine import MachineEdge
 from pacman.model.partitioner_splitters.abstract_splitters import (
     AbstractDependentSplitter)
@@ -268,8 +267,7 @@ class SplitterDelayVertexSlice(AbstractDependentSplitter):
     def check_supported_constraints(self):
         utility_calls.check_algorithm_can_support_constraints(
             constrained_vertices=[self._governed_app_vertex],
-            supported_constraints=[
-                MaxVertexAtomsConstraint, FixedVertexAtomsConstraint],
+            supported_constraints=[MaxVertexAtomsConstraint],
             abstract_constraint_type=AbstractPartitionerConstraint)
 
     @overrides(AbstractDependentSplitter.machine_vertices_for_recording)

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_delay_vertex_slice.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_delay_vertex_slice.py
@@ -18,7 +18,7 @@ from pacman.exceptions import (
     PacmanConfigurationException, PacmanInvalidParameterException)
 from pacman.executor.injection_decorator import inject_items
 from pacman.model.constraints.partitioner_constraints import (
-    MaxVertexAtomsConstraint, AbstractPartitionerConstraint)
+    AbstractPartitionerConstraint)
 from pacman.model.graphs.machine import MachineEdge
 from pacman.model.partitioner_splitters.abstract_splitters import (
     AbstractDependentSplitter)
@@ -267,7 +267,7 @@ class SplitterDelayVertexSlice(AbstractDependentSplitter):
     def check_supported_constraints(self):
         utility_calls.check_algorithm_can_support_constraints(
             constrained_vertices=[self._governed_app_vertex],
-            supported_constraints=[MaxVertexAtomsConstraint],
+            supported_constraints=[],
             abstract_constraint_type=AbstractPartitionerConstraint)
 
     @overrides(AbstractDependentSplitter.machine_vertices_for_recording)

--- a/spynnaker/pyNN/models/populations/population.py
+++ b/spynnaker/pyNN/models/populations/population.py
@@ -24,8 +24,6 @@ from spinn_utilities.logger_utils import warn_once
 from spinn_utilities.overrides import overrides
 from pacman.model.constraints import AbstractConstraint
 from pacman.model.constraints.placer_constraints import ChipAndCoreConstraint
-from pacman.model.constraints.partitioner_constraints import (
-    MaxVertexAtomsConstraint)
 from pacman.model.graphs.application import ApplicationVertex
 from spinn_front_end_common.utilities.globals_variables import (
     get_simulator, get_not_running_simulator)
@@ -1003,8 +1001,7 @@ class Population(PopulationBase):
             the new value for the max atoms per core.
         """
         get_simulator().verify_not_running()
-        self.__vertex.add_constraint(
-            MaxVertexAtomsConstraint(max_atoms_per_core))
+        self.__vertex.set_max_atoms_per_core(max_atoms_per_core)
         # state that something has changed in the population
         self.__change_requires_mapping = True
 

--- a/spynnaker/pyNN/models/populations/population.py
+++ b/spynnaker/pyNN/models/populations/population.py
@@ -29,7 +29,8 @@ from spinn_front_end_common.utilities.globals_variables import (
     get_simulator, get_not_running_simulator)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinn_front_end_common.abstract_models import AbstractChangableAfterRun
-from spynnaker.pyNN.exceptions import InvalidParameterType
+from spynnaker.pyNN.exceptions import (
+    InvalidParameterType, SpynnakerException)
 from spynnaker.pyNN.models.abstract_models import (
     AbstractContainsUnits, AbstractReadParametersBeforeSet,
     AbstractPopulationInitializable, AbstractPopulationSettable)
@@ -1009,6 +1010,11 @@ class Population(PopulationBase):
             the new value for the max atoms per core.
         """
         get_simulator().verify_not_running()
+        cap = self.celltype.get_max_atoms_per_core()
+        if max_atoms_per_core > cap:
+            raise SpynnakerException(
+                f"Set the max_atoms_per_core to {max_atoms_per_core} blocked "
+                f"as the current limit for the model is {cap}")
         self.__vertex.set_max_atoms_per_core(max_atoms_per_core)
         # state that something has changed in the population
         self.__change_requires_mapping = True

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -514,7 +514,7 @@ class SpiNNaker(AbstractSpinnakerBase, pynn_control.BaseState):
             if previous < max_permitted:
                 raise SpynnakerException(
                     f"Attempt to increase number_of_neurons_per_core "
-                    f"from {previous} to {previous} not supported")
+                    f"from {previous} to {max_permitted} not supported")
         neuron_type.set_model_max_atoms_per_core(max_permitted)
         self.__neurons_per_core_set.add(neuron_type)
         if self._populations:

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -40,6 +40,7 @@ from spinn_front_end_common.utilities.utility_objs import ExecutableFinder
 from spynnaker import _version
 from spynnaker.pyNN import model_binaries
 from spynnaker.pyNN.config_setup import CONFIG_FILE_NAME, setup_configs
+from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.extra_algorithms import (
     delay_support_adder, on_chip_bitfield_generator,
     redundant_packet_count_report,
@@ -513,12 +514,14 @@ class SpiNNaker(AbstractSpinnakerBase, pynn_control.BaseState):
         if hasattr(neuron_type, "get_max_atoms_per_core"):
             previous = neuron_type.get_max_atoms_per_core()
             if previous < max_permitted:
-                logger.warning(
-                    "Attempt to increase number_of_neurons_per_core "
-                    "from {} to {} ignored", previous, max_permitted)
-                return
+                raise SpynnakerException(
+                    f"Attempt to increase number_of_neurons_per_core "
+                    "from {previous} to {previous} not supported")
         neuron_type.set_model_max_atoms_per_core(max_permitted)
         self.__neurons_per_core_set.add(neuron_type)
+        if self._populations:
+            logger.warning("Calling set_number_of_neurons_per_core will not "
+                           "affect previously created Populations")
 
     def reset_number_of_neurons_per_core(self):
         for neuron_type in self.__neurons_per_core_set:

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -514,7 +514,7 @@ class SpiNNaker(AbstractSpinnakerBase, pynn_control.BaseState):
             if previous < max_permitted:
                 raise SpynnakerException(
                     f"Attempt to increase number_of_neurons_per_core "
-                    "from {previous} to {previous} not supported")
+                    f"from {previous} to {previous} not supported")
         neuron_type.set_model_max_atoms_per_core(max_permitted)
         self.__neurons_per_core_set.add(neuron_type)
         if self._populations:

--- a/unittests/test_using_virtual_board/test_max_cores.py
+++ b/unittests/test_using_virtual_board/test_max_cores.py
@@ -19,14 +19,14 @@ from spinnaker_testbase import BaseTestCase
 
 
 def before_run(nNeurons):
-    p.setup(timestep=1, min_delay=1)
+    sim.setup(timestep=1, min_delay=1)
 
     neuron_parameters = {'cm': 0.25, 'i_offset': 2, 'tau_m': 10.0,
                          'tau_refrac': 2.0, 'tau_syn_E': 0.5, 'tau_syn_I': 0.5,
                          'v_reset': -65.0, 'v_rest': -65.0, 'v_thresh': -50.0}
 
-    pop = p.Population(nNeurons, p.IF_curr_exp, neuron_parameters,
-                       label='pop_1')
+    pop = sim.Population(nNeurons, sim.IF_curr_exp, neuron_parameters,
+                         label='pop_1')
 
     return pop.celltype
 

--- a/unittests/test_using_virtual_board/test_max_cores.py
+++ b/unittests/test_using_virtual_board/test_max_cores.py
@@ -67,3 +67,23 @@ class Test_Max_Cores(BaseTestCase):
         with self.assertRaises(SpynnakerException):
             pop1.set_max_atoms_per_core(100)
         sim.end()
+
+    def test_raise_sim_cap(self):
+        sim.setup(timestep=1, min_delay=1)
+        with self.assertRaises(SpynnakerException):
+            sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 500)
+        pop1 = sim.Population(500, sim.IF_curr_exp)
+        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
+        vertex1 = pop1._Population__vertex
+        self.assertEqual(256, vertex1.get_max_atoms_per_core())
+        with self.assertRaises(SpynnakerException):
+            # This does not work because we have not programmed it
+            pop1.set_max_atoms_per_core(200)
+        pop1.set_max_atoms_per_core(50)
+        self.assertEqual(50, vertex1.get_max_atoms_per_core())
+        pop1.set_max_atoms_per_core(100)
+        self.assertEqual(100, vertex1.get_max_atoms_per_core())
+        with self.assertRaises(SpynnakerException):
+            # This does not work because we have not programmed it
+            sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 200)
+        sim.end()

--- a/unittests/test_using_virtual_board/test_max_cores.py
+++ b/unittests/test_using_virtual_board/test_max_cores.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pyNN.spiNNaker as sim
+from spynnaker.pyNN.exceptions import SpynnakerException
+from spinnaker_testbase import BaseTestCase
+
+
+def before_run(nNeurons):
+    p.setup(timestep=1, min_delay=1)
+
+    neuron_parameters = {'cm': 0.25, 'i_offset': 2, 'tau_m': 10.0,
+                         'tau_refrac': 2.0, 'tau_syn_E': 0.5, 'tau_syn_I': 0.5,
+                         'v_reset': -65.0, 'v_rest': -65.0, 'v_thresh': -50.0}
+
+    pop = p.Population(nNeurons, p.IF_curr_exp, neuron_parameters,
+                       label='pop_1')
+
+    return pop.celltype
+
+
+class Test_Max_Cores(BaseTestCase):
+
+    # NO unittest_setup() as sim.setup is called
+
+    def test_uncapped(self):
+        sim.setup(timestep=1, min_delay=1)
+        pop = sim.Population(500, sim.IF_curr_exp)
+        vertex = pop._Population__vertex
+        # 256 if the default
+        self.assertEqual(256, vertex.get_max_atoms_per_core())
+        # go over the model cap
+        with self.assertRaises(SpynnakerException):
+            pop.set_max_atoms_per_core(500)
+        # vertex unchanged
+        self.assertEqual(256, vertex.get_max_atoms_per_core())
+        pop.set_max_atoms_per_core(100)
+        # vertex changed
+        self.assertEqual(100, vertex.get_max_atoms_per_core())
+        pop.set_max_atoms_per_core(200)
+        # vertex changed up
+        self.assertEqual(200, vertex.get_max_atoms_per_core())
+        sim.end()
+
+    def test_model_cap(self):
+        sim.setup(timestep=1, min_delay=1)
+        pop1 = sim.Population(500, sim.IF_curr_exp)
+        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 50)
+        pop2 = sim.Population(500, sim.IF_curr_exp)
+        vertex1 = pop1._Population__vertex
+        self.assertEqual(256, vertex1.get_max_atoms_per_core())
+        vertex2 = pop2._Population__vertex
+        self.assertEqual(50, vertex2.get_max_atoms_per_core())
+        # go over the current model cap
+        with self.assertRaises(SpynnakerException):
+            pop1.set_max_atoms_per_core(100)
+        sim.end()


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/PACMAN/pull/433

Fixes:
https://github.com/SpiNNakerManchester/sPyNNaker/issues/1182
by warning that it will not affect already created Populations

We currently dont support the raising of 
sim.set_number_of_neurons_per_core
Mainly because I was too lazy to work out how to get and check the model hard cap
And there was no known need for it.

beyond the model cap give a clear error that is not allowed
higher than a previously lower value give an error that we dont allow that at the moment

pop.set_max_atoms_per_core
can now also raise a previously lowered value but only up to the cap for that model.
That is both the model hard cap and the sim.set_number_of_neurons_per_core soft cap.
