### PR TITLE
Switch to PyNN 0.11.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn
+        pynn >= 0.11
         lazyarray >= 0.2.9, <= 0.4.0
         neo
         # below may fail for read the docs

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,10 @@ install_requires =
         SpiNNFrontEndCommon == 1!6.0.1
         matplotlib
         pyparsing>=2.2.1,<3.0.0
-        quantities >= 0.12.1
-        pynn >= 0.9.1, < 0.10.0
+        quantities
+        pynn
         lazyarray >= 0.2.9, <= 0.4.0
-        neo >= 0.5.2, < 0.10.0
+        neo
         # below may fail for read the docs
         scipy
         csa

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,14 +51,9 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        'pynn >= 0.11; python >= "3.8"'
-        'neo; python >= "3.8"'
-        'lazyarray; python >= "3.8"'
-        # WARNING Python 3.7 is no longer supported
-        # This are just to check there are n know breaks
-        'pynn >= 0.9.1, < 0.10.0; python_version == "3.7"'
-        'neo >= 0.5.2, < 0.10.0; python_version == "3.7"'
-        'lazyarray >= 0.2.9, <= 0.4.0; python_version == "3.7"'
+        pynn
+        neo
+        lazyarray
         # below may fail for read the docs
         scipy
         csa

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,14 +51,14 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn >= 0.11; python >= '3.8'
-        neo; python >= '3.8'
-        lazyarray; python >= '3.8'
+        'pynn >= 0.11; python >= "3.8"'
+        'neo; python >= "3.8"'
+        'lazyarray; python >= "3.8"'
         # WARNING Python 3.7 is no longer supported
         # This are just to check there are n know breaks
-        pynn >= 0.9.1, < 0.10.0; python_version == '3.7'
-        neo >= 0.5.2, < 0.10.0; python_version == '3.7'
-        lazyarray >= 0.2.9, <= 0.4.0; python_version == '3.7'
+        'pynn >= 0.9.1, < 0.10.0; python_version == "3.7"'
+        'neo >= 0.5.2, < 0.10.0; python_version == "3.7"'
+        'lazyarray >= 0.2.9, <= 0.4.0; python_version == "3.7"'
         # below may fail for read the docs
         scipy
         csa

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,14 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn >= 0.11
-        lazyarray
-        neo
+        pynn >= 0.11; python >= '3.8'
+        neo; python >= '3.8'
+        lazyarray; python >= '3.8'
+        # WARNING Python 3.7 is no longer supported
+        # This are just to check there are n know breaks
+        pynn >= 0.9.1, < 0.10.0; python_version == '3.7'
+        neo >= 0.5.2, < 0.10.0; python_version == '3.7'
+        lazyarray >= 0.2.9, <= 0.4.0; python_version == '3.7'
         # below may fail for read the docs
         scipy
         csa

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
         pyparsing>=2.2.1,<3.0.0
         quantities
         pynn > 0.9.1, !=0.10.0, !=0.10.1
-        neo != 0.11.0, !- 0.11.1
+        neo != 0.11.0, != 0.11.1
         lazyarray
         # below may fail for read the docs
         scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,9 +51,13 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn > 0.9.1, !=0.10.0, !=0.10.1
-        neo != 0.11.0, != 0.11.1
-        lazyarray
+        pynn >= 0.11; python_version >= '3.8'
+        neo; python_version >= '3.8'
+        lazyarray; python_version >= '3.8'
+        # python 3.7 is no longer officially supported
+        pynn >= 0.9.1, < 0.10.0; python_version == '3.7'
+        neo >= 0.5.2, < 0.10.0; python_version == '3.7'
+        lazyarray >= 0.2.9, <= 0.4.0; python_version == '3.7'
         # below may fail for read the docs
         scipy
         csa

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
         pyparsing>=2.2.1,<3.0.0
         quantities
         pynn >= 0.11
-        lazyarray >= 0.2.9, <= 0.4.0
+        lazyarray
         neo
         # below may fail for read the docs
         scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,8 +51,8 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn
-        neo
+        pynn > 0.9.1, !=0.10.0, !=0.10.1
+        neo != 0.11.0, !- 0.11.1
         lazyarray
         # below may fail for read the docs
         scipy

