### PR TITLE
Many redundant packet count

### DIFF
--- a/spynnaker/pyNN/extra_algorithms/redundant_packet_count_report.py
+++ b/spynnaker/pyNN/extra_algorithms/redundant_packet_count_report.py
@@ -66,7 +66,6 @@ REDUNDANCY_SUMMARY = (
     "FROM redundancy_by_core")
 
 
-_FILE_NAME = "redundant_packet_count.rpt"
 _N_PROV_ITEMS_NEEDED = 4
 _MAX = 100
 
@@ -76,7 +75,9 @@ def redundant_packet_count_report():
 
     :return:
     """
-    file_name = os.path.join(SpynnakerDataView.get_run_dir_path(), _FILE_NAME)
+    file_name = os.path.join(
+        SpynnakerDataView.get_run_dir_path(),
+        f"redundant_packet_count{SpynnakerDataView.get_reset_str()}.rpt")
 
     try:
         _create_views()

--- a/spynnaker/pyNN/extra_algorithms/redundant_packet_count_report.py
+++ b/spynnaker/pyNN/extra_algorithms/redundant_packet_count_report.py
@@ -95,23 +95,23 @@ def _create_views():
 
 
 def _write_report(output):
-    reader = ProvenanceReader()
-    for data in reader.run_query("select * from redundancy_by_core"):
-        (_, _, _, source, _, filtered, invalid, _,
-         redundant, total, percent) = data
-        output.write(f"\ncore {source} \n")
-        output.write(f"    {total} packets received. \n")
-        output.write(f"    {redundant} were detected as "
-                     "redundant packets by the bitfield filter. \n")
-        output.write(
-            f"    {filtered} were detected as having no targets "
-            f"after the DMA stage. \n")
-        output.write(
-            f"    {invalid} were detected as packets which "
-            f"we should not have received in the first place. \n")
-        output.write(f"    Overall this makes a redundant percentage of "
-                     f"{percent}\n")
-    data = reader.run_query("select * from redundancy_summary")
+    with ProvenanceReader() as db:
+        for data in db.run_query("select * from redundancy_by_core"):
+            (_, _, _, source, _, filtered, invalid, _,
+             redundant, total, percent) = data
+            output.write(f"\ncore {source} \n")
+            output.write(f"    {total} packets received. \n")
+            output.write(f"    {redundant} were detected as "
+                         "redundant packets by the bitfield filter. \n")
+            output.write(
+                f"    {filtered} were detected as having no targets "
+                f"after the DMA stage. \n")
+            output.write(
+                f"    {invalid} were detected as packets which "
+                f"we should not have received in the first place. \n")
+            output.write(f"    Overall this makes a redundant percentage of "
+                         f"{percent}\n")
+        data = db.run_query("select * from redundancy_summary")
     (sum_total, max_total, min_total, avg_total,
         sum_reduant, max_redundant, min_redundant, avg_redundant,
         max_percent, min_percent, avg_percent, global_percent) = data[0]

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -29,7 +29,7 @@ from spinn_utilities.overrides import overrides
 from spinn_front_end_common.interface.abstract_spinnaker_base import (
     AbstractSpinnakerBase)
 from spinn_front_end_common.interface.provenance import (
-    FecTimer, ProvenanceWriter, TimerCategory, TimerWork)
+    FecTimer, GlobalProvenance, TimerCategory, TimerWork)
 from spinn_front_end_common.utilities.constants import (
     MICRO_TO_MILLISECOND_CONVERSION)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
@@ -118,7 +118,7 @@ class SpiNNaker(AbstractSpinnakerBase, pynn_control.BaseState):
         # set up machine targeted data
         self._set_up_timings(timestep, min_delay, time_scale_factor)
 
-        with ProvenanceWriter() as db:
+        with GlobalProvenance() as db:
             db.insert_version("sPyNNaker_version", _version.__version__)
             db.insert_version("pyNN_version", pynn_version)
             db.insert_version("quantities_version", quantities_version)

--- a/spynnaker_integration_tests/test_debug_mode/check_debug.py
+++ b/spynnaker_integration_tests/test_debug_mode/check_debug.py
@@ -106,6 +106,7 @@ class CheckDebug(BaseTestCase):
         for report in reports:
             self.assertIn(report, found)
         self.assertIn("data.sqlite3", found)
+        self.assertIn("redundant_packet_count.rpt", found)
 
         sim.run(10)
         pop.get_data("v")
@@ -118,6 +119,7 @@ class CheckDebug(BaseTestCase):
         pop.get_data("v")
         found = os.listdir(SpynnakerDataView.get_run_dir_path())
         self.assertIn("data1.sqlite3", found)
+        self.assertIn("redundant_packet_count1.rpt", found)
         # No point in checking files they are already there
 
         sim.reset()
@@ -128,5 +130,6 @@ class CheckDebug(BaseTestCase):
         for report in reports:
             self.assertIn(report, found)
         self.assertIn("data2.sqlite3", found)
+        self.assertIn("redundant_packet_count2.rpt", found)
 
         sim.end()

--- a/spynnaker_integration_tests/test_debug_mode/check_debug.py
+++ b/spynnaker_integration_tests/test_debug_mode/check_debug.py
@@ -105,6 +105,7 @@ class CheckDebug(BaseTestCase):
         found = os.listdir(SpynnakerDataView.get_run_dir_path())
         for report in reports:
             self.assertIn(report, found)
+        self.assertIn("data.sqlite3", found)
 
         sim.run(10)
         pop.get_data("v")
@@ -115,6 +116,8 @@ class CheckDebug(BaseTestCase):
         SpynnakerDataView.set_requires_data_generation()
         sim.run(10)
         pop.get_data("v")
+        found = os.listdir(SpynnakerDataView.get_run_dir_path())
+        self.assertIn("data1.sqlite3", found)
         # No point in checking files they are already there
 
         sim.reset()
@@ -124,5 +127,6 @@ class CheckDebug(BaseTestCase):
         found = os.listdir(SpynnakerDataView.get_run_dir_path())
         for report in reports:
             self.assertIn(report, found)
+        self.assertIn("data2.sqlite3", found)
 
         sim.end()

--- a/spynnaker_integration_tests/test_many_boards/many_boards.py
+++ b/spynnaker_integration_tests/test_many_boards/many_boards.py
@@ -87,7 +87,8 @@ class ManyBoards(BaseTestCase):
         for pop in self._pops:
             check_data(pop, self._expected_spikes, self.simtime)
         t_after_check = time.time()
-        results = ProvenanceReader().get_run_time_of_BufferExtractor()
+        with ProvenanceReader() as db:
+            results = db.get_run_time_of_BufferExtractor()
         self.report(results, report_file)
         self.report(
             "machine run time was: {} seconds\n".format(

--- a/spynnaker_integration_tests/test_many_boards/many_boards.py
+++ b/spynnaker_integration_tests/test_many_boards/many_boards.py
@@ -15,7 +15,7 @@
 import time
 from unittest import SkipTest
 from spinn_utilities.config_holder import get_config_bool
-from spinn_front_end_common.interface.provenance import ProvenanceReader
+from spinn_front_end_common.interface.provenance import GlobalProvenance
 from spynnaker.pyNN.exceptions import ConfigurationException
 import pyNN.spiNNaker as sim
 from spynnaker_integration_tests.scripts import check_data
@@ -87,7 +87,7 @@ class ManyBoards(BaseTestCase):
         for pop in self._pops:
             check_data(pop, self._expected_spikes, self.simtime)
         t_after_check = time.time()
-        with ProvenanceReader() as db:
+        with GlobalProvenance() as db:
             results = db.get_run_time_of_BufferExtractor()
         self.report(results, report_file)
         self.report(

--- a/spynnaker_integration_tests/test_onchip_compressor/many_routes.py
+++ b/spynnaker_integration_tests/test_onchip_compressor/many_routes.py
@@ -76,6 +76,7 @@ def do_run():
                     receptor_type="inhibitory")
 
     sim.run(1)
-    t = ProvenanceReader().get_timer_provenance("Routing table loader")
+    with ProvenanceReader() as db:
+        t = db.get_timer_provenance("Routing table loader")
     assert t == "", "Routing table loader should not have run"
     sim.end()

--- a/spynnaker_integration_tests/test_onchip_compressor/many_routes.py
+++ b/spynnaker_integration_tests/test_onchip_compressor/many_routes.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import math
 from unittest import SkipTest
-from spinn_front_end_common.interface.provenance import ProvenanceReader
+from spinn_front_end_common.interface.provenance import GlobalProvenance
 from spynnaker.pyNN.exceptions import ConfigurationException
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
@@ -76,7 +76,7 @@ def do_run():
                     receptor_type="inhibitory")
 
     sim.run(1)
-    with ProvenanceReader() as db:
+    with GlobalProvenance() as db:
         t = db.get_timer_provenance("Routing table loader")
     assert t == "", "Routing table loader should not have run"
     sim.end()

--- a/spynnaker_integration_tests/test_onchip_compressor/one_route.py
+++ b/spynnaker_integration_tests/test_onchip_compressor/one_route.py
@@ -80,6 +80,7 @@ def do_one_run():
                     receptor_type="inhibitory")
 
     sim.run(1)
-    t = ProvenanceReader().get_timer_provenance("Routing table loader")
+    with ProvenanceReader() as db:
+        t = db.get_timer_provenance("Routing table loader")
     assert t == "", "Routing table loader should not have run"
     sim.end()

--- a/spynnaker_integration_tests/test_onchip_compressor/one_route.py
+++ b/spynnaker_integration_tests/test_onchip_compressor/one_route.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import math
 from unittest import SkipTest
-from spinn_front_end_common.interface.provenance import ProvenanceReader
+from spinn_front_end_common.interface.provenance import GlobalProvenance
 from spynnaker.pyNN.exceptions import ConfigurationException
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
@@ -80,7 +80,7 @@ def do_one_run():
                     receptor_type="inhibitory")
 
     sim.run(1)
-    with ProvenanceReader() as db:
+    with GlobalProvenance() as db:
         t = db.get_timer_provenance("Routing table loader")
     assert t == "", "Routing table loader should not have run"
     sim.end()

--- a/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
+++ b/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
@@ -64,7 +64,7 @@ class TestDebug(BaseTestCase):
             # write_network_specification_report
             network_specification_file_name,
             # write_provenance_data
-            "provenance_data",
+            "data.sqlite3",
             # write_tag_allocation_reports
             reports_names._TAGS_FILENAME,
             # write_algorithm_timings


### PR DESCRIPTION
Builds on https://github.com/SpiNNakerManchester/sPyNNaker/pull/1239 which is part of
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/999

Stops the overwriting of the redundant packet count after a reset.

Must be merged at the same time or after https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/999
 and related.

tested by:
