### PR TITLE
Iterate projections

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_fixed.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_fixed.py
@@ -344,13 +344,14 @@ class SplitterAbstractPopulationVertexFixed(
         """
         if self.__bitfield_sz is None:
             sdram = MultiRegionSDRAM()
-            projections = self._governed_app_vertex.incoming_projections
             sdram.add_cost(
                 PopulationMachineVertex.SYNAPSE_REGIONS.bitfield_filter,
-                get_estimated_sdram_for_bit_field_region(projections))
+                get_estimated_sdram_for_bit_field_region(
+                    self._governed_app_vertex.incoming_projections))
             sdram.add_cost(
                 PopulationMachineVertex.SYNAPSE_REGIONS.bitfield_key_map,
-                get_estimated_sdram_for_key_region(projections))
+                get_estimated_sdram_for_key_region(
+                    self._governed_app_vertex.incoming_projections))
             sdram.add_cost(
                 PopulationMachineVertex.SYNAPSE_REGIONS.bitfield_builder,
                 exact_sdram_for_bit_field_builder_region())

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
@@ -683,8 +683,7 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
             self, n_atoms, all_syn_block_sz, structural_sz):
         app_vertex = self._governed_app_vertex
         independent_synapse_sdram = self.__independent_synapse_sdram()
-        proj_dependent_sdram = self.__proj_dependent_synapse_sdram(
-            app_vertex.incoming_projections)
+        proj_dependent_sdram = self.__proj_dependent_synapse_sdram()
         dynamics_sz = self._governed_app_vertex.get_synapse_dynamics_size(
             n_atoms)
         dynamics_sz = max(dynamics_sz, BYTES_PER_WORD)
@@ -742,7 +741,7 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
             max(exact_sdram_for_bit_field_builder_region(), BYTES_PER_WORD))
         return sdram
 
-    def __proj_dependent_synapse_sdram(self, incoming_projections):
+    def __proj_dependent_synapse_sdram(self):
         """ Get the SDRAM used by synapse cores dependent on the projections
 
         :param list(~spynnaker.pyNN.models.Projection) incoming_projections:
@@ -754,7 +753,7 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
         sdram.add_cost(
             PopulationSynapsesMachineVertexLead.SYNAPSE_REGIONS.pop_table,
             max(MasterPopTableAsBinarySearch.get_master_population_table_size(
-                    incoming_projections), BYTES_PER_WORD))
+                    app_vertex.incoming_projections), BYTES_PER_WORD))
         sdram.add_cost(
             PopulationSynapsesMachineVertexLead.SYNAPSE_REGIONS
             .connection_builder,
@@ -763,12 +762,14 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
         sdram.add_cost(
             PopulationSynapsesMachineVertexLead.SYNAPSE_REGIONS
             .bitfield_filter,
-            max(get_estimated_sdram_for_bit_field_region(incoming_projections),
+            max(get_estimated_sdram_for_bit_field_region(
+                app_vertex.incoming_projections),
                 BYTES_PER_WORD))
         sdram.add_cost(
             PopulationSynapsesMachineVertexLead.SYNAPSE_REGIONS
             .bitfield_key_map,
-            max(get_estimated_sdram_for_key_region(incoming_projections),
+            max(get_estimated_sdram_for_key_region(
+                app_vertex.incoming_projections),
                 BYTES_PER_WORD))
         return sdram
 

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
@@ -681,7 +681,6 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
 
     def __get_shared_synapse_sdram(
             self, n_atoms, all_syn_block_sz, structural_sz):
-        app_vertex = self._governed_app_vertex
         independent_synapse_sdram = self.__independent_synapse_sdram()
         proj_dependent_sdram = self.__proj_dependent_synapse_sdram()
         dynamics_sz = self._governed_app_vertex.get_synapse_dynamics_size(

--- a/spynnaker/pyNN/models/neuron/population_machine_synapses.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_synapses.py
@@ -159,15 +159,14 @@ class PopulationMachineSynapses(
         :param int all_syn_block_sz: The maximum size of the synapses in bytes
         :param int structural_sz: The size of the structural data
         """
-        # Get incoming projections
-        incoming = self._app_vertex.incoming_projections
 
         # Write the synapse parameters
         self._write_synapse_parameters(spec, ring_buffer_shifts)
 
         # Write the synaptic matrices
         self._synaptic_matrices.write_synaptic_data(
-            spec, incoming, all_syn_block_sz, weight_scales)
+            spec, self._app_vertex.incoming_projections, all_syn_block_sz,
+            weight_scales)
 
         # Write any synapse dynamics
         synapse_dynamics = self._app_vertex.synapse_dynamics
@@ -206,14 +205,15 @@ class PopulationMachineSynapses(
         # write up the bitfield builder data
         # reserve bit field region
         bit_field_utilities.reserve_bit_field_regions(
-            spec, incoming, self._synapse_regions.bitfield_builder,
+            spec, self._app_vertex.incoming_projections,
+            self._synapse_regions.bitfield_builder,
             self._synapse_regions.bitfield_filter,
             self._synapse_regions.bitfield_key_map,
             self._synapse_references.bitfield_builder,
             self._synapse_references.bitfield_filter,
             self._synapse_references.bitfield_key_map)
         bit_field_utilities.write_bitfield_init_data(
-            spec, incoming,
+            spec, self._app_vertex.incoming_projections,
             self._synapse_regions.bitfield_builder,
             self._synapse_regions.pop_table,
             self._synapse_regions.synaptic_matrix,

--- a/spynnaker/pyNN/models/neuron/population_machine_synapses.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_synapses.py
@@ -205,7 +205,7 @@ class PopulationMachineSynapses(
         # write up the bitfield builder data
         # reserve bit field region
         bit_field_utilities.reserve_bit_field_regions(
-            spec, self._app_vertex.incoming_projections,
+            spec, self._app_vertex,
             self._synapse_regions.bitfield_builder,
             self._synapse_regions.bitfield_filter,
             self._synapse_regions.bitfield_key_map,

--- a/spynnaker/pyNN/utilities/bit_field_utilities.py
+++ b/spynnaker/pyNN/utilities/bit_field_utilities.py
@@ -107,7 +107,7 @@ def exact_sdram_for_bit_field_builder_region():
 
 
 def reserve_bit_field_regions(
-        spec, incoming_projections, bit_field_builder_region,
+        spec, app_vertex, bit_field_builder_region,
         bit_filter_region, bit_field_key_region,
         bit_field_builder_region_ref=None, bit_filter_region_ref=None,
         bit_field_key_region_ref=None):
@@ -134,7 +134,8 @@ def reserve_bit_field_regions(
     # reserve the final destination for the bitfields
     spec.reserve_memory_region(
         region=bit_filter_region,
-        size=get_estimated_sdram_for_bit_field_region(incoming_projections),
+        size=get_estimated_sdram_for_bit_field_region(
+            app_vertex.incoming_projections),
         label="bit_field region",
         reference=bit_filter_region_ref)
 
@@ -148,7 +149,8 @@ def reserve_bit_field_regions(
     # reserve memory region for the key region
     spec.reserve_memory_region(
         region=bit_field_key_region,
-        size=get_estimated_sdram_for_key_region(incoming_projections),
+        size=get_estimated_sdram_for_key_region(
+            app_vertex.incoming_projections),
         label="bit field key data",
         reference=bit_field_key_region_ref)
 


### PR DESCRIPTION
This avoids reusing incoming_projections to make sure that iterations over projections actually happen in all cases.

Tested by SpiNNakerManchester/IntegrationTests#148