### PR TITLE
Apply delay check correctly and increment skipped in mad impl

### DIFF
--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_izhikevich_neuromodulation.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_izhikevich_neuromodulation.c
@@ -411,7 +411,7 @@ static inline neuromodulated_synapse_t process_plastic_synapse(
             &post_event_history[s.index]);
 
 	// Add weight to ring-buffer entry, but only if not too late
-    if (s.delay_dendritic + s.delay_axonal >= colour_delay) {
+    if (s.delay_dendritic + s.delay_axonal > colour_delay) {
         synapse_dynamics_stdp_update_ring_buffers(ring_buffers, s,
                 final_state.weight);
     } else {

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -28,6 +28,8 @@ struct synapse_row_plastic_data_t {
     plastic_synapse_t synapses[];
 };
 
+extern uint32_t skipped_synapses;
+
 //---------------------------------------
 //! \brief Synapse update loop core
 //! \param[in] time: The current time
@@ -214,10 +216,12 @@ static inline plastic_synapse_t process_plastic_synapse(
 			&post_event_history[s.index]);
 
 	// Add weight to ring-buffer entry, but only if not too late
-	if (s.delay_axonal + s.delay_dendritic >= colour_delay) {
+	if (s.delay_axonal + s.delay_dendritic > colour_delay) {
 	    int32_t weight = synapse_structure_get_final_weight(final_state);
 	    synapse_dynamics_stdp_update_ring_buffers(ring_buffers, s, weight);
-	}
+    } else {
+        skipped_synapses++;
+    }
 
 	return synapse_structure_get_final_synaptic_word(final_state);
 }

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -221,8 +221,9 @@ static inline bool process_fixed_synapses(
         // (should auto increment pointer in single instruction)
         uint32_t synaptic_word = *synaptic_words++;
 
-        // If the delay is too small, skip
-        if ((synaptic_word & synapse_delay_mask_shifted) <= colour_delay_shifted) {
+        // If the (shifted) delay is non zero and too small, skip
+        if (((synaptic_word & synapse_delay_mask_shifted) != 0) &&
+        		((synaptic_word & synapse_delay_mask_shifted) <= colour_delay_shifted)) {
             skipped_synapses++;
             continue;
         }

--- a/neural_modelling/src/neuron/synapses.c
+++ b/neural_modelling/src/neuron/synapses.c
@@ -222,7 +222,7 @@ static inline bool process_fixed_synapses(
         uint32_t synaptic_word = *synaptic_words++;
 
         // If the delay is too small, skip
-        if ((synaptic_word & synapse_delay_mask_shifted) < colour_delay_shifted) {
+        if ((synaptic_word & synapse_delay_mask_shifted) <= colour_delay_shifted) {
             skipped_synapses++;
             continue;
         }


### PR DESCRIPTION
The check against the colour_delay wasn't quite right, and skipped synapses were not being calculated in the stdp mad impl.

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/171
(Doesn't depend on https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1011 necessarily but gave the branches the same name for testing purposes).