### PR TITLE
Typing and better errors for delay and weights

### DIFF
--- a/spynnaker/py.typed
+++ b/spynnaker/py.typed
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -354,7 +354,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
 
     def _get_distances(self, values: str, synapse_info):
         if self.__space is None:
-            raise self.delay_type_exception(values)
+            raise self._no_space_exception(values, synapse_info)
         expand_distances = self._expand_distances(values)
 
         return self.__space.distances(
@@ -397,7 +397,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
             f"{synapse_info.pre_population}-"
             f"{synapse_info.post_population}")
 
-    def weight_exception(self, weights: Weight_Types):
+    def weight_type_exception(self, weights: Weight_Types):
         """
         Returns an Exception explaining incorrect weight or delay type
 
@@ -488,7 +488,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif numpy.isscalar(values):
             return numpy.repeat([values], n_connections).astype("float64")
         if weights:
-            raise self.weight_exception(values)
+            raise self.weight_type_exception(values)
         else:
             raise self.delay_type_exception(values)
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -26,8 +26,8 @@ from spinn_utilities.safe_eval import SafeEval
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_front_end_common.interface.provenance import ProvenanceWriter
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
-    import Weight_Delay_Types
+from spynnaker.pyNN.types import (
+    Delay_Types, is_scalar, Weight_Delay_Types, Weight_Types)
 from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
@@ -99,7 +99,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         self.__min_delay = SpynnakerDataView.get_simulation_time_step_ms()
 
     def _get_delay_minimum(
-            self, delays: Weight_Delay_Types, n_connections: int,
+            self, delays: Delay_Types, n_connections: int,
             synapse_info) -> float:
         """
         Get the minimum delay given a float or RandomDistribution.
@@ -120,12 +120,12 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif isinstance(delays, str):
             d = self._get_distances(delays, synapse_info)
             return numpy.min(_expr_context.eval(delays, d=d))
-        elif numpy.isscalar(delays):
+        elif is_scalar(delays):
             return delays
         raise self.delay_type_exception(delays)
 
     def _get_delay_maximum(
-            self, delays: Weight_Delay_Types, n_connections, synapse_info):
+            self, delays: Delay_Types, n_connections, synapse_info):
         """
         Get the maximum delay given a float or RandomDistribution.
 
@@ -145,7 +145,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif isinstance(delays, str):
             d = self._get_distances(delays, synapse_info)
             return numpy.max(_expr_context.eval(delays, d=d))
-        elif numpy.isscalar(delays):
+        elif is_scalar(delays):
             return delays
         raise self.delay_type_exception(delays)
 
@@ -170,7 +170,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         """
 
     def get_delay_variance(
-            self, delays: Weight_Delay_Types, synapse_info):
+            self, delays: Delay_Types, synapse_info):
         """
         Get the variance of the delays.
 
@@ -183,12 +183,12 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif isinstance(delays, str):
             d = self._get_distances(delays, synapse_info)
             return numpy.var(_expr_context.eval(delays, d=d))
-        elif numpy.isscalar(delays):
+        elif is_scalar(delays):
             return 0.0
         raise self.delay_type_exception(delays)
 
     def _get_n_connections_from_pre_vertex_with_delay_maximum(
-            self, delays: Weight_Delay_Types, n_total_connections,
+            self, delays: Delay_Types, n_total_connections,
             n_connections, min_delay, max_delay, synapse_info):
         """
         Get the expected number of delays that will fall within min_delay and
@@ -226,7 +226,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
             prob_delayed = float(n_delayed) / float(n_total)
             return int(math.ceil(utility_calls.get_probable_maximum_selected(
                 n_total_connections, n_connections, prob_delayed)))
-        elif numpy.isscalar(delays):
+        elif is_scalar(delays):
             if min_delay <= delays <= max_delay:
                 return int(math.ceil(n_connections))
             return 0
@@ -262,7 +262,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         :rtype: int
         """
 
-    def get_weight_mean(self, weights: Weight_Delay_Types,  synapse_info):
+    def get_weight_mean(self, weights: Weight_Types,  synapse_info):
         """
         Get the mean of the weights.
 
@@ -275,11 +275,11 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif isinstance(weights, str):
             d = self._get_distances(weights, synapse_info)
             return numpy.mean(_expr_context.eval(weights, d=d))
-        elif numpy.isscalar(weights):
+        elif is_scalar(weights):
             return abs(weights)
         raise self.weight_type_exception(synapse_info)
 
-    def _get_weight_maximum(self, weights: Weight_Delay_Types,
+    def _get_weight_maximum(self, weights: Weight_Types,
                             n_connections, synapse_info):
         """
         Get the maximum of the weights.
@@ -308,7 +308,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif isinstance(weights, str):
             d = self._get_distances(weights, synapse_info)
             return numpy.max(_expr_context.eval(weights, d=d))
-        elif numpy.isscalar(weights):
+        elif is_scalar(weights):
             return abs(weights)
         raise self.weight_type_exception(weights)
 
@@ -321,7 +321,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         :rtype: float
         """
 
-    def get_weight_variance(self, weights: Weight_Delay_Types, synapse_info):
+    def get_weight_variance(self, weights: Weight_Types, synapse_info):
         """
         Get the variance of the weights.
 
@@ -334,7 +334,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         elif isinstance(weights, str):
             d = self._get_distances(weights, synapse_info)
             return numpy.var(_expr_context.eval(weights, d=d))
-        elif numpy.isscalar(weights):
+        elif is_scalar(weights):
             return 0.0
         raise self.weight_type_exception(weights)
 
@@ -397,11 +397,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
             f"{synapse_info.pre_population}-"
             f"{synapse_info.post_population}")
 
-    def weight_delay_type_exception(
-            self, values: Weight_Delay_Types, synapse_info):
-        pass
-
-    def weight_exception(self, weights: Weight_Delay_Types):
+    def weight_exception(self, weights: Weight_Types):
         """
         Returns an Exception explaining incorrect weight or delay type
 
@@ -426,7 +422,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         else:
             return SpynnakerException(f"Unrecognised weight or delay {weights}")
 
-    def delay_type_exception(self, delays: Weight_Delay_Types):
+    def delay_type_exception(self, delays: Delay_Types):
         """
         Returns an Exception explaining incorrect delay type
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -18,7 +18,6 @@ import re
 import numpy
 from numpy import float64
 from numpy.typing import NDArray
-from typing import TYPE_CHECKING
 from spinn_utilities.log import FormatAdapter
 from pyNN.random import NumpyRNG, RandomDistribution
 
@@ -263,7 +262,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         :rtype: int
         """
 
-    def get_weight_mean(self, weights, synapse_info):
+    def get_weight_mean(self, weights: Weight_Delay_Types,  synapse_info):
         """
         Get the mean of the weights.
 
@@ -278,9 +277,10 @@ class AbstractConnector(object, metaclass=AbstractBase):
             return numpy.mean(_expr_context.eval(weights, d=d))
         elif numpy.isscalar(weights):
             return abs(weights)
-        raise SpynnakerException("Unrecognised weight format")
+        raise self.weight_delay_type_exception(weights, synapse_info)
 
-    def _get_weight_maximum(self, weights, n_connections, synapse_info):
+    def _get_weight_maximum(self, weights: Weight_Delay_Types,
+                            n_connections, synapse_info):
         """
         Get the maximum of the weights.
 
@@ -310,7 +310,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
             return numpy.max(_expr_context.eval(weights, d=d))
         elif numpy.isscalar(weights):
             return abs(weights)
-        raise SpynnakerException("Unrecognised weight format")
+        raise self.weight_delay_type_exception(weights, synapse_info)
 
     @abstractmethod
     def get_weight_maximum(self, synapse_info):
@@ -321,7 +321,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         :rtype: float
         """
 
-    def get_weight_variance(self, weights, synapse_info):
+    def get_weight_variance(self, weights: Weight_Delay_Types, synapse_info):
         """
         Get the variance of the weights.
 
@@ -336,7 +336,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
             return numpy.var(_expr_context.eval(weights, d=d))
         elif numpy.isscalar(weights):
             return 0.0
-        raise SpynnakerException("Unrecognised weight format")
+        raise self.weight_delay_type_exception(weights, synapse_info)
 
     def _expand_distances(self, d_expression):
         """

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -420,7 +420,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
                 f"list or arrays for weight."
                 f"Please use a FromListConnector instead")
         else:
-            return SpynnakerException(f"Unrecognised weight or delay {weights}")
+            return SpynnakerException(f"Unrecognised weight {weights}")
 
     def delay_type_exception(self, delays: Delay_Types):
         """
@@ -441,7 +441,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
                 f"list or arrays for weight or delay."
                 f"Please use a FromListConnector instead")
         else:
