### PR TITLE
SkipTest must have a reason

### DIFF
--- a/spynnaker_integration_tests/test_0_1_time_steps/test_allow_violate/test_allow.py
+++ b/spynnaker_integration_tests/test_0_1_time_steps/test_allow_violate/test_allow.py
@@ -43,7 +43,8 @@ class TestAllow(BaseTestCase):
             # no check of gsyn as the system overloads
         # System intentional overload so may error
         except SpinnmanTimeoutException as ex:
-            SpynnakerDataView.raise_skiptest(parent=ex)
+            SpynnakerDataView.raise_skiptest(
+                "Overload caused timeout", parent=ex)
 
     def test_allow(self):
         self.runsafe(self.allow)


### PR DESCRIPTION
Found by type Checking branches

unittest.SkipTest must have a reason

so raise_skiptest must have one too

part of https://github.com/SpiNNakerManchester/SpiNNUtils/pull/248