### PR TITLE
Warning if SpikeSourceArray sends more that 100 spikes at one time.

### DIFF
--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from collections import Counter
 import logging
 import numpy
 from spinn_utilities.log import FormatAdapter
@@ -28,6 +29,8 @@ from pyNN.space import Grid2D, Grid3D
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
+# Cutoff to warn too many spikes sent at one time
+TOO_MANY_SPIKES = 100
 
 def _as_numpy_ticks(times, time_step):
     return numpy.ceil(
@@ -71,8 +74,48 @@ class SpikeSourceArrayVertex(
             send_buffer_partition_id=constants.SPIKE_PARTITION_ID,
             splitter=splitter)
 
+        self._check_spike_density()
         # handle recording
         self.__spike_recorder = EIEIOSpikeRecorder()
+
+    def _check_spike_density(self):
+        if self._spike_times:
+            if hasattr(self._spike_times[0], '__iter__'):
+                self._check_density_double_list()
+            else:
+                self._check_density_single_list()
+        else:
+            logger.warning("SpikeSourceArray has no spike times")
+
+    def _check_density_single_list(self):
+        counter = Counter(self._spike_times)
+        top = counter.most_common(1)
+        val, count = top[0]
+        if count * self.n_atoms > TOO_MANY_SPIKES:
+            if self.n_atoms > 1:
+                logger.warning(
+                    "Danger of SpikeSourceArray sending too many spikes "
+                    "at the same time. "
+                    f"This is because ({self.n_atoms}) neurons "
+                    f"share the same spike list")
+            else:
+                logger.warning(
+                    "Danger of SpikeSourceArray sending too many spikes "
+                    "at the same time. "
+                    f"For example at time {val} {count * self.n_atoms} "
+                    f"spikes will be sent")
+
+    def _check_density_double_list(self):
+        counter = Counter()
+        for neuron_id in range(0, self.n_atoms):
+            counter.update(self._spike_times[neuron_id])
+        top = counter.most_common(1)
+        val, count = top[0]
+        if count > TOO_MANY_SPIKES:
+            logger.warning(
+                "Danger of SpikeSourceArray sending too many spikes "
+                "at the same time. "
+                f"For example at time {val} {count} spikes will be sent")
 
     @overrides(SupportsStructure.set_structure)
     def set_structure(self, structure):
@@ -144,6 +187,7 @@ class SpikeSourceArrayVertex(
                 self._to_early_spikes_single_list(spike_times)
         self.send_buffer_times = _send_buffer_times(spike_times, time_step)
         self._spike_times = spike_times
+        self._check_spike_density()
 
     @overrides(AbstractSpikeRecordable.is_recording_spikes)
     def is_recording_spikes(self):

--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -32,6 +32,7 @@ logger = FormatAdapter(logging.getLogger(__name__))
 # Cutoff to warn too many spikes sent at one time
 TOO_MANY_SPIKES = 100
 
+
 def _as_numpy_ticks(times, time_step):
     return numpy.ceil(
         numpy.floor(numpy.array(times) * 1000.0) / time_step).astype("int64")

--- a/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
+++ b/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
@@ -45,12 +45,6 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             label="test", max_atoms_per_core=None, model=None, splitter=None)
         v.spike_times = [2, 12, 32]
 
-    def test_singleton_list(self):
-        v = SpikeSourceArrayVertex(
-            n_neurons=5, spike_times=[1, 11, 22], constraints=None,
-            label="test", max_atoms_per_core=None, model=None, splitter=None)
-        v.spike_times = [2, 12, 32]
-
     def test_double_list(self):
         SpikeSourceArrayVertex(
             n_neurons=3, spike_times=[[1], [11], [22]], constraints=None,
@@ -66,17 +60,17 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
         spike_list3.extend([21, 23, 45])
         spike_list = [spike_list1, spike_list2, spike_list3]
         with LogCapture() as lc:
-             SpikeSourceArrayVertex(
+            SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=spike_list, constraints=None,
                 label="test", max_atoms_per_core=None, model=None,
                 splitter=None)
-             found = False
-             for record in lc.records:
+            found = False
+            for record in lc.records:
                 if "too many spikes" in record.msg.fmt:
                     self.assertIn("110", record.msg.fmt)
                     self.assertIn("15", record.msg.fmt)
                     found = True
-             self.assertTrue(found)
+            self.assertTrue(found)
 
     def test_shared_list_big(self):
         with LogCapture() as lc:

--- a/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
+++ b/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
@@ -61,7 +61,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
         spike_list = [spike_list1, spike_list2, spike_list3]
         with LogCapture() as lc:
             SpikeSourceArrayVertex(
-                n_neurons=3, spike_times=spike_list, constraints=None,
+                n_neurons=3, spike_times=spike_list,
                 label="test", max_atoms_per_core=None, model=None,
                 splitter=None)
             found = False
@@ -75,7 +75,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
     def test_shared_list_big(self):
         with LogCapture() as lc:
             v = SpikeSourceArrayVertex(
-                n_neurons=3, spike_times=None, constraints=None,
+                n_neurons=3, spike_times=None,
                 label="test", max_atoms_per_core=None, model=None,
                 splitter=None)
             v.spike_times = [34] * 35
@@ -89,7 +89,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
     def test_list_big(self):
         with LogCapture() as lc:
             SpikeSourceArrayVertex(
-                n_neurons=1, spike_times=[37] * 109, constraints=None,
+                n_neurons=1, spike_times=[37] * 109,
                 label="test", max_atoms_per_core=None, model=None,
                 splitter=None)
             found = False


### PR DESCRIPTION
With a SSA we know in advance how many spikes are send.

Se we can warn the users.

Most common cause is likely to be
1. A mutli neuron SSA with a single list and then a OneToOne
     Where a single Neuron SSA and an AllToAll have the same affect
2. Random generated lists.

This simplified version does not consider how the spike source could be partitioned as that only reduces spikes received by the target if filtering is done.

This version does not consider timescale factor to determine the warning cutoff.