--- a/spynnaker/pyNN/models/populations/population.py
+++ b/spynnaker/pyNN/models/populations/population.py
@@ -14,7 +14,6 @@
 
 import logging
 import numpy
-import neo
 import os
 import inspect
 from pyNN import descriptions
@@ -32,6 +31,7 @@ from .population_view import PopulationView, IDMixin
 from spynnaker.pyNN.models.abstract_models import SupportsStructure
 from spynnaker.pyNN.models.common import PopulationApplicationVertex
 from spynnaker.pyNN.utilities.neo_buffer_database import NeoBufferDatabase
+from spynnaker.pyNN.utilities.utility_calls import get_neo_io
 
 logger = FormatAdapter(logging.getLogger(__file__))
 
@@ -239,7 +239,7 @@ class Population(PopulationBase):
                 self.__recorder.csv_neo_block(
                     io, variables, annotations=annotations)
                 return
-            io = neo.get_io(io)
+            io = get_neo_io(io)
 
         data = self.__recorder.extract_neo_block(
             variables, None, clear, annotations)

--- a/spynnaker/pyNN/models/populations/population_view.py
+++ b/spynnaker/pyNN/models/populations/population_view.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-import neo
 import numpy
 import os
 from spinn_utilities.log import FormatAdapter
@@ -24,6 +23,7 @@ from spinn_utilities.ranged.abstract_sized import AbstractSized
 from .population_base import PopulationBase
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.utilities.neo_buffer_database import NeoBufferDatabase
+from spynnaker.pyNN.utilities.utility_calls import get_neo_io
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -606,7 +606,8 @@ class PopulationView(PopulationBase):
                     io, variables, view_indexes=self.__indexes,
                     annotations=annotations)
                 return
-            io = neo.get_io(io)
+            io = get_neo_io(io)
+
 
         data = self.__recorder.extract_neo_block(
             variables, self.__indexes, clear, annotations)

--- a/spynnaker/pyNN/models/populations/population_view.py
+++ b/spynnaker/pyNN/models/populations/population_view.py
@@ -608,7 +608,6 @@ class PopulationView(PopulationBase):
                 return
             io = get_neo_io(io)
 
-
         data = self.__recorder.extract_neo_block(
             variables, self.__indexes, clear, annotations)
 

--- a/spynnaker/pyNN/utilities/data_population.py
+++ b/spynnaker/pyNN/utilities/data_population.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import logging
-import neo
 import numpy
 from spinn_utilities.ranged.abstract_sized import AbstractSized
 from spinn_utilities.log import FormatAdapter
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.models.populations import Population
 from spynnaker.pyNN.utilities.neo_buffer_database import NeoBufferDatabase
