### PR TITLE
Count machine entries as well as application entries

### DIFF
--- a/spynnaker/pyNN/models/neuron/master_pop_table.py
+++ b/spynnaker/pyNN/models/neuron/master_pop_table.py
@@ -369,6 +369,7 @@ class MasterPopTableAsBinarySearch(object):
                     n_cores *= _DELAY_SCALE
 
                 n_vertices += n_cores
+                n_entries += n_vertices
 
         return (
             _BASE_SIZE_BYTES +


### PR DESCRIPTION
In certain scenarios with large enough source populations and multiple projections between this source and a single target, the master pop table size is being underestimated (this was found when investigating particular parts of the cerebellum network).  This PR is a temporary sticking plaster and whether this calculation is correct or not should be considered again when e.g. https://github.com/SpiNNakerManchester/sPyNNaker/pull/1196 is reviewed or merged.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/156