### PR TITLE
Push bot viewer

### DIFF
--- a/spynnaker/pyNN/external_devices_models/push_bot/parameters/push_bot_retina_viewer.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/parameters/push_bot_retina_viewer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from threading import Thread
+from threading import Thread, RLock
 from time import sleep
 from matplotlib import pyplot
 import numpy
@@ -44,6 +44,7 @@ class PushBotRetinaViewer():
         self.__height = retina_resolution.value.pixels
 
         self.__running = True
+        self.__image_lock = RLock()
 
         self.__sim = sim
         self.__conn = sim.external_devices.SpynnakerLiveSpikesConnection(
@@ -62,7 +63,9 @@ class PushBotRetinaViewer():
     def __recv(self, label, time, spikes):
         np_spikes = numpy.array(spikes) & self.__without_polarity_mask
         x_vals, y_vals = numpy.divmod(np_spikes, self.__height)
+        self.__image_lock.acquire()
         self.__image_data[x_vals, y_vals] += 1.0
+        self.__image_lock.release()
 
     def __run_sim_forever(self):
         self.__sim.external_devices.run_forever()
@@ -78,10 +81,12 @@ class PushBotRetinaViewer():
 
         while self.__running and self.__fig.get_visible():
             try:
+                self.__image_lock.acquire()
                 self.__plot.set_array(self.__image_data)
                 self.__fig.canvas.draw()
                 self.__fig.canvas.flush_events()
                 self.__image_data *= DECAY_FACTOR
+                self.__image_lock.release()
                 sleep(0.1)
             # pylint: disable=broad-except
             except Exception:

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_retina_device.py
@@ -47,12 +47,14 @@ class PushBotSpiNNakerLinkRetinaDevice(
         PopulationApplicationVertex):
     __slots__ = ["__new_key_command"]
 
-    default_parameters = {'label': None, 'board_address': None}
+    default_parameters = {'label': None, 'board_address': None,
+                          'n_machine_vertices': 1}
 
     def __init__(
             self, spinnaker_link_id, protocol, resolution,
             board_address=default_parameters['board_address'],
-            label=default_parameters['label']):
+            label=default_parameters['label'],
+            n_machine_vertices=default_parameters['n_machine_vertices']):
         """
         :param spinnaker_link_id:
         :param protocol:
@@ -67,7 +69,8 @@ class PushBotSpiNNakerLinkRetinaDevice(
         ApplicationSpiNNakerLinkVertex.__init__(
             self, spinnaker_link_id=spinnaker_link_id,
             n_atoms=resolution.value.n_neurons,
-            board_address=board_address, label=label)
+            board_address=board_address, label=label,
+            n_machine_vertices=n_machine_vertices)
 
         # stores for the injection aspects
         self.__new_key_command = None
@@ -82,7 +85,7 @@ class PushBotSpiNNakerLinkRetinaDevice(
         """
         routing_info = SpynnakerDataView.get_routing_infos()
         key = routing_info.get_first_key_from_pre_vertex(
-            next(iter(self.machine_vertices)), SPIKE_PARTITION_ID)
+            self, SPIKE_PARTITION_ID)
         return key
 
     @property


### PR DESCRIPTION
Changes to the pushbot viewer that make it work better.  Also lets the pushbot retina input be divided into multiple source cores (depends on SpiNNakerManchester/PACMAN#501 to avoid crashes)