### PR TITLE
Specify to use accum

### DIFF
--- a/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
+++ b/neural_modelling/src/neuron/implementations/neuron_impl_standard.h
@@ -274,8 +274,8 @@ static void neuron_impl_do_timestep_update(
                     inh_syn_values, input_types, NUM_INHIBITORY_RECEPTORS);
 
             // Sum g_syn contributions from all receptors for recording
-            REAL total_exc = 0;
-            REAL total_inh = 0;
+            REAL total_exc = ZERO;
+            REAL total_inh = ZERO;
 
             for (int i = 0; i < NUM_EXCITATORY_RECEPTORS; i++) {
                 total_exc += exc_input_values[i];

--- a/neural_modelling/src/neuron/models/neuron_model_izh_impl.h
+++ b/neural_modelling/src/neuron/models/neuron_model_izh_impl.h
@@ -168,8 +168,8 @@ static inline state_t neuron_model_state_update(
         uint16_t num_excitatory_inputs, const input_t *exc_input,
         uint16_t num_inhibitory_inputs, const input_t *inh_input,
         input_t external_bias, REAL current_offset, neuron_t *restrict neuron) {
-    REAL total_exc = 0;
-    REAL total_inh = 0;
+    REAL total_exc = ZERO;
+    REAL total_inh = ZERO;
 
     for (int i =0; i<num_excitatory_inputs; i++) {
         total_exc += exc_input[i];

--- a/neural_modelling/src/neuron/models/neuron_model_lif_impl.h
+++ b/neural_modelling/src/neuron/models/neuron_model_lif_impl.h
@@ -147,8 +147,8 @@ static inline state_t neuron_model_state_update(
 
     // If outside of the refractory period
     if (neuron->refract_timer <= 0) {
-        REAL total_exc = 0;
-        REAL total_inh = 0;
+        REAL total_exc = ZERO;
+        REAL total_inh = ZERO;
 
         for (int i=0; i < num_excitatory_inputs; i++) {
             total_exc += exc_input[i];

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_delta_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_delta_impl.h
@@ -91,8 +91,8 @@ static void synapse_types_save_state(synapse_types_t *state, synapse_types_param
 //! \param[in,out] parameters: the pointer to the parameters to use
 static inline void synapse_types_shape_input(
         synapse_types_t *parameters) {
-	parameters->exc = 0;
-	parameters->inh = 0;
+	parameters->exc = ZERO;
+	parameters->inh = ZERO;
 }
 
 //! \brief adds the inputs for a give timer period to a given neuron that is

--- a/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
+++ b/neural_modelling/src/neuron/synapse_types/synapse_types_semd_impl.h
@@ -147,17 +147,17 @@ static inline void synapse_types_add_neuron_input(
 //! \return the excitatory input buffers for a given neuron ID.
 static inline input_t *synapse_types_get_excitatory_input(
         input_t *excitatory_response, synapse_types_t *parameters) {
-	if (parameters->exc2.synaptic_input_value >= 0.001
-	        && parameters->multiplicator == 0
-			&& parameters->exc2_old == 0) {
+	if (parameters->exc2.synaptic_input_value >= 0.001k
+	        && parameters->multiplicator == ZERO
+			&& parameters->exc2_old == ZERO) {
 		parameters->multiplicator = parameters->exc.synaptic_input_value;
-	} else if (parameters->exc2.synaptic_input_value < 0.001) {
-		parameters->multiplicator = 0;
+	} else if (parameters->exc2.synaptic_input_value < 0.001k) {
+		parameters->multiplicator = ZERO;
 	}
 
 	parameters->exc2_old = parameters->exc2.synaptic_input_value;
 
-    excitatory_response[0] = 0;
+    excitatory_response[0] = ZERO;
     excitatory_response[1] =
     		parameters->exc2.synaptic_input_value * parameters->multiplicator
     		* parameters->scaling_factor;


### PR DESCRIPTION
There were missing k's to specify accums in the sEMD synapse type.  It also seems that in places it's better to use ZERO rather than 0, so for consistency I've edited all the places I could find where this was needed.