### PR TITLE
Fix version of matplotlib for python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,9 @@ SpiNNaker_PACMAN == 1!6.0.1
 SpiNNaker_DataSpecification == 1!6.0.1
 spalloc == 1!6.0.1
 SpiNNFrontEndCommon == 1!6.0.1
-matplotlib < 3.4; python_version == '3.6'
-matplotlib; python_version >= '3.7'
+matplotlib < 3.4; python_version <= '3.6'
+matplotlib < 3.6; python_version == '3.7'
+matplotlib; python_version >= '3.8'
 quantities >= 0.12.1
 pynn >= 0.9.1, < 0.10
 lazyarray >= 0.2.9, <= 0.4.0


### PR DESCRIPTION
Matplotlib version needs to be limited for python 3.7, see e.g. https://github.com/SpiNNakerManchester/PyNN8Examples/runs/7999013468?check_suite_focus=true