+from spynnaker.pyNN.utilities.utility_calls import get_neo_io
 
 logger = FormatAdapter(logging.getLogger(__file__))
 _SELECTIVE_RECORDED_MSG = (
@@ -52,11 +52,10 @@ class DataPopulation(object):
         if clear:
             logger.warning("Ignoring clear as supported in this mode")
         if isinstance(io, str):
-            io = neo.get_io(io)
-
+            io = get_neo_io(io)
         data = self.get_data(variables)
         # write the neo block to the file
-        io.write(data)
+        io.write(bl=data)
 
     @overrides(Population.describe)
     def describe(self, template=None, engine=None):

--- a/spynnaker/pyNN/utilities/neo_compare.py
+++ b/spynnaker/pyNN/utilities/neo_compare.py
@@ -86,8 +86,8 @@ def compare_analogsignal(as1, as2, same_length=True):
         data extracted part way with data extracted at the end.
     :raises AssertionError: If the analog signals are not equal
     """
-    as1_index = as1.channel_index.index
-    as2_index = as2.channel_index.index
+    as1_index = as1.annotations["channel_names"]
+    as2_index = as2.annotations["channel_names"]
 
     if as1.name != as2.name:
         raise AssertionError(

--- a/spynnaker/pyNN/utilities/neo_convertor.py
+++ b/spynnaker/pyNN/utilities/neo_convertor.py
@@ -28,7 +28,7 @@ def convert_analog_signal(signal_array, time_unit=quantities.ms):
         Data time unit for time index
     :rtype: ~numpy.ndarray
     """
-    ids = signal_array.channel_index.index.astype(int)
+    ids = signal_array.annotations["channel_names"]
     xs = range(len(ids))
     if time_unit == quantities.ms:
         times = signal_array.times.magnitude
@@ -141,8 +141,8 @@ def convert_gsyn(gsyn_exc, gsyn_inh):
     """
     exc = gsyn_exc.segments[0].filter(name='gsyn_exc')[0]
     inh = gsyn_inh.segments[0].filter(name='gsyn_inh')[0]
-    ids = exc.channel_index
-    ids2 = inh.channel_index
+    ids = exc.annotations["channel_names"]
+    ids2 = inh.annotations["channel_names"]
     if len(ids) != len(ids2):
         raise ValueError(
             f"Found {len(ids)} neuron IDs in gsyn_exc "

--- a/spynnaker/pyNN/utilities/neo_csv.py
+++ b/spynnaker/pyNN/utilities/neo_csv.py
@@ -236,23 +236,6 @@ class NeoCsv(object):
                              "So this data will be skipped", variable, ex)
             return
 
-    def __get_channel_index(self, ids, block):
-        """
-        Creates a Channel Index object.
-
-        :param list(int) ids:
-        :param ~neo.core.Block block: neo block
-        :rtype: ~neo.core.ChannelIndex
-        """
-        for channel_index in block.channel_indexes:
-            if numpy.array_equal(channel_index.index, ids):
-                return channel_index
-        count = len(block.channel_indexes)
-        channel_index = neo.ChannelIndex(
-            fname=f"Index {count}", index=ids)
-        block.channel_indexes.append(channel_index)
-        return channel_index
-
     def _insert_matrix_data(
             self, variable, segment, signal_array,
             indexes, t_start, sampling_rate, units):
@@ -283,12 +266,10 @@ class NeoCsv(object):
             sampling_rate=sampling_rate,
             name=variable,
             source_population=block.name,
-            source_ids=ids)
-        channel_index = self.__get_channel_index(indexes, segment.block)
-        data_array.channel_index = channel_index
+            source_ids=ids,
+            channel_names=indexes)
         data_array.shape = (data_array.shape[0], data_array.shape[1])
         segment.analogsignals.append(data_array)
-        channel_index.analogsignals.append(data_array)
 
     def _csv_matrix_data(self, csv_writer, signal_array, indexes):
         """

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -441,11 +441,12 @@ def get_time_to_write_us(n_bytes, n_cores):
 
 
 def get_neo_io(file_or_folder):
-    _, suffix = os.path.splitext(file_or_folder)
-    if len(suffix) > 0:
+    try:
+        return neo.get_io(file_or_folder)
+    except ValueError as ex:
+        # As neo.get_io only works with existinf files
+        _, suffix = os.path.splitext(file_or_folder)
         suffix = suffix[1:].lower()
         if suffix in neo.io_by_extension:
             writer_list = neo.io_by_extension[suffix]
             return writer_list[0](file_or_folder)
-
-    return neo.get_io()

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -441,13 +441,11 @@ def get_time_to_write_us(n_bytes, n_cores):
 
 
 def get_neo_io(file_or_folder):
-    try:
-        return neo.get_io(file_or_folder)
-    except ValueError as ex:
-        # As neo.get_io only works with existinf files
-        _, suffix = os.path.splitext(file_or_folder)
+    _, suffix = os.path.splitext(file_or_folder)
+    if len(suffix) > 0:
         suffix = suffix[1:].lower()
         if suffix in neo.io_by_extension:
             writer_list = neo.io_by_extension[suffix]
             return writer_list[0](file_or_folder)
 
+    return neo.get_io()

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -450,3 +450,4 @@ def get_neo_io(file_or_folder):
         if suffix in neo.io_by_extension:
             writer_list = neo.io_by_extension[suffix]
             return writer_list[0](file_or_folder)
+        raise ex

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -444,7 +444,7 @@ def get_neo_io(file_or_folder):
     try:
         return neo.get_io(file_or_folder)
     except ValueError as ex:
-        # As neo.get_io only works with existinf files
+        # As neo.get_io only works with existing files
         _, suffix = os.path.splitext(file_or_folder)
         suffix = suffix[1:].lower()
         if suffix in neo.io_by_extension:

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -18,6 +18,7 @@ Utility package containing simple helper functions.
 import logging
 import os
 import math
+import neo
 import numpy
 from math import isnan
 from pyNN.random import RandomDistribution
@@ -437,3 +438,16 @@ def get_time_to_write_us(n_bytes, n_cores):
     bandwidth_per_core = WRITE_BANDWIDTH_BYTES_PER_SECOND / n_cores
     seconds = n_bytes / bandwidth_per_core
     return int(math.ceil(seconds * MICRO_TO_SECOND_CONVERSION))
+
+
+def get_neo_io(file_or_folder):
+    try:
+        return neo.get_io(file_or_folder)
+    except ValueError as ex:
+        # As neo.get_io only works with existinf files
+        _, suffix = os.path.splitext(file_or_folder)
+        suffix = suffix[1:].lower()
+        if suffix in neo.io_by_extension:
+            writer_list = neo.io_by_extension[suffix]
+            return writer_list[0](file_or_folder)
+

--- a/spynnaker_integration_tests/scripts/pattern_spiker.py
+++ b/spynnaker_integration_tests/scripts/pattern_spiker.py
@@ -57,7 +57,8 @@ class PatternSpiker(object):
         if v_rec_indexes is None:
             v_rec_indexes = range(len(v[0]))
         else:
-            actual_indexes = list(v.channel_index.index)
+            actual_indexes = list(v.annotations["channel_names"])
+
             if missing:
                 v_rec_indexes = [index for index in v_rec_indexes
                                  if index in actual_indexes]

--- a/spynnaker_integration_tests/test_selective_recording/test_thritytwo.py
+++ b/spynnaker_integration_tests/test_selective_recording/test_thritytwo.py
@@ -43,6 +43,6 @@ class TestSampling(BaseTestCase):
         for i in range(32, 40):
             self.assertEqual(0, len(spikes[i]))
         v = neo.segments[0].filter(name='v')[0]
-        self.assertEqual(32, len(v.channel_index.index))
+        self.assertEqual(32, len(v.annotations["channel_names"]))
         self.assertEqual(32, len(v[0]))
         sim.end()

--- a/unittests/test_pop_views_assembly/test_data_population.py
+++ b/unittests/test_pop_views_assembly/test_data_population.py
@@ -144,7 +144,8 @@ class TestDataPopulation(BaseTestCase):
         v = neo.segments[0].filter(name='v')[0].magnitude
         target = self.v_expected[:, 1:3]
         assert numpy.array_equal(
-            [1, 2], neo.segments[0].filter(name='v')[0].channel_index.index)
+            [1, 2],
+            neo.segments[0].filter(name='v')[0].annotations["channel_names"])
         assert v.shape == target.shape
         for i in range(35):
             print(i)