-            return SpynnakerException(f"Unrecognised weight or delay {delays}")
+            return SpynnakerException(f"Unrecognised delay {delays}")
 
     def _generate_values(
             self, values: Weight_Delay_Types, sources, targets, n_connections,

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -33,10 +33,6 @@ from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
-if TYPE_CHECKING:
-    from spynnaker.pyNN.models.neural_projections import (
-        SynapseInformation)
-
 # global objects
 logger = FormatAdapter(logging.getLogger(__name__))
 _expr_context = SafeEval(
@@ -193,8 +189,8 @@ class AbstractConnector(object, metaclass=AbstractBase):
         raise self.weight_delay_type_exception(delays, synapse_info)
 
     def _get_n_connections_from_pre_vertex_with_delay_maximum(
-            self, delays: Weight_Delay_Types, n_total_connections, n_connections,
-            min_delay, max_delay, synapse_info):
+            self, delays: Weight_Delay_Types, n_total_connections,
+            n_connections, min_delay, max_delay, synapse_info):
         """
         Get the expected number of delays that will fall within min_delay and
         max_delay given given a float, RandomDistribution or list of delays.

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -27,7 +27,8 @@ from spinn_utilities.safe_eval import SafeEval
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_front_end_common.interface.provenance import ProvenanceWriter
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.models.neuron.synapse_dynamics import Weight_Delay_Types
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
@@ -22,7 +22,8 @@ from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.common.param_generator_data import (
     param_generator_params, param_generator_params_size_in_bytes,
     param_generator_id, is_param_generatable)
-from spynnaker.pyNN.models.neuron.synapse_dynamics import Weight_Delay_Types
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
 from pyNN.random import RandomDistribution

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
@@ -22,8 +22,7 @@ from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.common.param_generator_data import (
     param_generator_params, param_generator_params_size_in_bytes,
     param_generator_id, is_param_generatable)
-from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
-    import Weight_Delay_Types
+from spynnaker.pyNN.types import (Delay_Types, Weight_Types)
 from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
 from pyNN.random import RandomDistribution
@@ -61,7 +60,7 @@ class AbstractGenerateConnectorOnMachine(
                     " be generated on host!")
 
     def generate_on_machine(
-            self, weights: Weight_Delay_Types, delays: Weight_Delay_Types):
+            self, weights: Weight_Types, delays: Delay_Types):
         """
         Determine if this instance can generate on the machine.
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_generate_connector_on_machine.py
@@ -22,6 +22,7 @@ from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.common.param_generator_data import (
     param_generator_params, param_generator_params_size_in_bytes,
     param_generator_id, is_param_generatable)
+from spynnaker.pyNN.models.neuron.synapse_dynamics import Weight_Delay_Types
 from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
 from pyNN.random import RandomDistribution
@@ -58,7 +59,8 @@ class AbstractGenerateConnectorOnMachine(
                     " generated on the machine, but the connector cannot"
                     " be generated on host!")
 
-    def generate_on_machine(self, weights, delays):
+    def generate_on_machine(
+            self, weights: Weight_Delay_Types, delays: Weight_Delay_Types):
         """
         Determine if this instance can generate on the machine.
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/connection_types.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/connection_types.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Types (and related) that are useful for implementing connectors.
+"""
+
+import numpy
+from numpy.typing import NDArray
+from pyNN.random import RandomDistribution
+import pyNN
+from typing import Union
+from typing_extensions import TypeAlias, TypeGuard
+#: The type of weights and delays provided by
+D: TypeAlias = Union[pyNN.random.RandomDistribution, int, float, str]
+Weight_Delay_Types: TypeAlias = \
+    Union[float, str, RandomDistribution, NDArray[numpy.float64]]
+
+
+def is_scalar(value: Weight_Delay_Types) -> TypeGuard[Union[int, float]]:
+    """
+    Are the weights or delays a simple integer or float?
+    """
+    return numpy.isscalar(value)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -16,8 +16,7 @@ import numpy
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.exceptions import InvalidParameterType
-from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
-    import Weight_Delay_Types
+from spynnaker.pyNN.types import Weight_Types
 from .abstract_connector import AbstractConnector
 from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
@@ -250,10 +249,10 @@ class FromListConnector(AbstractConnector, AbstractGenerateConnectorOnHost):
             return numpy.amax(numpy.abs(self.__weights))
 
     @overrides(AbstractConnector.get_weight_variance)
-    def get_weight_variance(self, weights: Weight_Delay_Types, synapse_info):
+    def get_weight_variance(self, weights: Weight_Types, synapse_info):
         # pylint: disable=too-many-arguments
         if self.__weights is None:
-            if hasattr(synapse_info.weights, "__len__"):
+            if isinstance(synapse_info.weights, numpy.ndarray):
                 return numpy.var(synapse_info.weights)
             return AbstractConnector.get_weight_variance(
                 self, weights, synapse_info)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -16,6 +16,8 @@ import numpy
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.exceptions import InvalidParameterType
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from .abstract_connector import AbstractConnector
 from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
@@ -248,7 +250,7 @@ class FromListConnector(AbstractConnector, AbstractGenerateConnectorOnHost):
             return numpy.amax(numpy.abs(self.__weights))
 
     @overrides(AbstractConnector.get_weight_variance)
-    def get_weight_variance(self, weights, synapse_info):
+    def get_weight_variance(self, weights: Weight_Delay_Types, synapse_info):
         # pylint: disable=too-many-arguments
         if self.__weights is None:
             if hasattr(synapse_info.weights, "__len__"):

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -21,7 +21,8 @@ from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from pyNN.random import RandomDistribution
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.models.neuron.synapse_dynamics import Weight_Delay_Types
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from .abstract_generate_connector_on_machine import (
     AbstractGenerateConnectorOnMachine, ConnectorIDs)
 from .abstract_generate_connector_on_host import (
@@ -218,7 +219,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
         c = ((pre_c - self._pre_start_w - 1) // self._pre_step_w) + 1
         return (r, c)
 
-    def __get_kernel_vals(self, vals: Union[_Kernel, Weight_Delay_Types]):
+    def __get_kernel_vals(self, vals):
         """
         Convert kernel values given into the correct format.
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -399,7 +399,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
             weights, synapse_info)
 
     @overrides(AbstractConnector.get_weight_variance)
-    def get_weight_variance(self, weights, synapse_info):
+    def get_weight_variance(self, weights: Weight_Delay_Types, synapse_info):
         # Use the kernel weights if user has supplied them
         if self._krn_weights is not None:
             return numpy.var(self._krn_weights)

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -21,8 +21,7 @@ from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from pyNN.random import RandomDistribution
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
-    import Weight_Delay_Types
+from spynnaker.pyNN.types import (Delay_Types, Weight_Delay_Types, Weight_Types)
 from .abstract_generate_connector_on_machine import (
     AbstractGenerateConnectorOnMachine, ConnectorIDs)
 from .abstract_generate_connector_on_host import (
@@ -250,7 +249,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
             f"{self._kernel_h} and width: {self._kernel_w}).")
 
     def __compute_statistics(
-            self, weights: Weight_Delay_Types, delays: Weight_Delay_Types,
+            self, weights: Weight_Types, delays: Delay_Types,
             post_vertex_slice, n_pre_neurons):
         """
         Compute the relevant information required for the connections.
@@ -399,7 +398,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
             weights, synapse_info)
 
     @overrides(AbstractConnector.get_weight_variance)
-    def get_weight_variance(self, weights: Weight_Delay_Types, synapse_info):
+    def get_weight_variance(self, weights: Weight_Types, synapse_info):
         # Use the kernel weights if user has supplied them
         if self._krn_weights is not None:
             return numpy.var(self._krn_weights)

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import numpy
 from numpy.typing import NDArray
-from typing import List, Union, TYPE_CHECKING
+from typing import List, Union
 from typing_extensions import TypeAlias
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.interface.ds import DataType
@@ -60,7 +60,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
 
     def __init__(
             self, shape_pre, shape_post, shape_kernel,
-            weight_kernel: _Kernel = None, delay_kernel: _Kernel =None,
+            weight_kernel: _Kernel = None, delay_kernel: _Kernel = None,
             shape_common=None,
             pre_sample_steps_in_post=None, pre_start_coords_in_post=None,
             post_sample_steps_in_pre=None, post_start_coords_in_pre=None,

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -29,9 +29,8 @@ from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
-if TYPE_CHECKING:
-    _Kernel: TypeAlias = Union[
-        float, int, List[float], NDArray[numpy.floating], RandomDistribution]
+_Kernel: TypeAlias = Union[
+    float, int, List[float], NDArray[numpy.floating], RandomDistribution]
 
 HEIGHT, WIDTH = 0, 1
 N_KERNEL_PARAMS = 8
@@ -60,8 +59,9 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
     """
 
     def __init__(
-            self, shape_pre, shape_post, shape_kernel, weight_kernel=None,
-            delay_kernel=None, shape_common=None,
+            self, shape_pre, shape_post, shape_kernel,
+            weight_kernel: _Kernel = None, delay_kernel: _Kernel =None,
+            shape_common=None,
             pre_sample_steps_in_post=None, pre_start_coords_in_post=None,
             post_sample_steps_in_pre=None, post_start_coords_in_pre=None,
             safe=True, space=None, verbose=False, callback=None):
@@ -219,7 +219,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
         c = ((pre_c - self._pre_start_w - 1) // self._pre_step_w) + 1
         return (r, c)
 
-    def __get_kernel_vals(self, vals):
+    def __get_kernel_vals(self, vals: Union[_Kernel, Weight_Delay_Types]):
         """
         Convert kernel values given into the correct format.
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -12,17 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy
+from numpy.typing import NDArray
+from typing import List, Union, TYPE_CHECKING
+from typing_extensions import TypeAlias
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.interface.ds import DataType
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from pyNN.random import RandomDistribution
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.exceptions import SpynnakerException
+from spynnaker.pyNN.models.neuron.synapse_dynamics import Weight_Delay_Types
 from .abstract_generate_connector_on_machine import (
     AbstractGenerateConnectorOnMachine, ConnectorIDs)
 from .abstract_generate_connector_on_host import (
     AbstractGenerateConnectorOnHost)
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
+
+if TYPE_CHECKING:
+    _Kernel: TypeAlias = Union[
+        float, int, List[float], NDArray[numpy.floating], RandomDistribution]
 
 HEIGHT, WIDTH = 0, 1
 N_KERNEL_PARAMS = 8
@@ -210,7 +218,7 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
         c = ((pre_c - self._pre_start_w - 1) // self._pre_step_w) + 1
         return (r, c)
 
-    def __get_kernel_vals(self, vals):
+    def __get_kernel_vals(self, vals: Union[_Kernel, Weight_Delay_Types]):
         """
         Convert kernel values given into the correct format.
 
@@ -241,7 +249,8 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
             f"{self._kernel_h} and width: {self._kernel_w}).")
 
     def __compute_statistics(
-            self, weights, delays, post_vertex_slice, n_pre_neurons):
+            self, weights: Weight_Delay_Types, delays: Weight_Delay_Types,
+            post_vertex_slice, n_pre_neurons):
         """
         Compute the relevant information required for the connections.
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -21,7 +21,8 @@ from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from pyNN.random import RandomDistribution
 from .abstract_connector import AbstractConnector
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.types import (Delay_Types, Weight_Delay_Types, Weight_Types)
+from spynnaker.pyNN.types import (
+    Delay_Types, Weight_Delay_Types, Weight_Types)
 from .abstract_generate_connector_on_machine import (
     AbstractGenerateConnectorOnMachine, ConnectorIDs)
 from .abstract_generate_connector_on_host import (

--- a/spynnaker/pyNN/models/neural_projections/synapse_information.py
+++ b/spynnaker/pyNN/models/neural_projections/synapse_information.py
@@ -16,7 +16,8 @@ from spinn_utilities.config_holder import get_config_bool
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractGenerateConnectorOnMachine, OneToOneConnector)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
-    AbstractGenerateOnMachine, SynapseDynamicsStatic, Weight_Delay_Types)
+    AbstractGenerateOnMachine, SynapseDynamicsStatic)
+from spynnaker.pyNN.types import (Delay_Types, Weight_Types)
 
 
 class SynapseInformation(object):
@@ -41,7 +42,7 @@ class SynapseInformation(object):
     def __init__(self, connector, pre_population, post_population,
                  prepop_is_view, postpop_is_view, synapse_dynamics,
                  synapse_type, receptor_type, synapse_type_from_dynamics,
-                 weights: Weight_Delay_Types, delays: Weight_Delay_Types):
+                 weights: Weight_Types, delays: Delay_Types):
         """
         :param AbstractConnector connector:
             The connector connected to the synapse
@@ -174,7 +175,7 @@ class SynapseInformation(object):
         return self.__receptor_type
 
     @property
-    def weights(self) -> Weight_Delay_Types:
+    def weights(self) -> Weight_Types:
         """
         The synaptic weights (if any).
 
@@ -183,7 +184,7 @@ class SynapseInformation(object):
         return self.__weights
 
     @property
-    def delays(self) -> Weight_Delay_Types:
+    def delays(self) -> Delay_Types:
         """
         The total synaptic delays (if any).
 

--- a/spynnaker/pyNN/models/neural_projections/synapse_information.py
+++ b/spynnaker/pyNN/models/neural_projections/synapse_information.py
@@ -16,7 +16,7 @@ from spinn_utilities.config_holder import get_config_bool
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractGenerateConnectorOnMachine, OneToOneConnector)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
-    AbstractGenerateOnMachine, SynapseDynamicsStatic)
+    AbstractGenerateOnMachine, SynapseDynamicsStatic, Weight_Delay_Types)
 
 
 class SynapseInformation(object):
@@ -41,7 +41,7 @@ class SynapseInformation(object):
     def __init__(self, connector, pre_population, post_population,
                  prepop_is_view, postpop_is_view, synapse_dynamics,
                  synapse_type, receptor_type, synapse_type_from_dynamics,
-                 weights=None, delays=None):
+                 weights: Weight_Delay_Types, delays: Weight_Delay_Types):
         """
         :param AbstractConnector connector:
             The connector connected to the synapse
@@ -72,6 +72,8 @@ class SynapseInformation(object):
         self.__synapse_dynamics = synapse_dynamics
         self.__synapse_type = synapse_type
         self.__receptor_type = receptor_type
+        assert (weights is not None)
+        assert (delays is not None)
         self.__weights = weights
         self.__delays = delays
         self.__synapse_type_from_dynamics = synapse_type_from_dynamics
@@ -172,20 +174,20 @@ class SynapseInformation(object):
         return self.__receptor_type
 
     @property
-    def weights(self):
+    def weights(self) -> Weight_Delay_Types:
         """
         The synaptic weights (if any).
 
-        :rtype: float or list(float) or ~numpy.ndarray(float) or None
+        :rtype: float or ~numpy.ndarray(float64) or str or RandomDistribution
         """
         return self.__weights
 
     @property
-    def delays(self):
+    def delays(self) -> Weight_Delay_Types:
         """
         The total synaptic delays (if any).
 
-        :rtype: float or list(float) or ~numpy.ndarray(float) or None
+        :rtype: float or ~numpy.ndarray(float64) or str or RandomDistribution
         """
         return self.__delays
 

--- a/spynnaker/pyNN/models/neural_projections/synapse_information.py
+++ b/spynnaker/pyNN/models/neural_projections/synapse_information.py
@@ -73,7 +73,6 @@ class SynapseInformation(object):
         self.__synapse_dynamics = synapse_dynamics
         self.__synapse_type = synapse_type
         self.__receptor_type = receptor_type
-        assert (weights is not None)
         assert (delays is not None)
         self.__weights = weights
         self.__delays = delays

--- a/spynnaker/pyNN/models/neuron/local_only/abstract_local_only.py
+++ b/spynnaker/pyNN/models/neuron/local_only/abstract_local_only.py
@@ -22,6 +22,14 @@ class AbstractLocalOnly(AbstractSynapseDynamics):
     Processes synapses locally without the need for SDRAM.
     """
 
+    def __init__(self, delay=None):
+        """
+        :param float delay:
+            The delay used in the connection; by default 1 time step
+        """
+        # We don't have a weight here, it is in the connector
+        super().__init__(delay=delay, weight=0)
+
     @abstractmethod
     def get_parameters_usage_in_bytes(
             self, n_atoms, incoming_projections):

--- a/spynnaker/pyNN/models/neuron/local_only/abstract_local_only.py
+++ b/spynnaker/pyNN/models/neuron/local_only/abstract_local_only.py
@@ -15,6 +15,7 @@ from spinn_utilities.abstract_base import abstractmethod
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     AbstractSynapseDynamics)
+from spynnaker.pyNN.types import Weight_Delay_In_Types
 
 
 class AbstractLocalOnly(AbstractSynapseDynamics):
@@ -22,13 +23,13 @@ class AbstractLocalOnly(AbstractSynapseDynamics):
     Processes synapses locally without the need for SDRAM.
     """
 
-    def __init__(self, delay=None):
+    def __init__(self, delay: Weight_Delay_In_Types):
         """
         :param float delay:
             The delay used in the connection; by default 1 time step
         """
         # We don't have a weight here, it is in the connector
-        super().__init__(delay=delay, weight=0)
+        super().__init__(delay=delay, weight=None)
 
     @abstractmethod
     def get_parameters_usage_in_bytes(

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
@@ -23,6 +23,7 @@ from spynnaker.pyNN.models.neural_projections.connectors import (
     ConvolutionConnector)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     AbstractSupportsSignedWeights)
+from spynnaker.pyNN.types import Weight_Delay_In_Types
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from .abstract_local_only import AbstractLocalOnly
 
@@ -45,7 +46,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
         "__cached_n_incoming"
     ]
 
