### PR TITLE
rate_and_count_per_slice

### DIFF
--- a/spynnaker/pyNN/models/common/neuron_recorder.py
+++ b/spynnaker/pyNN/models/common/neuron_recorder.py
@@ -198,21 +198,18 @@ class NeuronRecorder(object):
         """
         return self.__region_ids[variable]
 
-    def _count_recording_per_slice(
-            self, variable, vertex_slice):
-        """
-        :param str variable:
-        :param ~pacman.model.graphs.common.Slice vertex_slice:
-        :rtype: int or None
-        """
+    def _rate_and_count_per_slice(self, variable, vertex_slice):
         if variable not in self.__sampling_rates:
-            return None
+            return None, None
         if self.__sampling_rates[variable] == 0:
-            return 0
+            return 0, 0
         if self.__indexes[variable] is None:
-            return vertex_slice.n_atoms
-        return sum(vertex_slice.lo_atom <= index <= vertex_slice.hi_atom
-                   for index in self.__indexes[variable])
+            return self.__sampling_rates[variable], vertex_slice.n_atoms
+        count = sum(vertex_slice.lo_atom <= index <= vertex_slice.hi_atom
+                    for index in self.__indexes[variable])
+        if count:
+            return self.__sampling_rates[variable], count
+        return 0, 0
 
     def _max_recording_per_slice(self, variable, n_atoms):
         """
@@ -1087,7 +1084,7 @@ class NeuronRecorder(object):
         :return:
         :rtype: int
         """
-        n_neurons = self._count_recording_per_slice(variable, vertex_slice)
+        _, n_neurons = self._rate_and_count_per_slice(variable, vertex_slice)
         return self._get_buffered_sdram_per_record(variable, n_neurons)
 
     def get_max_buffered_sdram_per_record(self, variable, n_atoms):
@@ -1339,22 +1336,14 @@ class NeuronRecorder(object):
         # There is no data here for per-timestep variables by design
         data = list()
         for variable in self.__sampling_rates:
-            # Do bitfields afterwards
+            rate, n_recording = self._rate_and_count_per_slice(
+                variable, vertex_slice)
             if variable in self.__bitfield_variables:
-                continue
-            rate = self.__sampling_rates[variable]
-            n_recording = self._count_recording_per_slice(
-                variable, vertex_slice)
-            dtype = self.__data_types[variable]
-            data.append(numpy.array(
-                [rate, n_recording, dtype.size], dtype="uint32"))
-            self.__add_indices(data, variable, rate, n_recording, vertex_slice)
-
-        for variable in self.__bitfield_variables:
-            rate = self.__sampling_rates[variable]
-            n_recording = self._count_recording_per_slice(
-                variable, vertex_slice)
-            data.append(numpy.array([rate, n_recording], dtype="uint32"))
+                data.append(numpy.array([rate, n_recording], dtype="uint32"))
+            else:
+                dtype = self.__data_types[variable]
+                data.append(numpy.array(
+                    [rate, n_recording, dtype.size], dtype="uint32"))
             self.__add_indices(data, variable, rate, n_recording, vertex_slice)
 
         return numpy.concatenate(data)
@@ -1396,18 +1385,12 @@ class NeuronRecorder(object):
         n_vars = len(self.__sampling_rates) - len(self.__bitfield_variables)
         data = [n_vars, len(self.__bitfield_variables)]
         for variable in self.__sampling_rates:
+            rate, _ = self._rate_and_count_per_slice(
+                variable, vertex_slice)
             if variable in self.__bitfield_variables:
-                continue
-            rate = self.__sampling_rates[variable]
-            data.extend([rate, self.__data_types[variable].size])
-            if rate == 0:
-                data.extend([0, 0])
+                data.append(rate)
             else:
-                data.extend(self.__get_generator_indices(
-                    variable, vertex_slice, atoms_shape))
-        for variable in self.__bitfield_variables:
-            rate = self.__sampling_rates[variable]
-            data.append(rate)
+                data.extend([rate, self.__data_types[variable].size])
             if rate == 0:
                 data.extend([0, 0])
             else:

--- a/spynnaker_integration_tests/test_selective_recording/test_sampling.py
+++ b/spynnaker_integration_tests/test_selective_recording/test_sampling.py
@@ -94,3 +94,19 @@ class TestSampling(BaseTestCase):
 
     def test_standard(self):
         self.runsafe(self.standard)
+
+    def one_core_no_recording(self):
+        sim.setup(timestep=1)
+        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 5)
+
+        pop_1 = sim.Population(10, sim.IF_curr_exp(), label="pop_1")
+        input_pop = sim.Population(
+            10, sim.SpikeSourceArray(spike_times=[0]), label="input")
+        sim.Projection(input_pop, pop_1, sim.OneToOneConnector(),
+                       synapse_type=sim.StaticSynapse(weight=5, delay=1))
+        pop_1[0:3].record(["spikes", "v"])
+        simtime = 10
+        sim.run(simtime)
+
+    def test_one_core_no_recording(self):
+        self.runsafe(self.one_core_no_recording)


### PR DESCRIPTION
Fix for: https://github.com/SpiNNakerManchester/sPyNNaker/issues/1274

Easiest was to tell the cores where no neurons where recording that the recording rate was zero.

Used the new _rate_and_count_per_slice for both sdram sizes and data spec to make sure they same in sync 

Simplified the if variable in self.__bitfield_variables
as most of the code was them same.

Added a new test which was broken before the fix.

manually tested the no generate on machine by
tweaking the neuron_data generate_on_machine method to just return False

https://github.com/SpiNNakerManchester/sPyNNaker/blob/0a6621814128e839f9ec8cb8a592208077a6917f/spynnaker/pyNN/models/neuron/neuron_data.py#L100

tested by:
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/rate_and_count_per_slice/1/pipeline