### PR TITLE
Use app_vertex and vertex_slice

### DIFF
--- a/spynnaker/pyNN/models/neuron/population_machine_common.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_common.py
@@ -168,4 +168,4 @@ class PopulationMachineCommon(
     @overrides(MachineVertex.get_n_keys_for_partition)
     def get_n_keys_for_partition(self, partition_id):
         # Colour each time slot with up to 16 colours to allow for delays
-        return self._vertex_slice.n_atoms * 16
+        return self.vertex_slice.n_atoms * 16

--- a/spynnaker/pyNN/models/neuron/population_machine_synapses.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_synapses.py
@@ -43,7 +43,7 @@ class PopulationMachineSynapses(
     __slots__ = []
 
     @abstractproperty
-    def _app_vertex(self):
+    def app_vertex(self):
         """
         The application vertex of the machine vertex.
 
@@ -54,7 +54,7 @@ class PopulationMachineSynapses(
         """
 
     @abstractproperty
-    def _vertex_slice(self):
+    def vertex_slice(self):
         """
         The slice of the application vertex atoms on this machine vertex.
 
@@ -141,12 +141,12 @@ class PopulationMachineSynapses(
         # Write the synaptic matrices
         self._synaptic_matrices.generate_data()
         self._synaptic_matrices.write_synaptic_data(
-            spec, self._vertex_slice, self._synapse_references)
+            spec, self.vertex_slice, self._synapse_references)
 
         # Write any synapse dynamics
-        synapse_dynamics = self._app_vertex.synapse_dynamics
-        synapse_dynamics_sz = self._app_vertex.get_synapse_dynamics_size(
-            self._vertex_slice.n_atoms)
+        synapse_dynamics = self.app_vertex.synapse_dynamics
+        synapse_dynamics_sz = self.app_vertex.get_synapse_dynamics_size(
+            self.vertex_slice.n_atoms)
         if synapse_dynamics_sz > 0:
             spec.reserve_memory_region(
                 region=self._synapse_regions.synapse_dynamics,
@@ -154,7 +154,7 @@ class PopulationMachineSynapses(
                 reference=self._synapse_references.synapse_dynamics)
             synapse_dynamics.write_parameters(
                 spec, self._synapse_regions.synapse_dynamics,
-                self._app_vertex.weight_scale, weight_scales)
+                self.app_vertex.weight_scale, weight_scales)
         elif self._synapse_references.synapse_dynamics is not None:
             # If there is a reference for this region, we have to create it!
             spec.reserve_memory_region(
@@ -168,7 +168,7 @@ class PopulationMachineSynapses(
                 reference=self._synapse_references.structural_dynamics)
             synapse_dynamics.write_structural_parameters(
                 spec, self._synapse_regions.structural_dynamics,
-                weight_scales, self._app_vertex, self._vertex_slice,
+                weight_scales, self.app_vertex, self.vertex_slice,
                 self._synaptic_matrices)
         elif self._synapse_references.structural_dynamics is not None:
             # If there is a reference for this region, we have to create it!
@@ -189,7 +189,7 @@ class PopulationMachineSynapses(
         # Reserve space
         spec.reserve_memory_region(
             region=self._synapse_regions.synapse_params,
-            size=self._app_vertex.get_synapse_params_size(),
+            size=self.app_vertex.get_synapse_params_size(),
             label='SynapseParams',
             reference=self._synapse_references.synapse_params)
 
@@ -197,8 +197,8 @@ class PopulationMachineSynapses(
         n_neurons = self._max_atoms_per_core
         # We only count neuron synapse types here, as this is related to
         # the ring buffers
-        n_synapse_types = self._app_vertex.neuron_impl.get_n_synapse_types()
-        max_delay = self._app_vertex.splitter.max_support_delay()
+        n_synapse_types = self.app_vertex.neuron_impl.get_n_synapse_types()
+        max_delay = self.app_vertex.splitter.max_support_delay()
 
         # Write synapse parameters
         spec.switch_write_focus(self._synapse_regions.synapse_params)
@@ -207,8 +207,8 @@ class PopulationMachineSynapses(
         spec.write_value(get_n_bits(n_neurons))
         spec.write_value(get_n_bits(n_synapse_types))
         spec.write_value(get_n_bits(max_delay))
-        spec.write_value(int(self._app_vertex.drop_late_spikes))
-        spec.write_value(self._app_vertex.incoming_spike_buffer_size)
+        spec.write_value(int(self.app_vertex.drop_late_spikes))
+        spec.write_value(self.app_vertex.incoming_spike_buffer_size)
         spec.write_array(ring_buffer_shifts)
 
     @overrides(AbstractSynapseExpandable.gen_on_machine)

--- a/spynnaker/pyNN/models/neuron/population_machine_synapses_provenance.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_synapses_provenance.py
@@ -67,18 +67,6 @@ class PopulationMachineSynapsesProvenance(object):
     LATE_SPIKES = "Late spikes"
     MAX_LATE_SPIKE = "Max late spike"
 
-    @abstractproperty
-    def _app_vertex(self):
-        """
-        The application vertex of the machine vertex.
-
-        .. note::
-            This is likely to be available via the
-            :py:class:`~pacman.model.graphs.machine.MachineVertex`.
-
-        :rtype: AbstractPopulationVertex
-        """
-
     def _parse_synapse_provenance(self, label,  x, y, p, provenance_data):
         """
         Extract and yield synapse provenance.

--- a/spynnaker/pyNN/models/neuron/population_machine_synapses_provenance.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_synapses_provenance.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import ctypes
-from spinn_utilities.abstract_base import abstractproperty
 from spinn_front_end_common.interface.provenance import ProvenanceWriter
 
 

--- a/spynnaker/pyNN/models/neuron/population_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_vertex.py
@@ -402,4 +402,4 @@ class PopulationMachineVertex(
     @overrides(PopulationMachineCommon.get_n_keys_for_partition)
     def get_n_keys_for_partition(self, partition_id):
         n_colours = 2 ** self._app_vertex.n_colour_bits
-        return self._vertex_slice.n_atoms * n_colours
+        return self.vertex_slice.n_atoms * n_colours

--- a/spynnaker/pyNN/models/neuron/population_neurons_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_neurons_machine_vertex.py
@@ -300,4 +300,4 @@ class PopulationNeuronsMachineVertex(
     @overrides(PopulationMachineCommon.get_n_keys_for_partition)
     def get_n_keys_for_partition(self, partition_id):
         n_colours = 2 ** self._app_vertex.n_colour_bits
-        return self._vertex_slice.n_atoms * n_colours
+        return self.vertex_slice.n_atoms * n_colours

--- a/spynnaker/pyNN/models/spike_source/spike_source_array_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_machine_vertex.py
@@ -38,9 +38,9 @@ class SpikeSourceArrayMachineVertex(ReverseIPTagMulticastSourceMachineVertex):
         if first_time_step == end_time_step:
             return
         keys = get_field_based_keys(
-            key_base, self._vertex_slice, self.app_vertex.n_colour_bits)
+            key_base, self.vertex_slice, self.app_vertex.n_colour_bits)
         key_list = numpy.array(
-            [keys[atom] for atom in range(self._vertex_slice.n_atoms)])
+            [keys[atom] for atom in range(self.vertex_slice.n_atoms)])
         colour_mask = (2 ** self.app_vertex.n_colour_bits) - 1
         for tick in sorted(self._send_buffer_times):
             if self._is_in_range(tick, first_time_step, end_time_step):
@@ -54,9 +54,9 @@ class SpikeSourceArrayMachineVertex(ReverseIPTagMulticastSourceMachineVertex):
         if first_time_step == end_time_step:
             return
         keys = get_field_based_keys(
-            key_base, self._vertex_slice, self.app_vertex.n_colour_bits)
+            key_base, self.vertex_slice, self.app_vertex.n_colour_bits)
         colour_mask = (2 ** self.app_vertex.n_colour_bits) - 1
-        for atom in range(self._vertex_slice.n_atoms):
+        for atom in range(self.vertex_slice.n_atoms):
             for tick in sorted(self._send_buffer_times[atom]):
                 if self._is_in_range(tick, first_time_step, end_time_step):
                     self._send_buffer.add_key(

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -527,7 +527,7 @@ class SpikeSourcePoissonMachineVertex(
                 self.__poisson_rate_region_address(placement))
 
             # get size of poisson params
-            n_atoms = self._vertex_slice.n_atoms
+            n_atoms = self.vertex_slice.n_atoms
             n_rates = n_atoms * self._app_vertex.max_n_rates
             size_of_region = get_rates_bytes(n_atoms, n_rates)
 
@@ -538,8 +538,8 @@ class SpikeSourcePoissonMachineVertex(
 
             # For each atom, read the number of rates and the rate parameters
             offset = 0
-            for i in range(self._vertex_slice.lo_atom,
-                           self._vertex_slice.hi_atom + 1):
+            for i in range(self.vertex_slice.lo_atom,
+                           self.vertex_slice.hi_atom + 1):
                 n_rates, = _ONE_WORD.unpack_from(byte_array, offset)
                 # Skip the count and index
                 offset += PARAMS_WORDS_PER_NEURON * BYTES_PER_WORD
@@ -562,4 +562,4 @@ class SpikeSourcePoissonMachineVertex(
     @overrides(MachineVertex.get_n_keys_for_partition)
     def get_n_keys_for_partition(self, partition_id):
         n_colours = 2 ** self.app_vertex.n_colour_bits
-        return self._vertex_slice.n_atoms * n_colours
+        return self.vertex_slice.n_atoms * n_colours

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -280,7 +280,7 @@ class DelayExtensionMachineVertex(
                 break
 
         self.write_delay_parameters(
-            spec, self._vertex_slice, key, incoming_key, incoming_mask)
+            spec, self.vertex_slice, key, incoming_key, incoming_mask)
 
         # End-of-Spec:
         spec.end_specification()


### PR DESCRIPTION
PopulationMachineNeurons and PopulationMachineSynapses have @abstractproperty

_app_vertex and _vertex_slice

It picked these up from MachineVertex but not because MachineVertex implemented the properties but because these names where in MachineVertex's slots.
UGLY!

To make it worse Typing does not support @abstractproperty instead requiring  @property @abstractMethod.

So instead of also implementing _app_vertex and _vertex_slice better to use the unprotected methods!

The rest of the protected abstract are less of an issue as the Super classes of PopulationMachineNeurons implement these as methods already. 

PopulationMachineSynapsesProvenance also defined _app_vertex but never uses it!

PopulationMachineVertex could use the slots value (_vertex_slice) as it is a superclass but using the property is cleaner.