### PR TITLE
fix Clear bug

### DIFF
--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -1359,7 +1359,7 @@ class NeoBufferDatabase(BufferDatabase):
         """
         with self.transaction() as cursor:
             if isinstance(variables, str):
-               variables = [variables]
+                variables = [variables]
             if 'all' in variables:
                 variables = None
             if variables is None:
@@ -1395,7 +1395,6 @@ class NeoBufferDatabase(BufferDatabase):
                         FROM region_metadata NATURAL JOIN recording_view
                         WHERE label = ? AND variable = ?)
                     """, (pop_label, variable))
-
 
     def write_metadata(self):
         with self.transaction() as cursor:

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -1363,6 +1363,13 @@ class NeoBufferDatabase(BufferDatabase):
         :param list(str) variables: names of variable to get data for
         """
         with self.transaction() as cursor:
+            if isinstance(variables, str):
+               variables = [variables]
+            if 'all' in variables:
+                variables = None
+            if variables is None:
+                variables = self.__get_recording_variables(pop_label, cursor)
+
             for variable in variables:
                 cursor.execute(
                     """

--- a/spynnaker_integration_tests/test_various/test_clear.py
+++ b/spynnaker_integration_tests/test_various/test_clear.py
@@ -20,7 +20,6 @@ from spinnaker_testbase import BaseTestCase
 
 class TestClearData(BaseTestCase):
 
-
     def make_rewires(self):
         sim.setup(1.0)
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 5)

--- a/spynnaker_integration_tests/test_various/test_clear_rewires.py
+++ b/spynnaker_integration_tests/test_various/test_clear_rewires.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2017-2020 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import pyNN.spiNNaker as sim
+from spinnaker_testbase import BaseTestCase
+
+
+class TestClearData(BaseTestCase):
+
+
+    def make_rewires(self):
+        sim.setup(1.0)
+        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 5)
+        stim = sim.Population(9, sim.SpikeSourceArray(range(10)), label="stim")
+
+        # These populations should experience elimination
+        pop = sim.Population(9, sim.IF_curr_exp(), label="pop_1")
+
+        # Elimination with random selection (0 probability formation)
+        sim.Projection(
+            stim, pop, sim.AllToAllConnector(),
+            sim.StructuralMechanismStatic(
+                partner_selection=sim.RandomSelection(),
+                formation=sim.DistanceDependentFormation([3, 3], 0.0),
+                elimination=sim.RandomByWeightElimination(4.0, 1.0, 1.0),
+                f_rew=1000, initial_weight=4.0, initial_delay=3.0,
+                s_max=9, seed=0, weight=0.0, delay=1.0))
+
+        pop.record("rewiring")
+        sim.run(10)
+        neo = pop.get_data("rewiring", clear=True)
+        elimination_events = neo.segments[0].events[1]
+        self.assertEqual(len(elimination_events), 10)
+        sim.run(10)
+        neo = pop.get_data("rewiring", clear=True)
+        elimination_events = neo.segments[0].events[1]
+        self.assertEqual(len(elimination_events), 10)
+
+        sim.end()
+
+    def do_simple(self):
+        sim.setup(timestep=1.0)
+        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
+
+        pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")
+        input_pop = sim.Population(
+            1, sim.SpikeSourceArray(spike_times=[0, 10, 20]), label="input")
+        sim.Projection(input_pop, pop_1, sim.OneToOneConnector(),
+                       synapse_type=sim.StaticSynapse(weight=5, delay=1))
+        pop_1.record(["spikes", "v"])
+        sim.run(20)
+        neo = pop_1.get_data(variables=["spikes", "v"], clear=True)
+        spikes = neo.segments[0].spiketrains
+        self.assertEqual(
+            '<SpikeTrain(array([ 7., 14.]) * ms, [0.0 ms, 20.0 ms])>',
+            repr(spikes[0]))
+        v = neo.segments[0].filter(name='v')[0]
+        self.assertEqual(20, v.size)
+        sim.run(10)
+        neo = pop_1.get_data(variables=["spikes", "v"], clear=True)
+        spikes = neo.segments[0].spiketrains
+        self.assertEqual(
+            '<SpikeTrain(array([23.]) * ms, [20.0 ms, 30.0 ms])>',
+            repr(spikes[0]))
+        v = neo.segments[0].filter(name='v')[0]
+        self.assertEqual(10, v.size)
+        sim.end()
+
+    def test_rewires(self):
+        self.runsafe(self.make_rewires)
+
+    def test_simple(self):
+        self.runsafe(self.do_simple)


### PR DESCRIPTION
there where three bugs in the pop.get_data clear=True.

1. Did not handle the case of a single variable or "all"
2. Did not change the recording start time.
3. The event time incorrectly added t_start

this PR fixes those bugs and adds tests

tested by 
http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/clear/1/pipeline/16