### PR TITLE
Add colour shift in case with self-connection, and add test

### DIFF
--- a/neural_modelling/src/neuron/spike_processing_fast.c
+++ b/neural_modelling/src/neuron/spike_processing_fast.c
@@ -538,7 +538,7 @@ void spike_processing_fast_time_step_loop(uint32_t time, uint32_t n_rewires) {
             if (((spike & key_config.mask) == key_config.key) &&
                     (key_config.self_connected)) {
                 synapse_dynamics_process_post_synaptic_event(
-                        time, spike & key_config.spike_id_mask);
+                        time, (spike & key_config.spike_id_mask) >> key_config.colour_shift);
             }
 
             // See if there is another DMA to do

--- a/spynnaker_integration_tests/test_stdp/test_STDP_with_self_connection.py
+++ b/spynnaker_integration_tests/test_stdp/test_STDP_with_self_connection.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyNN.spiNNaker as sim
+from spinnaker_testbase import BaseTestCase
+from spynnaker.pyNN.extra_algorithms.splitter_components import (
+    SplitterAbstractPopulationVertexNeuronsSynapses)
+
+
+def stdp_with_self_connection():
+
+    sim.setup(timestep=1.0)
+
+    input_pop1 = sim.Population(64, sim.SpikeSourcePoisson(rate=10),
+                                label='input1')
+    main_pop = sim.Population(
+        64, sim.IF_curr_exp, label='main',
+        additional_parameters={
+            'splitter': SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+
+    delay1 = sim.RandomDistribution('uniform', (2,3))
+    delayself = sim.RandomDistribution('uniform', (5,6))
+
+    stdpmodel = sim.STDPMechanism(
+        timing_dependence=sim.SpikePairRule(),
+        weight_dependence=sim.AdditiveWeightDependence(),
+        weight=0.3, delay=delay1)
+
+    exc1_proj = sim.Projection(
+        input_pop1, main_pop, sim.AllToAllConnector(), synapse_type=stdpmodel,
+        receptor_type='excitatory')
+
+    self_inhib_proj = sim.Projection(
+        main_pop, main_pop, sim.AllToAllConnector(),
+        synapse_type=sim.StaticSynapse(weight=0.2, delay=delayself),
+        receptor_type='inhibitory')
+
+    sim.run(1000)
+
+    sim.end()
+
+class TestSTDPWithSelfConnection(BaseTestCase):
+
+    def test_stdp_with_self_connection(self):
+        self.runsafe(stdp_with_self_connection)
+
+
+if __name__ == '__main__':
+    stdp_with_self_connection()


### PR DESCRIPTION
Cases with STDP and a self-connection incoming to the same population were failing due to not being colour-shifted correctly.  This fixes that and adds a test to guard against it going wrong again in the future.