### PR TITLE
Sets for speed

### DIFF
--- a/spynnaker/pyNN/data/spynnaker_data_view.py
+++ b/spynnaker/pyNN/data/spynnaker_data_view.py
@@ -70,8 +70,8 @@ class _SpynnakerDataModel(object):
         self._min_delay: Optional[float] = None
         # Using a dict to verify if later could be stored here only
         self._neurons_per_core_set: Set[Type[AbstractPyNNModel]] = set()
-        self._populations: List[Population] = []
-        self._projections: List[Projection] = []
+        self._populations: Set[Population] = set()
+        self._projections: Set[Projection] = set()
         self._segment_counter = 0
 
     def _hard_reset(self) -> None:
@@ -139,6 +139,8 @@ class SpynnakerDataView(FecDataView):
 
         The iteration will be empty if no projections added.
 
+        Note: This method is backed by a set so does not guarantee order
+
         :rtype: iterable(Projection)
         """
         return iter(cls.__spy_data._projections)
@@ -174,7 +176,7 @@ class SpynnakerDataView(FecDataView):
                 "This method should only be called from the Projection init")
         if not isinstance(projection, Proj):
             raise TypeError("The projection must be a Projection")
-        cls.__spy_data._projections.append(projection)
+        cls.__spy_data._projections.add(projection)
 
     @classmethod
     def iterate_populations(cls) -> Iterator[Population]:
@@ -182,6 +184,8 @@ class SpynnakerDataView(FecDataView):
         An iteration of the populations previously added.
 
         The iteration will be empty if no populations added.
+
+        Note: This method is backed by a set so does not guarantee order
 
         :rtype: iterable(~spynnaker.pyNN.models.populations.Population)
         """
@@ -229,7 +233,7 @@ class SpynnakerDataView(FecDataView):
                 "This method should only be called from the Population init")
         first_id = cls.__spy_data._id_counter
         cls.__spy_data._id_counter += population.size
-        cls.__spy_data._populations.append(population)
+        cls.__spy_data._populations.add(population)
         return first_id, cls.__spy_data._id_counter-1
 
     @classmethod

--- a/spynnaker/pyNN/data/spynnaker_data_view.py
+++ b/spynnaker/pyNN/data/spynnaker_data_view.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 import logging
 from typing import (
-    Iterator, List, Optional, Set, Tuple, Type, Union, TYPE_CHECKING)
+    Iterator, Optional, Set, Tuple, Type, Union, TYPE_CHECKING)
 from spinn_utilities.log import FormatAdapter
 from spinn_front_end_common.data import FecDataView
 from spynnaker import _version

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -515,7 +515,7 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
                 SELECT region_id, recording_neurons_st, vertex_slice, base_key
                 FROM region_metadata
                 WHERE rec_id = ?
-                ORDER BY region_id, recording_neurons_st, vertex_slice, 
+                ORDER BY region_id, recording_neurons_st, vertex_slice,
                     base_key
                 """, (rec_id,))):
             vertex_slice = MDSlice.from_string(

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -515,7 +515,8 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
                 SELECT region_id, recording_neurons_st, vertex_slice, base_key
                 FROM region_metadata
                 WHERE rec_id = ?
-                ORDER BY region_id, recording_neurons_st, vertex_slice, base_key
+                ORDER BY region_id, recording_neurons_st, vertex_slice, 
+                    base_key
                 """, (rec_id,))):
             vertex_slice = MDSlice.from_string(
                 self._string(row["vertex_slice"]))

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -1459,6 +1459,9 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
         """
         Write the current metadata to the database.
 
+        The underlying call does not guarantee order
+        so there order the metadata is added is not consistent,
+
         .. note::
             The database must be writable for this to work!
         """

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -515,7 +515,7 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
                 SELECT region_id, recording_neurons_st, vertex_slice, base_key
                 FROM region_metadata
                 WHERE rec_id = ?
-                ORDER BY region_metadata_id
+                ORDER BY region_id, recording_neurons_st, vertex_slice, base_key
                 """, (rec_id,))):
             vertex_slice = MDSlice.from_string(
                 self._string(row["vertex_slice"]))

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -101,8 +101,9 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(5, writer._SpynnakerDataWriter__spy_data._id_counter)
         pop_2 = Population(size=15, cellclass=model)
 
-        self.assertListEqual(
-            [pop_1, pop_2], list(SpynnakerDataView.iterate_populations()))
+        as_list = list(SpynnakerDataView.iterate_populations())
+        self.assertListEqual([pop_1, pop_2], sorted(
+            SpynnakerDataView.iterate_populations(), key=lambda x: x.label))
         self.assertEqual(2, SpynnakerDataView.get_n_populations())
         # Hack to check internal data
         # DO NOT COPY as unsupported
@@ -114,8 +115,8 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(1, SpynnakerDataView.get_n_projections())
         pro_2 = Projection(
             pop_2, pop_1, OneToOneConnector(), receptor_type='excitatory')
-        self.assertListEqual(
-            [pro_1, pro_2], list(SpynnakerDataView.iterate_projections()))
+        self.assertListEqual([pro_1, pro_2], sorted(
+            SpynnakerDataView.iterate_projections(), key=lambda x: x.label))
         self.assertEqual(2, SpynnakerDataView.get_n_projections())
         writer.start_run()
         # Unable to add while running
@@ -127,11 +128,11 @@ class TestSimulatorData(unittest.TestCase):
         writer.finish_run()
         writer.hard_reset()
         # population not changed by hard reset
-        self.assertListEqual(
-            [pop_1, pop_2], list(SpynnakerDataView.iterate_populations()))
+        self.assertListEqual([pop_1, pop_2], sorted(
+            SpynnakerDataView.iterate_populations(), key=lambda x: x.label))
         self.assertEqual(2, SpynnakerDataView.get_n_populations())
-        self.assertListEqual(
-            [pro_1, pro_2], list(SpynnakerDataView.iterate_projections()))
+        self.assertListEqual([pro_1, pro_2], sorted(
+            SpynnakerDataView.iterate_projections(), key=lambda x: x.label))
         self.assertEqual(2, SpynnakerDataView.get_n_projections())
         self.assertEqual(20, writer._SpynnakerDataWriter__spy_data._id_counter)
         with self.assertRaises(TypeError):

--- a/unittests/data/test_simulator_data.py
+++ b/unittests/data/test_simulator_data.py
@@ -101,7 +101,6 @@ class TestSimulatorData(unittest.TestCase):
         self.assertEqual(5, writer._SpynnakerDataWriter__spy_data._id_counter)
         pop_2 = Population(size=15, cellclass=model)
 
-        as_list = list(SpynnakerDataView.iterate_populations())
         self.assertListEqual([pop_1, pop_2], sorted(
             SpynnakerDataView.iterate_populations(), key=lambda x: x.label))
         self.assertEqual(2, SpynnakerDataView.get_n_populations())


### PR DESCRIPTION
Alternative to https://github.com/SpiNNakerManchester/sPyNNaker/pull/1464

Keep the safety check but use sets.

This comes at the expense of none repeatable order.

The only place I found where this matters is in the data.ds

So fixed the order by used in the get method