### PR TITLE
Tidy up code with warnings in gcc v12.2

### DIFF
--- a/neural_modelling/src/neuron/c_main_neurons.c
+++ b/neural_modelling/src/neuron/c_main_neurons.c
@@ -122,7 +122,7 @@ static uint32_t recording_flags = 0;
 static struct sdram_config sdram_inputs;
 
 //! The inputs from the various synapse cores
-static weight_t *synaptic_contributions[N_SYNAPTIC_BUFFERS];
+static weight_t **synaptic_contributions;
 
 //! The timer overruns
 static uint32_t timer_overruns = 0;
@@ -271,6 +271,7 @@ static bool initialise(void) {
     spin1_memcpy(&sdram_inputs, sdram_config, sizeof(struct sdram_config));
 
     uint32_t n_words = sdram_inputs.size_in_bytes >> 2;
+    synaptic_contributions = spin1_malloc(N_SYNAPTIC_BUFFERS * sizeof(uint32_t*));
     for (uint32_t i = 0; i < N_SYNAPTIC_BUFFERS; i++) {
         synaptic_contributions[i] = spin1_malloc(sdram_inputs.size_in_bytes);
         if (synaptic_contributions == NULL) {

--- a/neural_modelling/src/neuron/c_main_neurons.c
+++ b/neural_modelling/src/neuron/c_main_neurons.c
@@ -122,7 +122,7 @@ static uint32_t recording_flags = 0;
 static struct sdram_config sdram_inputs;
 
 //! The inputs from the various synapse cores
-static weight_t **synaptic_contributions;
+static weight_t *synaptic_contributions[N_SYNAPTIC_BUFFERS];
 
 //! The timer overruns
 static uint32_t timer_overruns = 0;
@@ -271,10 +271,9 @@ static bool initialise(void) {
     spin1_memcpy(&sdram_inputs, sdram_config, sizeof(struct sdram_config));
 
     uint32_t n_words = sdram_inputs.size_in_bytes >> 2;
-    synaptic_contributions = spin1_malloc(N_SYNAPTIC_BUFFERS * sizeof(uint32_t*));
     for (uint32_t i = 0; i < N_SYNAPTIC_BUFFERS; i++) {
         synaptic_contributions[i] = spin1_malloc(sdram_inputs.size_in_bytes);
-        if (synaptic_contributions == NULL) {
+        if (synaptic_contributions[i] == NULL) {
             log_error("Could not allocate %d bytes for synaptic contributions %d",
                     sdram_inputs.size_in_bytes, i);
             return false;

--- a/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
+++ b/neural_modelling/src/neuron/structural_plasticity/synaptogenesis/sp_structs.h
@@ -177,7 +177,7 @@ static inline bool sp_structs_get_sub_pop_info(
             pre_pop_info_table->prepop_info[population_id];
     uint32_t neuron_id = pop_neuron_id;
     for (uint32_t i = 0; i < app_pop_info->no_pre_vertices; i++) {
-    	key_atom_info_t *kai = &app_pop_info->key_atom_info[i];
+    	const key_atom_info_t *kai = &app_pop_info->key_atom_info[i];
         uint32_t n_atoms = kai->n_atoms;
         if (neuron_id < n_atoms) {
             *sub_population_id = i;


### PR DESCRIPTION
Building code with -Werror just to catch some (recent) warnings that had crept in, some are only found by gcc v12 but others existed in gcc v9.  One warning found further down the toolchain which I suggest we don't (yet) fix is described at https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/issues/1013.

[I suggest we probably leave -Werror out of the default (user) build in automatic_make as we don't necessarily want to force people to use a particular version of gcc, though perhaps it might be a nice idea to have it somewhere in a build process that gets used in CI?]

Will test this branch once the big machine is back up and running again; for now scripts related to where changes were made seem to be working locally at least.