### PR TITLE
skip on missing fpga link

### DIFF
--- a/spynnaker_integration_tests/test_local_only/test_overlapping_network.py
+++ b/spynnaker_integration_tests/test_local_only/test_overlapping_network.py
@@ -142,4 +142,9 @@ def do_run():
 class TestOverlappingNetwork(BaseTestCase):
 
     def test_run(self):
-        self.runsafe(do_run)
+        try:
+            self.runsafe(do_run)
+        except KeyError as ke:
+            if "does not exist on board" in str(ke):
+                self.skipTest("https://github.com/SpiNNakerManchester/"
+                              "sPyNNaker/issues/1261")


### PR DESCRIPTION
Work around to stop https://github.com/SpiNNakerManchester/sPyNNaker/issues/1261 breaking tests

tested by http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/skip_missing_fpga/1/pipeline