### PR TITLE
need len for some versions of numpy

### DIFF
--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -80,7 +80,7 @@ class SpikeSourceArrayVertex(
         self.__spike_recorder = EIEIOSpikeRecorder()
 
     def _check_spike_density(self):
-        if self._spike_times:
+        if len(self._spike_times):
             if hasattr(self._spike_times[0], '__iter__'):
                 self._check_density_double_list()
             else:


### PR DESCRIPTION
 ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

note:
init converts None spike_times to an empty list
@spike_times.setter did and still does not