-    def __init__(self, delay=None):
+    def __init__(self, delay: Weight_Delay_In_Types = None):
         """
         :param float delay:
             The delay used in the connection; by default 1 time step

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
@@ -31,19 +31,17 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
     A convolution synapse dynamics that can process spikes with only DTCM.
     """
 
-    __slots__ = ["__delay"]
+    __slots__ = []
 
     def __init__(self, delay=None):
         """
         :param float delay:
             The delay used in the connection; by default 1 time step
         """
-        self.__delay = delay
-        if delay is None:
-            self.__delay = SpynnakerDataView.get_simulation_time_step_ms()
-        elif not isinstance(delay, (float, int)):
+        if delay is not None and not isinstance(self.delay, (float, int)):
             raise SynapticConfigurationException(
                 "Only single value delays are supported")
+        super().__init__(delay)
 
     @overrides(AbstractLocalOnly.merge)
     def merge(self, synapse_dynamics):
@@ -99,7 +97,7 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
             seen_pre_vertices.add(app_edge.pre_vertex)
 
             delay_vertex = None
-            if self.__delay > app_vertex.splitter.max_support_delay():
+            if self.delay > app_vertex.splitter.max_support_delay():
                 # pylint: disable=protected-access
                 delay_vertex = incoming._projection_edge.delay_edge.pre_vertex
 
