### PR TITLE
removes requires_data_generation

### DIFF
--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -927,7 +927,7 @@ class AbstractPopulationVertex(
         # If synapses change during the run also regenerate these to get
         # back to the initial state
         if self.__synapse_dynamics.changes_during_run:
-            SpynnakerDataView.set_requires_data_generation()
+            SpynnakerDataView.set_requires_mapping()
         else:
             # We only get neuron vertices to regenerate not redoing data
             # generation

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -923,15 +923,7 @@ class AbstractPopulationVertex(
     def reset_to_first_timestep(self):
         # Reset state variables
         self.__state_variables.copy_into(self.__initial_state_variables)
-
-        # If synapses change during the run also regenerate these to get
-        # back to the initial state
-        if self.__synapse_dynamics.changes_during_run:
-            SpynnakerDataView.set_requires_mapping()
-        else:
-            # We only get neuron vertices to regenerate not redoing data
-            # generation
-            self.__tell_neuron_vertices_to_regenerate()
+        self.__tell_neuron_vertices_to_regenerate()
 
     @staticmethod
     def _ring_buffer_expected_upper_bound(

--- a/spynnaker_integration_tests/test_debug_mode/check_debug.py
+++ b/spynnaker_integration_tests/test_debug_mode/check_debug.py
@@ -121,16 +121,6 @@ class CheckDebug(BaseTestCase):
         self.assertIn("data1.sqlite3", found)
         self.assertNotIn("ds1.sqlite3", found)
 
-        sim.reset()  # soft with dsg
-        SpynnakerDataView.set_requires_data_generation()
-        sim.run(10)
-        pop.get_data("v")
-        self.assertEqual(run0, SpynnakerDataView.get_run_dir_path())
-        found = os.listdir(run0)
-        self.assertIn("data2.sqlite3", found)
-        self.assertIn("ds2.sqlite3", found)
-        # No point in checking files they are already there
-
         sim.reset()  # hard
         SpynnakerDataView.set_requires_mapping()
         sim.run(10)


### PR DESCRIPTION
Fixes: https://github.com/SpiNNakerManchester/sPyNNaker/issues/1337

The only know place that requires_data_generation instead of requires_mapping was used was 
self.__synapse_dynamics.changes_during_run

As test show that this use case actually fails the simplest solution is just to make that a requires_mapping.

This change does come at a time cost the runs after reset.
As it will have to rerun the mapping and get machine steps.

Based on timing done on the microcircuit this extra time would add about 50% to the preparation time of the run after reset.
Ref: http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/time_report2/27/pipeline/99
Reports stage

If this PR is refused another solution for https://github.com/SpiNNakerManchester/sPyNNaker/issues/1337 will need to be found. And even if fixed this time there is a danger another error could slip in this rare use case.

This allows the complete removal of the requires_data_generation:
https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1058
https://github.com/SpiNNakerManchester/SpiNNUtils/pull/230

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/198


