### PR TITLE
Fix poisson multirun error

### DIFF
--- a/spynnaker_integration_tests/test_spike_source/test_poisson_spike_source.py
+++ b/spynnaker_integration_tests/test_spike_source/test_poisson_spike_source.py
@@ -237,3 +237,25 @@ class TestPoissonSpikeSource(BaseTestCase):
 
     def test_poisson_live_rates(self):
         self.runsafe(self.poisson_live_rates)
+
+    def poisson_multi_run_change_rate(self):
+
+        n_p = 2
+        sim.setup(timestep=1.0)
+
+        simtime = 1000
+
+        init_rate = [50, 50]
+        pop_src = sim.Population(
+            n_p, sim.SpikeSourcePoisson(rate=init_rate), label="src")
+
+        sim.run(simtime)
+
+        pop_src.set(rate=[1, 100])
+
+        sim.run(simtime)
+
+        sim.end()
+
+    def test_poisson_multi_run_change_rate(self):
+        self.runsafe(self.poisson_multi_run_change_rate)


### PR DESCRIPTION
The included test fails on the master branch because the region size calculation doesn't take into consideration that the set rate values may change from being the same to being different on a subsequent call to run().  This branch fixes the issue by assuming all the rates are different, though there may be a better way of doing it... ?

Tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/216