### PR TITLE
Avoid list searches

### DIFF
--- a/spynnaker/pyNN/data/spynnaker_data_view.py
+++ b/spynnaker/pyNN/data/spynnaker_data_view.py
@@ -164,9 +164,6 @@ class SpynnakerDataView(FecDataView):
         # UGLY but needed to avoid circular import
         from spynnaker.pyNN.models.projection import Projection
         cls.check_user_can_act()
-        if projection in cls.__spy_data._projections:
-            raise NotImplementedError(
-                "This method should only be called from the Projection init")
         if not isinstance(projection, Projection):
             raise TypeError("The projection must be a Projection")
         cls.__spy_data._projections.append(projection)
@@ -217,9 +214,6 @@ class SpynnakerDataView(FecDataView):
         cls.check_user_can_act()
         if not isinstance(population, Population):
             raise TypeError("The population must be a Population")
-        if population in cls.__spy_data._populations:
-            raise NotImplementedError(
-                "This method should only be called from the Population init")
         first_id = cls.__spy_data._id_counter
         cls.__spy_data._id_counter += population.size
         cls.__spy_data._populations.append(population)

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -90,9 +90,6 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(0, SpynnakerDataView.get_n_projections())
         model = IFCurrExpBase()
         pop_1 = Population(size=5, cellclass=model)
-        # Population adds itself so no one can
-        with self.assertRaises(NotImplementedError):
-            writer.add_population(pop_1)
         self.assertListEqual(
             [pop_1], list(SpynnakerDataView.iterate_populations()))
         self.assertEqual(1, SpynnakerDataView.get_n_populations())


### PR DESCRIPTION
Speed up runs by avoiding the searching of lists.

NOTE: This removes some safety checks