### PR TITLE
block broken PyNN 0.12.0 version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn >= 0.11; python_version >= '3.8'
+        pynn >= 0.11, pynn != 0.12.0; python_version >= '3.8'
         neo; python_version >= '3.8'
         lazyarray; python_version >= '3.8'
         # python 3.7 is no longer officially supported

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
         matplotlib
         pyparsing>=2.2.1,<3.0.0
         quantities
-        pynn >= 0.11, pynn != 0.12.0; python_version >= '3.8'
+        pynn >= 0.11, != 0.12.0; python_version >= '3.8'
         neo; python_version >= '3.8'
         lazyarray; python_version >= '3.8'
         # python 3.7 is no longer officially supported


### PR DESCRIPTION
https://pypi.org/project/PyNN/0.12.0/ is missing a dependency

This is actively been worked on see: https://github.com/NeuralEnsemble/PyNN/issues/788

Other changes to PyNN between 0.11 and 0.12 do not appear to affect Spynnaker
Test with adding a version of the missing dependency https://github.com/SpiNNakerManchester/sPyNNaker/pull/1390

This pr therefor blocks the unlucky version without excluding later ones.


