### PR TITLE
Fix SDRAM calculation on neurons-synapses splitter, add test

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
@@ -243,9 +243,9 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
 
             # Create the neuron vertex for the slice
             neuron_vertex = self.__add_neuron_core(
-                vertex_slice, total_sdram, label, index, rb_shifts,
+                vertex_slice, neuron_sdram, label, index, rb_shifts,
                 weight_scales)
-            chip_counter.add_core(total_sdram)
+            chip_counter.add_core(neuron_sdram)
 
             # Keep track of synapse vertices for each neuron vertex and
             # resources used by each core (neuron core is added later)

--- a/spynnaker_integration_tests/test_split_various/test_split_sdram.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_sdram.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import pyNN.spiNNaker as sim
+from spynnaker.pyNN.extra_algorithms.splitter_components import (
+    SplitterAbstractPopulationVertexNeuronsSynapses)
+from spinnaker_testbase import BaseTestCase
+
+
+def run_sdram_split():
+    sim.setup(1.0)
+
+    spikeArray = {'spike_times': []}
+    pre_pop = sim.Population(
+        21000, sim.SpikeSourceArray(**spikeArray), label="pre")
+    post_pop = sim.Population(
+        600, sim.IF_cond_exp, label="post",
+        additional_parameters={
+            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(
+                1, 64, False)})
+
+    pre_pop.set_max_atoms_per_core(20000)
+    post_pop.set_max_atoms_per_core(64)
+
+    sim.Projection(pre_pop, post_pop, sim.AllToAllConnector(), label="proj")
+
+    sim.run(1000)
+
+    sim.end()
+
+
+class TestSplitSDRAM(BaseTestCase):
+
+    def test_run_simple_split(self):
+        self.runsafe(run_sdram_split)
+
+
+if __name__ == "__main__":
+    run_sdram_split()


### PR DESCRIPTION
SDRAM bug found when trying to use splitters with the cerebellum network as it currently stands.

The test included here is a simplified version of the problem found which (on current master) results in the exception:
`
Exception: Too much SDRAM has been allocated on chip 0, 0:  129711198 of 123469792`

(Note: the cerebellum network currently uses FromList connectors; I've used an AllToAll here to simplify the script so it runs faster than having to load in a cerebellum-like FromList).

Tested by https://github.com/SpiNNakerManchester/sPyNNaker/pull/1241