### PR TITLE
Avoid whole board skips

### DIFF
--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -207,7 +207,7 @@ def test_run(x, y, b):
         triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
         job.launch_keepalive_task()
-        job.wait_until_ready(n_retries=1)
+        job.wait_until_ready(n_retries=2)
         state = job.get_state()
         # If queued or destroyed skip test
         if state == SpallocState.QUEUED:

--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -207,8 +207,8 @@ def test_run(x, y, b):
         triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
         job.launch_keepalive_task()
-        job.wait_until_ready(10.0, 3)
-        state = job.get_state(wait_for_change=True)
+        job.wait_until_ready(None, 3)
+        state = job.get_state()
         # If queued or destroyed skip test
         if state == SpallocState.QUEUED:
             job.destroy("Queued")

--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -207,7 +207,7 @@ def test_run(x, y, b):
         triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
         job.launch_keepalive_task()
-        job.wait_until_ready(None, 3)
+        job.wait_until_ready(31, 3)
         state = job.get_state()
         # If queued or destroyed skip test
         if state == SpallocState.QUEUED:

--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -207,7 +207,7 @@ def test_run(x, y, b):
         triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
         job.launch_keepalive_task()
-        job.wait_until_ready(n_retries=3)
+        job.wait_until_ready(n_retries=1)
         state = job.get_state()
         # If queued or destroyed skip test
         if state == SpallocState.QUEUED:

--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pyNN.spiNNaker as sim
-import spynnaker
-from spalloc_client.job import Job
-from spalloc_client.states import JobState
 import pytest
 import tempfile
 import os
 import traceback
 import sys
-import time
+import logging
+from time import sleep
+from shutil import rmtree
+
+import pyNN.spiNNaker as sim
+from spinnman.spalloc import SpallocClient, SpallocState
 
 
 class WholeBoardTest(object):
@@ -56,6 +57,10 @@ class WholeBoardTest(object):
           (4, 0), (5, 1), (6, 2), (7, 3)]
     dl = list(ur)
     dl.reverse()
+
+    def __init__(self):
+        self.to_allocate = None
+        self.targets = None
 
     def find_a_placement(self):
         for count in range(17, 0, -1):
@@ -187,40 +192,54 @@ class WholeBoardTest(object):
         sim.end()
 
 
-boards = [(x, y, b) for x in range(20) for y in range(20) for b in range(3)]
+BOARDS = [(x, y, b) for x in range(20) for y in range(20) for b in range(3)]
+SPALLOC_URL = "https://spinnaker.cs.man.ac.uk/spalloc"
+SPALLOC_USERNAME = "jenkins"
+SPALLOC_PASSWORD = os.getenv("SPALLOC_PASSWORD")
+SPALLOC_MACHINE = "SpiNNaker1M"
 
 
-@pytest.mark.parametrize("x,y,b", boards)
+@pytest.mark.parametrize("x,y,b", BOARDS)
 def test_run(x, y, b):
     test_dir = os.path.dirname(__file__)
-    job = Job(x, y, b, hostname="spinnaker.cs.man.ac.uk",
-              owner="Jenkins Machine Test")
-    # Sleep before checking for queued in case of multiple jobs running
-    time.sleep(2.0)
-    if job.state == JobState.queued:
-        job.destroy("Queued")
-        pytest.skip(f"Board {x}, {y}, {b} is in use")
-    elif job.state == JobState.destroyed:
-        pytest.skip(f"Board {x}, {y}, {b} could not be allocated")
+    client = SpallocClient(SPALLOC_URL, SPALLOC_USERNAME, SPALLOC_PASSWORD)
+    job = client.create_job_board(
+        triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
-        with tempfile.TemporaryDirectory(
-                prefix=f"{x}_{y}_{b}", dir=test_dir) as tmpdir:
-            os.chdir(tmpdir)
-            with open("spynnaker.cfg", "w", encoding="utf-8") as f:
-                f.write("[Machine]\n")
-                f.write("spalloc_server = None\n")
-                f.write(f"machine_name = {job.hostname}\n")
-                f.write("version = 5\n")
-            test = WholeBoardTest()
-            test.do_run()
+        job.launch_keepalive_task()
+        # Wait for not queued for up to 30 seconds
+        sleep(2.0)
+        state = job.get_state(wait_for_change=True)
+        # If queued or destroyed skip test
+        if state == SpallocState.QUEUED:
+            job.destroy("Queued")
+            pytest.skip(f"Some boards starting at {x}, {y}, {b} is in use")
+        elif state == SpallocState.DESTROYED:
+            pytest.skip(f"Boards {x}, {y}, {b} could not be allocated")
+        # Actually wait for ready now (as might be powering on)
+        job.wait_until_ready()
+        tmpdir = tempfile.mkdtemp(prefix=f"{x}_{y}_{b}", dir=test_dir)
+        os.chdir(tmpdir)
+        with open("spynnaker.cfg", "w", encoding="utf-8") as f:
+            f.write("[Machine]\n")
+            f.write("spalloc_server = None\n")
+            f.write(f"machine_name = {job.get_root_host()}\n")
+            f.write("version = 5\n")
+        test = WholeBoardTest()
+        test.do_run()
+        # If no errors we will get here and we can remove the tree;
+        # then only error folders will be left
+        rmtree(tmpdir)
 
 
 if __name__ == "__main__":
-    for x, y, b in boards:
+    logging.basicConfig(level=logging.DEBUG)
+    main_boards = [(0, 0, 0)]
+    for b_x, b_y, b_b in main_boards:
         print("", file=sys.stderr,)
-        print(f"*************** Testing {x}, {y}, {b} *******************",
+        print(f"************** Testing {b_x}, {b_y}, {b_b} ******************",
               file=sys.stderr)
         try:
-            test_run(x, y, b)
+            test_run(b_x, b_y, b_b)
         except Exception:
             traceback.print_exc()

--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -207,8 +207,7 @@ def test_run(x, y, b):
         triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
         job.launch_keepalive_task()
-        # Wait for not queued for up to 30 seconds
-        sleep(2.0)
+        job.wait_until_ready(10.0, 3)
         state = job.get_state(wait_for_change=True)
         # If queued or destroyed skip test
         if state == SpallocState.QUEUED:

--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -207,7 +207,7 @@ def test_run(x, y, b):
         triad=(x, y, b), machine_name=SPALLOC_MACHINE)
     with job:
         job.launch_keepalive_task()
-        job.wait_until_ready(31, 3)
+        job.wait_until_ready(n_retries=3)
         state = job.get_state()
         # If queued or destroyed skip test
         if state == SpallocState.QUEUED:


### PR DESCRIPTION
Allows the testing to avoid skipping when doing the whole board testing, by working with the new spalloc.

Tested by http://apollo.cs.man.ac.uk:8080/blue/organizations/jenkins/Integration%20Tests/detail/avoid_whole_board_skips/11/pipeline/, but note that was modified to only run the whole board tests!