### PR TITLE
test with python 3.11

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Adds python 3.11 to the tested versions.

once approved this should be added to the protection rules.

Also done in other repositories.