@@ -165,17 +163,6 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
             source.vertex_slice)
         return routing_info.get_routing_info_from_pre_vertex(
             delay_source, SPIKE_PARTITION_ID)
-
-    @property
-    @overrides(AbstractLocalOnly.delay)
-    def delay(self):
-        return self.__delay
-
-    @property
-    @overrides(AbstractLocalOnly.weight)
-    def weight(self):
-        # We don't have a weight here, it is in the connector
-        return 0
 
     @overrides(AbstractSupportsSignedWeights.get_positive_synapse_index)
     def get_positive_synapse_index(self, incoming_projection):

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
@@ -34,7 +34,7 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
     __slots__ = []
 
-    def __init__(self, delay: Weight_Delay_In_Types =None):
+    def __init__(self, delay: Weight_Delay_In_Types = None):
         """
         :param float delay:
             The delay used in the connection; by default 1 time step

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
@@ -22,6 +22,7 @@ from spynnaker.pyNN.models.neural_projections.connectors import (
     PoolDenseConnector)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     AbstractSupportsSignedWeights)
+from spynnaker.pyNN.types import Weight_Delay_In_Types
 from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from .abstract_local_only import AbstractLocalOnly
 
@@ -33,7 +34,7 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
     __slots__ = []
 
-    def __init__(self, delay=None):
+    def __init__(self, delay: Weight_Delay_In_Types =None):
         """
         :param float delay:
             The delay used in the connection; by default 1 time step

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .abstract_synapse_dynamics import AbstractSynapseDynamics
+from .abstract_synapse_dynamics import (
+    AbstractSynapseDynamics, Weight_Delay_Types)
 from .abstract_sdram_synapse_dynamics import AbstractSDRAMSynapseDynamics
 from .abstract_generate_on_machine import AbstractGenerateOnMachine
 from .abstract_synapse_dynamics_structural import (
@@ -44,5 +45,5 @@ __all__ = ["AbstractGenerateOnMachine", "AbstractPlasticSynapseDynamics",
            "SynapseDynamicsStructuralStatic",
            "SynapseDynamicsStructuralSTDP",
            # Neuromodulation
-           "SynapseDynamicsNeuromodulation",
+           "SynapseDynamicsNeuromodulation", "Weight_Delay_Types",
            "AbstractSupportsSignedWeights"]

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .abstract_synapse_dynamics import (
-    AbstractSynapseDynamics, Weight_Delay_Types)
+from .abstract_synapse_dynamics import AbstractSynapseDynamics
 from .abstract_sdram_synapse_dynamics import AbstractSDRAMSynapseDynamics
 from .abstract_generate_on_machine import AbstractGenerateOnMachine
 from .abstract_synapse_dynamics_structural import (
@@ -45,5 +44,5 @@ __all__ = ["AbstractGenerateOnMachine", "AbstractPlasticSynapseDynamics",
            "SynapseDynamicsStructuralStatic",
            "SynapseDynamicsStructuralSTDP",
            # Neuromodulation
-           "SynapseDynamicsNeuromodulation", "Weight_Delay_Types",
+           "SynapseDynamicsNeuromodulation",
            "AbstractSupportsSignedWeights"]

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -29,7 +29,6 @@ from spynnaker.pyNN.exceptions import InvalidParameterType
 logger = FormatAdapter(logging.getLogger(__name__))
 
 
-
 class AbstractSynapseDynamics(object, metaclass=AbstractBase):
     """
     How do the dynamics of a synapse interact with the rest of the model.

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -18,12 +18,13 @@ import numpy
 from typing import Iterable, Optional, Union
 from typing_extensions import TypeAlias
 from numpy import float64
-from numpy.typing import NDArray
 from pyNN.random import RandomDistribution
 from spinn_utilities.abstract_base import (
     AbstractBase, abstractmethod, abstractproperty)
 from spinn_utilities.log import FormatAdapter
 from spynnaker.pyNN.data import SpynnakerDataView
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from spynnaker.pyNN.utilities.constants import POP_TABLE_MAX_ROW_LENGTH
 from spynnaker.pyNN.exceptions import InvalidParameterType
 
@@ -31,8 +32,6 @@ logger = FormatAdapter(logging.getLogger(__name__))
 
 In_Types: TypeAlias = \
     Union[int, float, str, RandomDistribution, Iterable[Union[int, float]]]
-Weight_Delay_Types: TypeAlias = \
-    Union[float, str, RandomDistribution, NDArray[float64]]
 
 
 class AbstractSynapseDynamics(object, metaclass=AbstractBase):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -32,7 +32,7 @@ logger = FormatAdapter(logging.getLogger(__name__))
 In_Types: TypeAlias = \
     Union[int, float, str, RandomDistribution, Iterable[Union[int, float]]]
 Weight_Types = In_Types
-Out_Types: TypeAlias = Union[float, str, RandomDistribution]
+Out_Types: TypeAlias = Union[float, str, RandomDistribution, NDArray[float64]]
 
 
 class AbstractSynapseDynamics(object, metaclass=AbstractBase):
@@ -74,14 +74,15 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
     def __check_out_type(self, value, name):
         if isinstance(value, (float, (str, RandomDistribution))):
             return
-        if isinstance(value, list):
+        if isinstance(value, numpy.ndarray):
             for x in value:
-                if not isinstance(x, (float)):
+                if not isinstance(x, (float64)):
                     raise TypeError(
-                        f"Unexpected list of type  {type(x)} for {name}")
+                        f"Unexpected numpy ndarray of type {type(x)}"
+                        f" for {name}")
             return
         raise TypeError(
-            f"Unexpected type for output data: {type(name)} for {name} "
+            f"Unexpected type for output data: {type(value)} for {name} "
             "Expected types are float, str, RandomDistribution "
             "and list of type float")
 
@@ -141,7 +142,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         if isinstance(new_delay, float64):
             return float(new_delay)
         if isinstance(new_delay, numpy.ndarray):
-            return new_delay.tolist()
+            return new_delay # .tolist()
         raise TypeError("{tpye(new_delay)=")
 
     def _convert_weight(self, weight: In_Types) -> Out_Types:
@@ -156,7 +157,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         if isinstance(weight, (int, float)):
             return float(weight)
         new_weight = numpy.array(weight, dtype=float)
-        return new_weight.tolist()
+        return new_weight #.tolist()
 
     @property
     def delay(self) -> Out_Types:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -31,7 +31,11 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
     How do the dynamics of a synapse interact with the rest of the model.
     """
 
-    __slots__ = ()
+    __slots__ = ("__delay", "__weight")
+
+    def __init(self, delay, weight):
+        self.__delay = self._round_delay(delay)
+        self.__weight = weight
 
     @abstractmethod
     def merge(self, synapse_dynamics):
@@ -66,6 +70,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
 
         :rtype: float
         """
+        return self.__weight
 
     def _round_delay(self, delay):
         """
@@ -76,6 +81,8 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         :param delay:
         :return: Rounded delay
         """
+        if delay is None:
+            return SpynnakerDataView.get_min_delay()
         if isinstance(delay, RandomDistribution):
             return delay
         if isinstance(delay, str):
@@ -89,13 +96,13 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
                            self, delay, new_delay)
         return new_delay
 
-    @abstractproperty
     def delay(self):
         """
         The delay of connections.
 
         :rtype: float
         """
+        return self.__delay
 
     @abstractproperty
     def is_combined_core_capable(self):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -62,7 +62,6 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
             "Expected types are int, float, str, RandomDistribution "
             "and collections of type int or float")
 
-
     @abstractmethod
     def merge(self, synapse_dynamics):
         """

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -33,7 +33,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
 
     __slots__ = ("__delay", "__weight")
 
-    def __init(self, delay, weight):
+    def __init__(self, delay, weight):
         self.__delay = self._round_delay(delay)
         self.__weight = weight
 
@@ -63,7 +63,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         :rtype: bool
         """
 
-    @abstractproperty
+    @property
     def weight(self):
         """
         The weight of connections.
@@ -96,6 +96,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
                            self, delay, new_delay)
         return new_delay
 
+    @property
     def delay(self):
         """
         The delay of connections.

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -37,20 +37,31 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         if delay is None:
             if delay is None:
                 delay = SpynnakerDataView.get_min_delay()
-        if not isinstance(delay, (int, float, str, RandomDistribution)):
-            raise TypeError(
-                f"Unexpected type for delay: {type(delay)}. "
-                "Expected types are int, float, str and RandomDistribution")
+        self.__check_type(delay, "delay")
         self.__delay = self._round_delay(delay)
-        if not isinstance(self.__delay, (int, float, str, RandomDistribution)):
-            raise TypeError(
-                f"Unexpected type for delay: {type(self.__delay)}. "
-                "Expected types are int, float, str and RandomDistribution")
-        if not isinstance(weight, (int, float, str, RandomDistribution)):
-            raise TypeError(
-                f"Unexpected type for weight: {type(weight)}. "
-                "Expected types are int, float, str and RandomDistribution")
+        self.__check_type(weight, "weight")
         self.__weight = weight
+
+    def __check_type(self, value, name):
+        if isinstance(value, (int, float, str, RandomDistribution)):
+            return
+        try:
+            for x in value:
+                if isinstance(x, (int, float)):
+                    # assume if first in list colelction is ok all are
+                    return
+                else:
+                    raise TypeError(
+                        f"Unexpected collection of type  {type(x)} for {name}"
+                        f"Expected types in collection are int and float")
+        except TypeError:
+            # Ok not a collection
+            pass
+        raise TypeError(
+            f"Unexpected type for {name}: {type(value)}. "
+            "Expected types are int, float, str, RandomDistribution "
+            "and collections of type int or float")
+
 
     @abstractmethod
     def merge(self, synapse_dynamics):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -251,7 +251,8 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         """
         return connector.get_weight_maximum(synapse_info)
 
-    def get_weight_variance(self, connector, weights, synapse_info):
+    def get_weight_variance(
+            self, connector, weights: Weight_Delay_Types, synapse_info):
         """
         Get the variance in weight for the synapses.
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -142,8 +142,8 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         if isinstance(new_delay, float64):
             return float(new_delay)
         if isinstance(new_delay, numpy.ndarray):
-            return new_delay # .tolist()
-        raise TypeError("{tpye(new_delay)=")
+            return new_delay
+        raise TypeError(f"{type(delay)=}")
 
     def _convert_weight(self, weight: In_Types) -> Out_Types:
         """
@@ -157,7 +157,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         if isinstance(weight, (int, float)):
             return float(weight)
         new_weight = numpy.array(weight, dtype=float)
-        return new_weight #.tolist()
+        return new_weight
 
     @property
     def delay(self) -> Out_Types:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -34,7 +34,22 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
     __slots__ = ("__delay", "__weight")
 
     def __init__(self, delay, weight):
+        if delay is None:
+            if delay is None:
+                delay = SpynnakerDataView.get_min_delay()
+        if not isinstance(delay, (int, float, str, RandomDistribution)):
+            raise TypeError(
+                f"Unexpected type for delay: {type(delay)}. "
+                "Expected types are int, float, str and RandomDistribution")
         self.__delay = self._round_delay(delay)
+        if not isinstance(self.__delay, (int, float, str, RandomDistribution)):
+            raise TypeError(
+                f"Unexpected type for delay: {type(self.__delay)}. "
+                "Expected types are int, float, str and RandomDistribution")
+        if not isinstance(weight, (int, float, str, RandomDistribution)):
+            raise TypeError(
+                f"Unexpected type for weight: {type(weight)}. "
+                "Expected types are int, float, str and RandomDistribution")
         self.__weight = weight
 
     @abstractmethod
@@ -81,8 +96,6 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         :param delay:
         :return: Rounded delay
         """
-        if delay is None:
-            return SpynnakerDataView.get_min_delay()
         if isinstance(delay, RandomDistribution):
             return delay
         if isinstance(delay, str):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -31,8 +31,8 @@ logger = FormatAdapter(logging.getLogger(__name__))
 
 In_Types: TypeAlias = \
     Union[int, float, str, RandomDistribution, Iterable[Union[int, float]]]
-Weight_Types = In_Types
-Out_Types: TypeAlias = Union[float, str, RandomDistribution, NDArray[float64]]
+Weight_Delay_Types: TypeAlias = \
+    Union[float, str, RandomDistribution, NDArray[float64]]
 
 
 class AbstractSynapseDynamics(object, metaclass=AbstractBase):
@@ -53,7 +53,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         self.__weight = self._convert_weight(weight)
         self.__check_out_type(self.__weight, "weight")
 
-    def __check_in_type(self, value, name):
+    def __check_in_type(self, value: In_Types, name: str):
         if isinstance(value, (int, float, str, RandomDistribution)):
             return
         try:
@@ -71,7 +71,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
             "Expected types are int, float, str, RandomDistribution "
             "and collections of type int or float")
 
-    def __check_out_type(self, value, name):
+    def __check_out_type(self, value: Weight_Delay_Types, name: str):
         if isinstance(value, (float, (str, RandomDistribution))):
             return
         if isinstance(value, numpy.ndarray):
@@ -113,7 +113,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         """
 
     @property
-    def weight(self) -> Weight_Types:
+    def weight(self) -> Weight_Delay_Types:
         """
         The weight of connections.
 
@@ -121,7 +121,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         """
         return self.__weight
 
-    def _round_delay(self, delay: In_Types) -> Out_Types:
+    def _round_delay(self, delay: In_Types) -> Weight_Delay_Types:
         """
         Round the delays to multiples of full timesteps.
 
@@ -145,7 +145,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
             return new_delay
         raise TypeError(f"{type(delay)=}")
 
-    def _convert_weight(self, weight: In_Types) -> Out_Types:
+    def _convert_weight(self, weight: In_Types) -> Weight_Delay_Types:
         """
         Convert the weights if numerical to (list of) float .
 
@@ -160,7 +160,7 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         return new_weight
 
     @property
-    def delay(self) -> Out_Types:
+    def delay(self) -> Weight_Delay_Types:
         """
         The delay of connections.
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
@@ -44,7 +44,6 @@ class SynapseDynamicsNeuromodulation(
     """
 
     __slots__ = [
-        "__weight",
         "__tau_c",
         "__tau_d",
         "__tau_c_data",
@@ -54,7 +53,7 @@ class SynapseDynamicsNeuromodulation(
 
     def __init__(self, weight=StaticSynapse.default_parameters['weight'],
                  tau_c=1000.0, tau_d=200.0, w_min=0.0, w_max=1.0):
-        self.__weight = weight
+        super().__init__(delay=1, weight=weight)
         self.__tau_c = tau_c
         self.__tau_d = tau_d
         ts = SpynnakerDataView.get_simulation_time_step_ms()
@@ -259,17 +258,6 @@ class SynapseDynamicsNeuromodulation(
     @overrides(AbstractPlasticSynapseDynamics.changes_during_run)
     def changes_during_run(self):
         return False
-
-    @property
-    @overrides(AbstractPlasticSynapseDynamics.weight)
-    def weight(self):
-        return self.__weight
-
-    @property
-    @overrides(AbstractPlasticSynapseDynamics.delay)
-    def delay(self):
-        # Delay is always 1!
-        return 1
 
     @property
     @overrides(AbstractPlasticSynapseDynamics.pad_to_length)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
@@ -21,6 +21,7 @@ from spynnaker.pyNN.exceptions import (
     SynapticConfigurationException, InvalidParameterType)
 from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
     STDP_FIXED_POINT_ONE, get_exp_lut_array)
+from spynnaker.pyNN.types import Weight_Delay_In_Types as _Weight
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .abstract_generate_on_machine import (
     AbstractGenerateOnMachine, MatrixGeneratorID)
@@ -51,7 +52,8 @@ class SynapseDynamicsNeuromodulation(
         "__w_min",
         "__w_max"]
 
-    def __init__(self, weight=StaticSynapse.default_parameters['weight'],
+    def __init__(self,
+                 weight: _Weight = StaticSynapse.default_parameters['weight'],
                  tau_c=1000.0, tau_d=200.0, w_min=0.0, w_max=1.0):
         super().__init__(delay=1, weight=weight)
         self.__tau_c = tau_c

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -34,11 +34,7 @@ class SynapseDynamicsStatic(
 
     __slots__ = [
         # padding to add to a synaptic row for synaptic rewiring
-        "__pad_to_length",
-        # weight of connections
-        "__weight",
-        # delay of connections
-        "__delay"]
+        "__pad_to_length"]
 
     def __init__(self, weight=StaticSynapse.default_parameters['weight'],
                  delay=None, pad_to_length=None):
@@ -48,10 +44,7 @@ class SynapseDynamicsStatic(
         :type delay: float or None
         :param int pad_to_length:
         """
-        self.__weight = weight
-        if delay is None:
-            delay = SpynnakerDataView.get_min_delay()
-        self.__delay = self._round_delay(delay)
+        super().__init__(delay=delay, weight=weight)
         self.__pad_to_length = pad_to_length
 
     @overrides(AbstractStaticSynapseDynamics.merge)
@@ -217,16 +210,6 @@ class SynapseDynamicsStatic(
     @overrides(AbstractStaticSynapseDynamics.changes_during_run)
     def changes_during_run(self):
         return False
-
-    @property
-    @overrides(AbstractStaticSynapseDynamics.weight)
-    def weight(self):
-        return self.__weight
-
-    @property
-    @overrides(AbstractStaticSynapseDynamics.delay)
-    def delay(self):
-        return self.__delay
 
     @property
     @overrides(AbstractStaticSynapseDynamics.pad_to_length)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -20,6 +20,7 @@ from .abstract_generate_on_machine import (
     AbstractGenerateOnMachine, MatrixGeneratorID)
 from .synapse_dynamics_neuromodulation import SynapseDynamicsNeuromodulation
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
+from spynnaker.pyNN.types import Weight_Delay_In_Types as _Weight
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 
@@ -35,7 +36,8 @@ class SynapseDynamicsStatic(
         # padding to add to a synaptic row for synaptic rewiring
         "__pad_to_length"]
 
-    def __init__(self, weight=StaticSynapse.default_parameters['weight'],
+    def __init__(self,
+                 weight: _Weight = StaticSynapse.default_parameters['weight'],
                  delay=None, pad_to_length=None):
         """
         :param float weight:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -15,7 +15,6 @@
 import numpy
 from pyNN.standardmodels.synapses import StaticSynapse
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.data import SpynnakerDataView
 from .abstract_static_synapse_dynamics import AbstractStaticSynapseDynamics
 from .abstract_generate_on_machine import (
     AbstractGenerateOnMachine, MatrixGeneratorID)
@@ -44,7 +43,8 @@ class SynapseDynamicsStatic(
         :type delay: float or None
         :param int pad_to_length:
         """
-        super(AbstractStaticSynapseDynamics, self).__init__(delay=delay, weight=weight)
+        super(AbstractStaticSynapseDynamics, self).__init__(
+            delay=delay, weight=weight)
         self.__pad_to_length = pad_to_length
 
     @overrides(AbstractStaticSynapseDynamics.merge)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -44,7 +44,7 @@ class SynapseDynamicsStatic(
         :type delay: float or None
         :param int pad_to_length:
         """
-        super().__init__(delay=delay, weight=weight)
+        super(AbstractStaticSynapseDynamics, self).__init__(delay=delay, weight=weight)
         self.__pad_to_length = pad_to_length
 
     @overrides(AbstractStaticSynapseDynamics.merge)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -66,8 +66,8 @@ class SynapseDynamicsSTDP(
     def __init__(
             self, timing_dependence, weight_dependence,
             voltage_dependence=None, dendritic_delay_fraction=1.0,
-            weight: _In_Types =StaticSynapse.default_parameters['weight'],
-            delay: _In_Types =None, pad_to_length=None, backprop_delay=True):
+            weight: _In_Types = StaticSynapse.default_parameters['weight'],
+            delay: _In_Types = None, pad_to_length=None, backprop_delay=True):
         """
         :param AbstractTimingDependence timing_dependence:
         :param AbstractWeightDependence weight_dependence:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -21,6 +21,8 @@ from spinn_front_end_common.utilities.constants import (
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.exceptions import (
     SynapticConfigurationException, InvalidParameterType)
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .abstract_synapse_dynamics_structural import (
@@ -476,7 +478,8 @@ class SynapseDynamicsSTDP(
         return self.get_weight_maximum(connector, synapse_info)
 
     @overrides(AbstractPlasticSynapseDynamics.get_weight_variance)
-    def get_weight_variance(self, connector, weights, synapse_info):
+    def get_weight_variance(
+            self, connector, weights: Weight_Delay_Types, synapse_info):
         # Because the weights could all be changed to the maximum, the variance
         # has to be given as no variance
         return 0.0

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -58,10 +58,6 @@ class SynapseDynamicsSTDP(
         "__neuromodulation",
         # padding to add to a synaptic row for synaptic rewiring
         "__pad_to_length",
-        # Weight of connections formed by connector
-        "__weight",
-        # Delay of connections formed by connector
-        "__delay",
         # Whether to use back-propagation delay or not
         "__backprop_delay"]
 
@@ -89,7 +85,7 @@ class SynapseDynamicsSTDP(
         if voltage_dependence is not None:
             raise NotImplementedError(
                 "Voltage dependence has not been implemented")
-
+        super().__init__(delay=delay, weight=weight)
         self.__timing_dependence = timing_dependence
         self.__weight_dependence = weight_dependence
         # move data from timing to weight dependence; that's where we need it
@@ -97,10 +93,6 @@ class SynapseDynamicsSTDP(
             timing_dependence.A_plus, timing_dependence.A_minus)
         self.__dendritic_delay_fraction = float(dendritic_delay_fraction)
         self.__pad_to_length = pad_to_length
-        self.__weight = weight
-        if delay is None:
-            delay = SpynnakerDataView.get_min_delay()
-        self.__delay = self._round_delay(delay)
         self.__backprop_delay = backprop_delay
         self.__neuromodulation = None
 
@@ -578,16 +570,6 @@ class SynapseDynamicsSTDP(
     @overrides(AbstractPlasticSynapseDynamics.changes_during_run)
     def changes_during_run(self):
         return True
-
-    @property
-    @overrides(AbstractPlasticSynapseDynamics.weight)
-    def weight(self):
-        return self.__weight
-
-    @property
-    @overrides(AbstractPlasticSynapseDynamics.delay)
-    def delay(self):
-        return self.__delay
 
     @property
     @overrides(AbstractPlasticSynapseDynamics.is_combined_core_capable)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -21,8 +21,8 @@ from spinn_front_end_common.utilities.constants import (
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.exceptions import (
     SynapticConfigurationException, InvalidParameterType)
-from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
-    import Weight_Delay_Types
+from spynnaker.pyNN.types import Weight_Types
+from spynnaker.pyNN.types import Weight_Delay_In_Types as _In_Types
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .abstract_synapse_dynamics_structural import (
@@ -66,8 +66,8 @@ class SynapseDynamicsSTDP(
     def __init__(
             self, timing_dependence, weight_dependence,
             voltage_dependence=None, dendritic_delay_fraction=1.0,
-            weight=StaticSynapse.default_parameters['weight'],
-            delay=None, pad_to_length=None, backprop_delay=True):
+            weight: _In_Types =StaticSynapse.default_parameters['weight'],
+            delay: _In_Types =None, pad_to_length=None, backprop_delay=True):
         """
         :param AbstractTimingDependence timing_dependence:
         :param AbstractWeightDependence weight_dependence:
@@ -479,7 +479,7 @@ class SynapseDynamicsSTDP(
 
     @overrides(AbstractPlasticSynapseDynamics.get_weight_variance)
     def get_weight_variance(
-            self, connector, weights: Weight_Delay_Types, synapse_info):
+            self, connector, weights: Weight_Types, synapse_info):
         # Because the weights could all be changed to the maximum, the variance
         # has to be given as no variance
         return 0.0

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -16,6 +16,8 @@ import numpy
 from pyNN.standardmodels.synapses import StaticSynapse
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
+from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
+    import Weight_Delay_Types
 from spynnaker.pyNN.utilities.utility_calls import create_mars_kiss_seeds
 from .abstract_synapse_dynamics_structural import (
     AbstractSynapseDynamicsStructural)
@@ -239,7 +241,8 @@ class SynapseDynamicsStructuralStatic(SynapseDynamicsStatic, _Common):
         return self.get_weight_maximum(connector, synapse_info)
 
     @overrides(SynapseDynamicsStatic.get_weight_variance)
-    def get_weight_variance(self, connector, weights, synapse_info):
+    def get_weight_variance(
+            self, connector, weights: Weight_Delay_Types, synapse_info):
         return 0.0
 
     @overrides(SynapseDynamicsStatic.get_weight_maximum)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -16,8 +16,7 @@ import numpy
 from pyNN.standardmodels.synapses import StaticSynapse
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
-from spynnaker.pyNN.models.neural_projections.connectors.connection_types \
-    import Weight_Delay_Types
+from spynnaker.pyNN.types import Weight_Types
 from spynnaker.pyNN.utilities.utility_calls import create_mars_kiss_seeds
 from .abstract_synapse_dynamics_structural import (
     AbstractSynapseDynamicsStructural)
@@ -242,7 +241,7 @@ class SynapseDynamicsStructuralStatic(SynapseDynamicsStatic, _Common):
 
     @overrides(SynapseDynamicsStatic.get_weight_variance)
     def get_weight_variance(
-            self, connector, weights: Weight_Delay_Types, synapse_info):
+            self, connector, weights: Weight_Types, synapse_info):
         return 0.0
 
     @overrides(SynapseDynamicsStatic.get_weight_maximum)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -16,6 +16,7 @@ import numpy
 from pyNN.standardmodels.synapses import StaticSynapse
 from spinn_utilities.overrides import overrides
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
+from spynnaker.pyNN.types import Weight_Delay_In_Types as _In_Types
 from spynnaker.pyNN.utilities.utility_calls import create_mars_kiss_seeds
 from .abstract_synapse_dynamics_structural import (
     AbstractSynapseDynamicsStructural)
@@ -72,8 +73,8 @@ class SynapseDynamicsStructuralSTDP(
             f_rew=DEFAULT_F_REW, initial_weight=DEFAULT_INITIAL_WEIGHT,
             initial_delay=DEFAULT_INITIAL_DELAY, s_max=DEFAULT_S_MAX,
             with_replacement=True, seed=None,
-            weight=StaticSynapse.default_parameters['weight'], delay=None,
-            backprop_delay=True):
+            weight: _In_Types = StaticSynapse.default_parameters['weight'],
+            delay: _In_Types =None, backprop_delay=True):
         """
         :param AbstractPartnerSelection partner_selection:
             The partner selection rule

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -74,7 +74,7 @@ class SynapseDynamicsStructuralSTDP(
             initial_delay=DEFAULT_INITIAL_DELAY, s_max=DEFAULT_S_MAX,
             with_replacement=True, seed=None,
             weight: _In_Types = StaticSynapse.default_parameters['weight'],
-            delay: _In_Types =None, backprop_delay=True):
+            delay: _In_Types = None, backprop_delay=True):
         """
         :param AbstractPartnerSelection partner_selection:
             The partner selection rule

--- a/spynnaker/pyNN/types.py
+++ b/spynnaker/pyNN/types.py
@@ -30,6 +30,8 @@ Weight_Types: TypeAlias = Optional[Union[
     int, float, str, RandomDistribution, NDArray[numpy.float64]]]
 Delay_Types: TypeAlias = \
     Union[float, str, RandomDistribution, NDArray[numpy.float64]]
+# These are the Types we know are coming in.
+# Most things that can be considered ints and floats will work
 Weight_Delay_In_Types: TypeAlias = Optional[Union[
     int, float, str, RandomDistribution, Iterable[Union[int, float]]]]
 

--- a/spynnaker/pyNN/types.py
+++ b/spynnaker/pyNN/types.py
@@ -19,13 +19,19 @@ Types (and related) that are useful for implementing connectors.
 import numpy
 from numpy.typing import NDArray
 from pyNN.random import RandomDistribution
-import pyNN
-from typing import Union
+from typing import Iterable, Optional, Union
 from typing_extensions import TypeAlias, TypeGuard
-#: The type of weights and delays provided by
-D: TypeAlias = Union[pyNN.random.RandomDistribution, int, float, str]
-Weight_Delay_Types: TypeAlias = \
+
+#: The type of weights and delays provided by Synapse / SynapseInformation
+# Combined types (where value could be either)
+Weight_Delay_Types: TypeAlias = Optional[Union[
+    int, float, str, RandomDistribution, NDArray[numpy.float64]]]
+Weight_Types: TypeAlias = Optional[Union[
+    int, float, str, RandomDistribution, NDArray[numpy.float64]]]
+Delay_Types: TypeAlias = \
     Union[float, str, RandomDistribution, NDArray[numpy.float64]]
+Weight_Delay_In_Types: TypeAlias = Optional[Union[
+    int, float, str, RandomDistribution, Iterable[Union[int, float]]]]
 
 
 def is_scalar(value: Weight_Delay_Types) -> TypeGuard[Union[int, float]]:

--- a/unittests/connector_tests/test_weights_delays_connector.py
+++ b/unittests/connector_tests/test_weights_delays_connector.py
@@ -1,0 +1,75 @@
+﻿# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy
+import pytest
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    OneToOneConnector)
+from unittests.mocks import MockPopulation
+from spynnaker.pyNN.models.neural_projections import SynapseInformation
+from spynnaker.pyNN.config_setup import unittest_setup
+from spynnaker.pyNN.exceptions import SpynnakerException
+
+@pytest.mark.parametrize(
+    "weight, delay", [
+        (1, 2.0),
+        (3.3, 4.4)
+        ], ids=[
+        "ints",
+        "floats"
+    ])
+def test_good_values(weight, delay):
+    unittest_setup()
+    connector = OneToOneConnector()
+    synapse_info = SynapseInformation(
+            connector=None, pre_population=MockPopulation(10, "Pre"),
+            post_population=MockPopulation(10, "Post"), prepop_is_view=False,
+            postpop_is_view=False, synapse_dynamics=None,
+            synapse_type=None, receptor_type=None,
+            synapse_type_from_dynamics=False, weights=weight, delays=delay)
+    assert delay == connector.get_delay_maximum(synapse_info)
+    assert weight == connector.get_weight_maximum(synapse_info)
+
+
+@pytest.mark.parametrize(
+    "weight, delay", [
+        ([0, 1, 2, 3], [4, 5, 6, 7]),
+        (numpy.array([0, 1, 2, 3]), numpy.array([4, 5, 6, 7])),
+        ("foo", "bar"),
+        (OneToOneConnector(), MockPopulation(10, "Pre"))
+        ], ids=[
+        "ints",
+        "array",
+        "str",
+        "weird types"
+    ])
+def test_bad_values(weight, delay):
+    unittest_setup()
+    connector = OneToOneConnector()
+    synapse_info = SynapseInformation(
+            connector=None, pre_population=MockPopulation(10, "Pre"),
+            post_population=MockPopulation(10, "Post"), prepop_is_view=False,
+            postpop_is_view=False, synapse_dynamics=None,
+            synapse_type=None, receptor_type=None,
+            synapse_type_from_dynamics=False, weights=weight, delays=delay)
+    try:
+        connector.get_delay_maximum(synapse_info)
+        raise NotImplementedError
+    except SpynnakerException:
+        pass
+    try:
+        connector.get_weight_maximum(synapse_info)
+        raise NotImplementedError
+    except SpynnakerException:
+        pass

--- a/unittests/connector_tests/test_weights_delays_connector.py
+++ b/unittests/connector_tests/test_weights_delays_connector.py
@@ -21,6 +21,7 @@ from spynnaker.pyNN.models.neural_projections import SynapseInformation
 from spynnaker.pyNN.config_setup import unittest_setup
 from spynnaker.pyNN.exceptions import SpynnakerException
 
+
 @pytest.mark.parametrize(
     "weight, delay", [
         (1, 2.0),

--- a/unittests/model_tests/neuron/synapse_dynamics/__init__.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2023 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from numpy import float64, ndarray
+from numpy.typing import NDArray
+from pyNN.random import RandomDistribution
+import unittest
+from spynnaker.pyNN.config_setup import unittest_setup
+from spynnaker.pyNN.models.neuron.synapse_dynamics import (
+    SynapseDynamicsStatic)
+
+
+class TestAbstractSynapseDynamics(unittest.TestCase):
+
+    # Note these tests use SynapseDynamicsStatic because it is the simplist
+    # Just because it is used here does not indicate that all types are
+    # by it let alone in all use case
+
+    def setUp(self):
+        unittest_setup()
+
+    def test_int(self):
+        synapse = SynapseDynamicsStatic(delay=1, weight=2)
+        self.assertEqual(float64, type(synapse.delay))
+        self.assertEqual(int, type(synapse.weight))
+
+    def test_float(self):
+        synapse = SynapseDynamicsStatic(delay=1.1, weight=2.2)
+        self.assertEqual(float64, type(synapse.delay))
+        self.assertEqual(float, type(synapse.weight))
+
+    def test_str(self):
+        # Only some (distance) Connectors support str
+        # And of course not foo and bar
+        synapse = SynapseDynamicsStatic(delay="foo", weight="bar")
+        self.assertEqual(str, type(synapse.delay))
+        self.assertEqual(str, type(synapse.weight))
+
+    def test_random(self):
+        # Only some connectors support Random
+        rng = RandomDistribution('uniform', (-70, -50))
+        synapse = SynapseDynamicsStatic(delay=rng, weight=rng)
+        self.assertEqual(RandomDistribution, type(synapse.delay))
+        self.assertEqual(RandomDistribution, type(synapse.weight))
+
+    def test_int_list(self):
+        # Only some connectors support list
+        synapse = SynapseDynamicsStatic(delay=[1, 2, 3], weight=[4, 5, 6])
+        delay = synapse.delay
+        self.assertEqual(ndarray, type(delay))
+        for d in delay:
+            self.assertEqual(float64, type(d))
+        weight = synapse.weight
+        self.assertEqual(list, type(weight))
+        for w in weight:
+            self.assertEqual(int, type(w))
+
+    def test_float_list(self):
+        # Only some connectors support list
+        synapse = SynapseDynamicsStatic(
+            delay=[1.1, 2.2, 3.3], weight=[4.4, 5.5, 6.6])
+        delay = synapse.delay
+        self.assertEqual(ndarray, type(delay))
+        for d in delay:
+            self.assertEqual(float64, type(d))
+        weight = synapse.weight
+        self.assertEqual(list, type(weight))
+        for w in weight:
+            self.assertEqual(float, type(w))
+
+    def test_delay_none(self):
+        synapse = SynapseDynamicsStatic(delay=None, weight=2)
+        self.assertEqual(float64, type(synapse.delay))
+        self.assertEqual(int, type(synapse.weight))
+
+    def test_weight_none(self):
+        with self.assertRaises(TypeError):
+            SynapseDynamicsStatic(delay=1, weight=None)
+
+    def test_bad_type(self):
+        with self.assertRaises(TypeError):
+            SynapseDynamicsStatic(delay=1, weight=None)

--- a/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
@@ -122,4 +122,3 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
     def test_bad_type(self):
         with self.assertRaises(TypeError):
             SynapseDynamicsStatic(delay=bytes(), weight=1)
-

--- a/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
@@ -121,4 +121,5 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
 
     def test_bad_type(self):
         with self.assertRaises(TypeError):
-            SynapseDynamicsStatic(delay=1, weight=None)
+            SynapseDynamicsStatic(delay=bytes(), weight=1)
+

--- a/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numpy import float64, array
+from numpy import float64, array, ndarray
 from pyNN.random import RandomDistribution
 import unittest
 from spynnaker.pyNN.config_setup import unittest_setup
@@ -63,52 +63,52 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
         # Only some connectors support list
         synapse = SynapseDynamicsStatic(delay=[1, 2, 3], weight=[4, 5, 6])
         delay = synapse.delay
-        self.assertEqual(list, type(delay))
+        self.assertEqual(ndarray, type(delay))
         for d in delay:
-            self.assertEqual(float, type(d))
+            self.assertEqual(float64, type(d))
         weight = synapse.weight
-        self.assertEqual(list, type(weight))
+        self.assertEqual(ndarray, type(weight))
         for w in weight:
-            self.assertEqual(float, type(w))
+            self.assertEqual(float64, type(w))
 
     def test_int_array(self):
         # Only some connectors support list
         synapse = SynapseDynamicsStatic(
             delay=array([1, 2, 3]), weight=array([4, 5, 6]))
         delay = synapse.delay
-        self.assertEqual(list, type(delay))
+        self.assertEqual(ndarray, type(delay))
         for d in delay:
-            self.assertEqual(float, type(d))
+            self.assertEqual(float64, type(d))
         weight = synapse.weight
-        self.assertEqual(list, type(weight))
+        self.assertEqual(ndarray, type(weight))
         for w in weight:
-            self.assertEqual(float, type(w))
+            self.assertEqual(float64, type(w))
 
     def test_float_list(self):
         # Only some connectors support list
         synapse = SynapseDynamicsStatic(
             delay=[1.1, 2.2, 3.3], weight=[4.4, 5.5, 6.6])
         delay = synapse.delay
-        self.assertEqual(list, type(delay))
+        self.assertEqual(ndarray, type(delay))
         for d in delay:
-            self.assertEqual(float, type(d))
+            self.assertEqual(float64, type(d))
         weight = synapse.weight
-        self.assertEqual(list, type(weight))
+        self.assertEqual(ndarray, type(weight))
         for w in weight:
-            self.assertEqual(float, type(w))
+            self.assertEqual(float64, type(w))
 
     def test_float_array(self):
         # Only some connectors support list
         synapse = SynapseDynamicsStatic(
             delay=array([1.1, 2.2, 3.3]), weight=array([4.4, 5.5, 6.6]))
         delay = synapse.delay
-        self.assertEqual(list, type(delay))
+        self.assertEqual(ndarray, type(delay))
         for d in delay:
-            self.assertEqual(float, type(d))
+            self.assertEqual(float64, type(d))
         weight = synapse.weight
-        self.assertEqual(list, type(weight))
+        self.assertEqual(ndarray, type(weight))
         for w in weight:
-            self.assertEqual(float, type(w))
+            self.assertEqual(float64, type(w))
 
     def test_delay_none(self):
         synapse = SynapseDynamicsStatic(delay=None, weight=2)

--- a/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
@@ -32,7 +32,7 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
     def test_int(self):
         synapse = SynapseDynamicsStatic(delay=1, weight=2)
         self.assertEqual(float, type(synapse.delay))
-        self.assertEqual(float, type(synapse.weight))
+        self.assertEqual(int, type(synapse.weight))
 
     def test_float(self):
         synapse = SynapseDynamicsStatic(delay=1.1, weight=2.2)
@@ -113,11 +113,12 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
     def test_delay_none(self):
         synapse = SynapseDynamicsStatic(delay=None, weight=2)
         self.assertEqual(float, type(synapse.delay))
-        self.assertEqual(float, type(synapse.weight))
+        self.assertEqual(int, type(synapse.weight))
 
     def test_weight_none(self):
-        with self.assertRaises(TypeError):
-            SynapseDynamicsStatic(delay=1, weight=None)
+        synapse = SynapseDynamicsStatic(delay=1, weight=None)
+        self.assertEqual(float, type(synapse.delay))
+        self.assertIsNone(synapse.weight)
 
     def test_bad_type(self):
         with self.assertRaises(TypeError):

--- a/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
+++ b/unittests/model_tests/neuron/synapse_dynamics/test_abstract_synapse_dynamics.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from numpy import float64, ndarray
-from numpy.typing import NDArray
+from numpy import float64, array
 from pyNN.random import RandomDistribution
 import unittest
 from spynnaker.pyNN.config_setup import unittest_setup
@@ -32,12 +31,18 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
 
     def test_int(self):
         synapse = SynapseDynamicsStatic(delay=1, weight=2)
-        self.assertEqual(float64, type(synapse.delay))
-        self.assertEqual(int, type(synapse.weight))
+        self.assertEqual(float, type(synapse.delay))
+        self.assertEqual(float, type(synapse.weight))
 
     def test_float(self):
         synapse = SynapseDynamicsStatic(delay=1.1, weight=2.2)
-        self.assertEqual(float64, type(synapse.delay))
+        self.assertEqual(float, type(synapse.delay))
+        self.assertEqual(float, type(synapse.weight))
+
+    def test_float64(self):
+        synapse = SynapseDynamicsStatic(
+            delay=float64(1.1), weight=float64(2.2))
+        self.assertEqual(float, type(synapse.delay))
         self.assertEqual(float, type(synapse.weight))
 
     def test_str(self):
@@ -58,22 +63,48 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
         # Only some connectors support list
         synapse = SynapseDynamicsStatic(delay=[1, 2, 3], weight=[4, 5, 6])
         delay = synapse.delay
-        self.assertEqual(ndarray, type(delay))
+        self.assertEqual(list, type(delay))
         for d in delay:
-            self.assertEqual(float64, type(d))
+            self.assertEqual(float, type(d))
         weight = synapse.weight
         self.assertEqual(list, type(weight))
         for w in weight:
-            self.assertEqual(int, type(w))
+            self.assertEqual(float, type(w))
+
+    def test_int_array(self):
+        # Only some connectors support list
+        synapse = SynapseDynamicsStatic(
+            delay=array([1, 2, 3]), weight=array([4, 5, 6]))
+        delay = synapse.delay
+        self.assertEqual(list, type(delay))
+        for d in delay:
+            self.assertEqual(float, type(d))
+        weight = synapse.weight
+        self.assertEqual(list, type(weight))
+        for w in weight:
+            self.assertEqual(float, type(w))
 
     def test_float_list(self):
         # Only some connectors support list
         synapse = SynapseDynamicsStatic(
             delay=[1.1, 2.2, 3.3], weight=[4.4, 5.5, 6.6])
         delay = synapse.delay
-        self.assertEqual(ndarray, type(delay))
+        self.assertEqual(list, type(delay))
         for d in delay:
-            self.assertEqual(float64, type(d))
+            self.assertEqual(float, type(d))
+        weight = synapse.weight
+        self.assertEqual(list, type(weight))
+        for w in weight:
+            self.assertEqual(float, type(w))
+
+    def test_float_array(self):
+        # Only some connectors support list
+        synapse = SynapseDynamicsStatic(
+            delay=array([1.1, 2.2, 3.3]), weight=array([4.4, 5.5, 6.6]))
+        delay = synapse.delay
+        self.assertEqual(list, type(delay))
+        for d in delay:
+            self.assertEqual(float, type(d))
         weight = synapse.weight
         self.assertEqual(list, type(weight))
         for w in weight:
@@ -81,8 +112,8 @@ class TestAbstractSynapseDynamics(unittest.TestCase):
 
     def test_delay_none(self):
         synapse = SynapseDynamicsStatic(delay=None, weight=2)
-        self.assertEqual(float64, type(synapse.delay))
-        self.assertEqual(int, type(synapse.weight))
+        self.assertEqual(float, type(synapse.delay))
+        self.assertEqual(float, type(synapse.weight))
 
     def test_weight_none(self):
         with self.assertRaises(TypeError):

--- a/unittests/model_tests/neuron/test_synapse_io.py
+++ b/unittests/model_tests/neuron/test_synapse_io.py
@@ -59,7 +59,7 @@ def test_get_allowed_row_length(
         connector=None, pre_population=None, post_population=None,
         prepop_is_view=False, postpop_is_view=False, synapse_dynamics=dynamics,
         synapse_type_from_dynamics=False, synapse_type=None,
-        receptor_type=None, weights=0, delays=None)
+        receptor_type=None, weights=0, delays=1)
     in_edge = ProjectionApplicationEdge(None, None, synapse_information)
     if exception is not None:
         with pytest.raises(exception) as exc_info:


### PR DESCRIPTION
The types (as defined by PyNN) that we have to accept or weight and  delay are rather messy.

This PR checks the types and improves the Exceptions.

Changes include
1. py.typed file to tell the type checker to look for types
2. PyNN.types.py file to hold the type declarations in a single place
    - includes an is_scaler method which includes a TypeGuard
3. Methods to create more informative Exceptions (in AbstractConnector)
4. Pushing of holding the delay and weight into AbstractWeight
    - Allows converting the many inputs into a smaller known subset
    - Allows checking to types. (These methods could be commented out after all tests pass)
5. As we know multiple weights are converted to numpy.arrays the check len has been replaced by is-instance.
     - required because str has len
7. Adds some tests

tested by https://github.com/SpiNNakerManchester/IntegrationTests/pull/249