--- a/unittests/test_pop_views_assembly/test_getting.py
+++ b/unittests/test_pop_views_assembly/test_getting.py
@@ -168,7 +168,8 @@ class TestGetting(BaseTestCase):
         v = neo.segments[0].filter(name='v')[0].magnitude
         target = self.v_expected[:, 1:3]
         assert numpy.array_equal(
-            [1, 2], neo.segments[0].filter(name='v')[0].channel_index.index)
+            [1, 2],
+            neo.segments[0].filter(name='v')[0].annotations["channel_names"])
         assert v.shape == target.shape
         assert numpy.array_equal(v,  target)
 


### PR DESCRIPTION
This Pr switches to using PyNN 0.11 instead of the previously supported PyNN 0.9.1
Remember we could not use 0.10 due to a bug in the plotting code.

The critical change is that Neo AnnalogSignal no longer has a channel_index
To get the index an Analog signal covers instea of doing

v.channel_index.index

do 

v.annotations["channel_names"]

There was a minor bug  in the latest neo
https://github.com/NeuralEnsemble/python-neo/issues/1287
a small work around has been provided in Utils

So instead of
neo.get_io("filetowriteto.pkl")
do
from spynnaker.pyNN.utilities.utility_calls import get_neo_io
get_neo_io("filetowriteto.pkl")

Note this is only needed for NOT existing files. Ie before a write call


This change BREAKS usage of PyNN 0.9.1 due to pyNN/utility/plotting
see: http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/pynn9/1/pipeline/220/

It would not be too difficult to add a work around but as the change for users is minor I have choose not to do this.

This PR does NOT make use to the new way to load SpikeTrains

A follow up PR will.
This would then also require an if check on PyNN version to support older PyNN


This PR effectively ends our support for Python 3.7

tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/204








