### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - name: Checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ SpiNNaker_PACMAN == 1!6.0.1
 SpiNNaker_DataSpecification == 1!6.0.1
 spalloc == 1!6.0.1
 SpiNNFrontEndCommon == 1!6.0.1
-matplotlib < 3.4; python_version <= '3.6'
 matplotlib < 3.5.99; python_version == '3.7'
 matplotlib; python_version >= '3.8'
 quantities >= 0.12.1

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ install_requires = [
     'SpiNNaker_DataSpecification == 1!6.0.1',
     'spalloc == 1!6.0.1',
     'SpiNNFrontEndCommon == 1!6.0.1',
-    "matplotlib < 3.4; python_version <= '3.6'",
     "matplotlib < 3.5.99; python_version == '3.7'",
     "matplotlib; python_version >= '3.8'",
     'pyparsing>=2.2.1,<3.0.0',


### PR DESCRIPTION
Drop python 3.6 as described in https://github.com/SpiNNakerManchester/SupportScripts/pull/43