### PR TITLE
replace set_delay with round delay on init

### DIFF
--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
@@ -247,12 +247,6 @@ class SynapseDynamicsNeuromodulation(AbstractPlasticSynapseDynamics):
         # Delay is always 1!
         return 1
 
-    @overrides(AbstractPlasticSynapseDynamics.set_delay)
-    def set_delay(self, delay):
-        if delay != 1:
-            raise SynapticConfigurationException(
-                "Neuromodulation delay must be 0")
-
     @property
     @overrides(AbstractPlasticSynapseDynamics.pad_to_length)
     def pad_to_length(self):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -57,7 +57,7 @@ class SynapseDynamicsStatic(
         self.__weight = weight
         if delay is None:
             delay = get_simulator().min_delay
-        self.__delay = delay
+        self.__delay = self._round_delay(delay)
         self.__pad_to_length = pad_to_length
 
     @overrides(AbstractStaticSynapseDynamics.merge)
@@ -241,10 +241,6 @@ class SynapseDynamicsStatic(
     @overrides(AbstractStaticSynapseDynamics.delay)
     def delay(self):
         return self.__delay
-
-    @overrides(AbstractStaticSynapseDynamics.set_delay)
-    def set_delay(self, delay):
-        self.__delay = delay
 
     @property
     @overrides(AbstractStaticSynapseDynamics.pad_to_length)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -106,7 +106,7 @@ class SynapseDynamicsSTDP(
         self.__weight = weight
         if delay is None:
             delay = get_simulator().min_delay
-        self.__delay = delay
+        self.__delay = self._round_delay(delay)
         self.__backprop_delay = backprop_delay
         self.__neuromodulation = None
 
@@ -599,10 +599,6 @@ class SynapseDynamicsSTDP(
     @overrides(AbstractPlasticSynapseDynamics.delay)
     def delay(self):
         return self.__delay
-
-    @overrides(AbstractPlasticSynapseDynamics.set_delay)
-    def set_delay(self, delay):
-        self.__delay = delay
 
     @property
     @overrides(AbstractPlasticSynapseDynamics.pad_to_length)

--- a/spynnaker/pyNN/models/projection.py
+++ b/spynnaker/pyNN/models/projection.py
@@ -18,12 +18,10 @@ import logging
 import numpy
 from spinn_utilities.log import FormatAdapter
 from pyNN import common as pynn_common
-from pyNN.random import RandomDistribution
 from pyNN.recording.files import StandardTextFile
 from pyNN.space import Space as PyNNSpace
 from spinn_utilities.logger_utils import warn_once
-from spinn_front_end_common.utilities.globals_variables import (
-    get_simulator, machine_time_step_ms, machine_time_step_per_ms)
+from spinn_front_end_common.utilities.globals_variables import get_simulator
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.models.abstract_models import (
@@ -141,15 +139,6 @@ class Projection(object):
         # if any) and add them to the synapse dynamics object
         if isinstance(connector, FromListConnector):
             connector._apply_parameters_to_synapse_type(synaptic_type)
-
-        # round the delays to multiples of full timesteps
-        # (otherwise SDRAM estimation calculations can go wrong)
-        if ((not isinstance(synapse_dynamics.delay, RandomDistribution))
-                and (not isinstance(synapse_dynamics.delay, str))):
-            synapse_dynamics.set_delay(
-                numpy.rint(numpy.array(synapse_dynamics.delay) *
-                           machine_time_step_per_ms()) *
-                machine_time_step_ms())
 
         # set the plasticity dynamics for the post pop (allows plastic stuff
         #  when needed)


### PR DESCRIPTION
Fixes https://github.com/SpiNNakerManchester/sPyNNaker/issues/1188

Instead of Projections rounding delays the SynapseDynamics does it.
This is at a minor cost that SynapseDynamics these must be created after sim.setup

The user available set_delays has been removed
It also removed the only thing that looked like it could change delays.

Which makes it possible to reuse Delay Vertex even after a hard reset.
see https://github.com/SpiNNakerManchester/sPyNNaker/issues/1180
