### PR TITLE
write_provenance_data no longer used

### DIFF
--- a/spynnaker_integration_tests/test_debug_mode/check_debug.py
+++ b/spynnaker_integration_tests/test_debug_mode/check_debug.py
@@ -73,7 +73,6 @@ class CheckDebug(BaseTestCase):
             memory_map_on_host_report,
             # write_network_specification_report
             network_specification_file_name,
-            # write_provenance_data
             "provenance_data",
             # write_tag_allocation_reports
             reports_names._TAGS_FILENAME,

--- a/spynnaker_integration_tests/test_power_monitoring/spynnaker.cfg
+++ b/spynnaker_integration_tests/test_power_monitoring/spynnaker.cfg
@@ -6,4 +6,3 @@ use_java = False
 
 [Reports]
 write_energy_report = True
-write_provenance_data = True

--- a/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
+++ b/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
@@ -62,7 +62,6 @@ class TestDebug(BaseTestCase):
             # ??? used by MachineExecuteDataSpecification but not called ???
             # write_network_specification_report
             network_specification_file_name,
-            # write_provenance_data
             "data.sqlite3",
             # write_tag_allocation_reports
             reports_names._TAGS_FILENAME,


### PR DESCRIPTION
remove unused cfg flag

same as https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1067

http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/write_provenance_data/3/pipeline