### PR TITLE
External weight change

### DIFF
--- a/neural_modelling/makefiles/neuron/IF_curr_exp_weight_change/Makefile
+++ b/neural_modelling/makefiles/neuron/IF_curr_exp_weight_change/Makefile
@@ -1,0 +1,26 @@
+# Copyright (c) 2014 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+APP = $(notdir $(CURDIR))
+
+NEURON_IMPL_H = $(NEURON_DIR)/neuron/implementations/neuron_impl_standard.h
+NEURON_MODEL_H = $(NEURON_DIR)/neuron/models/neuron_model_lif_impl.h
+INPUT_TYPE_H = $(NEURON_DIR)/neuron/input_types/input_type_current.h
+THRESHOLD_TYPE_H = $(NEURON_DIR)/neuron/threshold_types/threshold_type_static.h
+SYNAPSE_TYPE_H = $(NEURON_DIR)/neuron/synapse_types/synapse_types_exponential_impl.h
+SYNAPSE_DYNAMICS = $(NEURON_DIR)/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
+SYNAPSE_DYNAMICS_CUSTOM = 1
+
+# ----------------------------------------------------------------------
+# Import the main Makefile
+include ../neural_build.mk

--- a/neural_modelling/makefiles/neuron/IF_curr_exp_weight_change/Makefile
+++ b/neural_modelling/makefiles/neuron/IF_curr_exp_weight_change/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 The University of Manchester
+# Copyright (c) 2024 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/neural_modelling/makefiles/neuron/Makefile
+++ b/neural_modelling/makefiles/neuron/Makefile
@@ -28,8 +28,7 @@ MODELS = IF_curr_exp \
          IF_trunc_delta \
          IF_curr_alpha \
          IF_cond_exp_stoc \
-         IF_curr_exp_sEMD \
-         IF_curr_exp_weight_change
+         IF_curr_exp_sEMD
 
 ifneq ($(SPYNNAKER_DEBUG), DEBUG)
     MODELS += external_device_lif_control \
@@ -49,7 +48,8 @@ ifneq ($(SPYNNAKER_DEBUG), DEBUG)
               IF_curr_delta_stdp_mad_pair_additive \
               IF_curr_delta_stdp_mad_nearest_pair_additive \
               IF_curr_exp_stdp_mad_recurrent_pre_stochastic_multiplicative \
-              IF_curr_exp_stdp_mad_pfister_triplet_additive
+              IF_curr_exp_stdp_mad_pfister_triplet_additive \
+              IF_curr_exp_weight_change
 endif
 
 all:

--- a/neural_modelling/makefiles/neuron/Makefile
+++ b/neural_modelling/makefiles/neuron/Makefile
@@ -28,7 +28,8 @@ MODELS = IF_curr_exp \
          IF_trunc_delta \
          IF_curr_alpha \
          IF_cond_exp_stoc \
-         IF_curr_exp_sEMD
+         IF_curr_exp_sEMD \
+         IF_curr_exp_weight_change
 
 ifneq ($(SPYNNAKER_DEBUG), DEBUG)
     MODELS += external_device_lif_control \

--- a/neural_modelling/makefiles/neuron/neural_build.mk
+++ b/neural_modelling/makefiles/neuron/neural_build.mk
@@ -158,14 +158,16 @@ else
     SYNAPSE_DYNAMICS_STATIC := neuron/plasticity/synapse_dynamics_static_impl.c
     STDP_ENABLED = 0
     ifneq ($(SYNAPSE_DYNAMICS), $(SYNAPSE_DYNAMICS_STATIC))
-        STDP_ENABLED = 1
-
-        ifndef TIMING_DEPENDENCE_H
-            $(error TIMING_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
-        endif
-        ifndef WEIGHT_DEPENDENCE_H
-            $(error WEIGHT_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
-        endif
+        ifndef SYNAPSE_DYNAMICS_CUSTOM
+	        STDP_ENABLED = 1
+	
+	        ifndef TIMING_DEPENDENCE_H
+	            $(error TIMING_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
+	        endif
+	        ifndef WEIGHT_DEPENDENCE_H
+	            $(error WEIGHT_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
+	        endif
+	    endif
     endif
 endif
 

--- a/neural_modelling/src/neuron/plasticity/weight_change/post_events_with_weight_change.h
+++ b/neural_modelling/src/neuron/plasticity/weight_change/post_events_with_weight_change.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! \file
+//! \brief Post-synaptic events
+#ifndef _POST_EVENTS_H_
+#define _POST_EVENTS_H_
+
+// Standard includes
+#include <stdbool.h>
+#include <stdint.h>
+
+// Include debug header for log_info etc
+#include <debug.h>
+#include <stddef.h>
+
+//---------------------------------------
+// Macros
+//---------------------------------------
+//! Maximum number of pre-synaptic events per post neuron
+#define MAX_EVENTS 16
+
+typedef struct update_post_trace_t {
+
+    //! The new weight to set
+    int16_t weight_change;
+
+    //! The synapse type
+    uint16_t synapse_type;
+
+    //! The pre-spike to look out for in doing the update
+    uint32_t pre_spike;
+} update_post_trace_t;
+
+//---------------------------------------
+// Structures
+//---------------------------------------
+//! Trace history of post-synaptic events
+typedef struct {
+    //! Number of events stored
+    uint32_t count;
+    //! Event traces
+    update_post_trace_t traces[MAX_EVENTS];
+} post_event_history_t;
+
+//---------------------------------------
+// Inline functions
+//---------------------------------------
+
+//! \brief Initialise an array of post-synaptic event histories
+//! \param[in] n_neurons: Number of neurons
+//! \return The array
+static inline post_event_history_t *post_events_init_buffers(
+        uint32_t n_neurons) {
+    post_event_history_t *history =
+            spin1_malloc(n_neurons * sizeof(post_event_history_t));
+    // Check allocations succeeded
+    if (history == NULL) {
+        log_error("Unable to allocate global STDP structures - Out of DTCM: Try "
+                "reducing the number of neurons per core to fix this problem ");
+        return NULL;
+    }
+
+    // Loop through neurons and set count to 0
+    for (uint32_t n = 0; n < n_neurons; n++) {
+    	history[n].count = 0;
+		for (uint32_t e = 0; e < MAX_EVENTS; e++) {
+			history[n].traces[e].synapse_type = 0;
+			history[n].traces[e].pre_spike = 0;
+			history[n].traces[e].weight_change = 0;
+		}
+    }
+
+    return history;
+}
+
+//---------------------------------------
+//! \brief Add a post-synaptic event to the history
+//! \param[in] time: the time of the event
+//! \param[in,out] events: the history to add to
+//! \param[in] trace: the trace of the event
+static inline void post_events_add(
+        post_event_history_t *events, uint16_t weight_change,
+        uint32_t pre_spike, uint16_t synapse_type) {
+    if (events->count < MAX_EVENTS) {
+        // If there's still space, store time at current end
+        // and increment count minus 1
+        const uint32_t new_index = events->count++;
+        events->traces[new_index].weight_change = weight_change;
+        events->traces[new_index].pre_spike = pre_spike;
+        events->traces[new_index].synapse_type = synapse_type;
+		log_debug("Added pre spike %u with weight change %d to index %d", pre_spike,
+			weight_change, new_index);
+    } else {
+    	log_debug("Events full, shuffling");
+        // Otherwise Shuffle down elements
+        for (uint32_t e = 1; e < MAX_EVENTS; e++) {
+            events->traces[e - 1] = events->traces[e];
+        }
+
+        // Stick new time at end
+        events->traces[MAX_EVENTS - 1].weight_change = weight_change;
+        events->traces[MAX_EVENTS - 1].pre_spike = pre_spike;
+        events->traces[MAX_EVENTS - 1].synapse_type = synapse_type;
+    	log_debug("Added pre spike %u with weight change %d to index %d", pre_spike,
+    			weight_change, MAX_EVENTS - 1);
+    }
+}
+
+static inline bool post_events_remove(post_event_history_t *events, uint32_t index) {
+    // Already gone? nothing to do!
+    if (index >= events->count) {
+        return false;
+    }
+    if (events->count > 1) {
+        // Swap the last one with the one to remove
+        events->traces[index] = events->traces[events->count - 1];
+    }
+    events->count--;
+    return events->count > 0;
+}
+
+#endif  // _POST_EVENTS_H_

--- a/neural_modelling/src/neuron/plasticity/weight_change/post_events_with_weight_change.h
+++ b/neural_modelling/src/neuron/plasticity/weight_change/post_events_with_weight_change.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 The University of Manchester
+ * Copyright (c) 2024 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/neural_modelling/src/neuron/plasticity/weight_change/post_events_with_weight_change.h
+++ b/neural_modelling/src/neuron/plasticity/weight_change/post_events_with_weight_change.h
@@ -35,7 +35,7 @@
 
 typedef struct update_post_trace_t {
 
-    //! The new weight to set
+    //! The amount to change the weight by (positive or negative)
     int16_t weight_change;
 
     //! The synapse type

--- a/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
+++ b/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 The University of Manchester
+ * Copyright (c) 2024 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
+++ b/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2016 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! \file
+//! \brief Allow weight change
+#include "post_events_with_weight_change.h"
+#include <neuron/synapses.h>
+#include <neuron/plasticity/synapse_dynamics.h>
+#include <stddef.h>
+
+typedef struct limits {
+	weight_t min;
+	weight_t max;
+} limits;
+
+typedef struct change_params {
+	uint32_t n_limits;
+	limits weight_limits[];
+} change_params;
+
+typedef struct updatable_synapse_t {
+    weight_t weight;
+} updatable_synapse_t;
+
+struct synapse_row_plastic_data_t {
+    uint32_t pre_spike: 31;
+    uint32_t is_update: 1;
+
+    // This is only present if is_update is false
+    updatable_synapse_t synapses[];
+};
+
+typedef struct fixed_stdp_synapse {
+    uint32_t delay;
+    uint32_t type;
+    uint32_t index;
+    uint32_t ring_buffer_index;
+} fixed_stdp_synapse;
+
+//! \brief The history data of post-events
+static post_event_history_t *post_event_history;
+
+//! Count of pre-synaptic events relevant to plastic processing
+static uint32_t num_plastic_pre_synaptic_events = 0;
+
+//! Count of times that the plastic math became saturated
+static uint32_t plastic_saturation_count = 0;
+
+//! Parameters
+static change_params *params;
+
+bool synapse_dynamics_initialise(
+        address_t address, uint32_t n_neurons,
+        uint32_t n_synapse_types,
+        UNUSED uint32_t *ring_buffer_to_input_buffer_left_shifts) {
+
+	change_params *sdram_params = (change_params *) address;
+	uint32_t size = sizeof(change_params) + (n_synapse_types * sizeof(limits));
+	params = spin1_malloc(size);
+	if (params == NULL) {
+		log_error("Unable to allocate memory for params");
+		return false;
+	}
+	spin1_memcpy(params, sdram_params, size);
+	for (uint32_t i = 0; i < n_synapse_types; i++) {
+		log_info("Synapse type %u: min = %d, max = %d", i,
+				params->weight_limits[i].min, params->weight_limits[i].max);
+	}
+
+    post_event_history = post_events_init_buffers(n_neurons);
+    if (post_event_history == NULL) {
+        log_error("Failed to allocate post_event_history");
+        return false;
+    }
+
+    return true;
+}
+
+//---------------------------------------
+void synapse_dynamics_process_post_synaptic_event(
+        UNUSED uint32_t time, UNUSED index_t neuron_index) {
+    // Do Nothing - not needed here!
+}
+
+static inline fixed_stdp_synapse synapse_dynamics_stdp_get_fixed(
+        uint32_t control_word, uint32_t time, uint32_t colour_delay) {
+    // Extract control-word components
+    // **NOTE** cunningly, control word is just the same as lower
+    // 16-bits of 32-bit fixed synapse so same functions can be used
+    uint32_t delay = synapse_row_sparse_delay(control_word,
+            synapse_type_index_bits, synapse_delay_mask);
+    uint32_t type_index = synapse_row_sparse_type_index(control_word,
+            synapse_type_index_mask);
+    uint32_t type = synapse_row_sparse_type(control_word, synapse_index_bits,
+    		synapse_type_mask);
+    uint32_t index = synapse_row_sparse_index(control_word, synapse_index_mask);
+    return (fixed_stdp_synapse) {
+       .delay = delay,
+       .type = type,
+	   .index = index,
+       .ring_buffer_index = synapse_row_get_ring_buffer_index_combined(
+                (delay + time) - colour_delay, type_index,
+                synapse_type_index_bits, synapse_delay_mask)
+    };
+}
+
+static inline void synapse_dynamics_stdp_update_ring_buffers(
+        weight_t *ring_buffers, fixed_stdp_synapse s, int32_t weight) {
+    uint32_t accumulation = ring_buffers[s.ring_buffer_index] + weight;
+
+    uint32_t sat_test = accumulation & 0xFFFF0000;
+    if (sat_test) {
+        accumulation = 0xFFFF;
+        plastic_saturation_count++;
+    }
+
+    ring_buffers[s.ring_buffer_index] = accumulation;
+}
+
+//---------------------------------------
+static inline updatable_synapse_t process_plastic_synapse(
+        uint32_t pre_spike, uint32_t control_word, weight_t *ring_buffers,
+        uint32_t time, uint32_t colour_delay, updatable_synapse_t synapse,
+        uint32_t *changed) {
+    fixed_stdp_synapse s = synapse_dynamics_stdp_get_fixed(control_word, time,
+            colour_delay);
+
+
+    // Work out if the weight needs to be updated
+    post_event_history_t *history = &post_event_history[s.index];
+    weight_t min_weight = params->weight_limits[s.type].min;
+    weight_t max_weight = params->weight_limits[s.type].max;
+    log_debug("    Looking at change weight history 0x%08x of %u items to post"
+    		" neuron index %u", history, history->count, s.index);
+    for (uint32_t i = 0; i < history->count; i++) {
+        update_post_trace_t *trace = &history->traces[i];
+		log_debug(
+				"        Checking history item %u, weight change %d for"
+				" pre-neuron %u, synapse_type = %u",
+				i, trace->weight_change, trace->pre_spike, trace->synapse_type);
+        if (trace->pre_spike == pre_spike && s.type == trace->synapse_type) {
+        	int32_t new_weight = synapse.weight + trace->weight_change;
+            if (new_weight < min_weight) {
+                synapse.weight = min_weight;
+            } else if (new_weight > max_weight) {
+                synapse.weight = max_weight;
+            } else {
+                synapse.weight = (weight_t) new_weight;
+            }
+            log_debug("        Weight now %d", synapse.weight);
+            *changed = 1;
+
+            // Remove the done item from history and then go back to make sure
+            // we do the next one!
+            if (post_events_remove(history, i)) {
+                i--;
+            }
+        }
+    }
+
+    // Add weight to ring-buffer entry, but only if not too late
+    if (s.delay > colour_delay) {
+        synapse_dynamics_stdp_update_ring_buffers(ring_buffers, s,
+                synapse.weight);
+    } else {
+        skipped_synapses++;
+    }
+
+    return synapse;
+}
+
+static inline int16_t change_sign(weight_t weight) {
+    union {
+        weight_t weight;
+        int16_t value;
+    } converter;
+    converter.weight = weight;
+    return converter.value;
+}
+
+static inline void process_weight_update(
+        synapse_row_plastic_data_t *plastic_region_address,
+        synapse_row_fixed_part_t *fixed_region) {
+    uint32_t n_synapses = synapse_row_num_plastic_controls(fixed_region);
+    const uint32_t *words = (uint32_t *) synapse_row_plastic_controls(fixed_region);
+    uint32_t pre_spike = plastic_region_address->pre_spike;
+
+	log_debug("Weight change update for pre-neuron %u", pre_spike);
+
+    // Loop through synapses
+    for (; n_synapses > 0; n_synapses--) {
+        // Get next control word (auto incrementing)
+        uint32_t word = *words++;
+        int32_t weight_change = change_sign(synapse_row_sparse_weight(word));
+        uint32_t synapse_type = synapse_row_sparse_type(word,
+        		synapse_index_bits, synapse_type_mask);
+        uint32_t neuron_index = synapse_row_sparse_index(word,
+        		synapse_index_mask);
+
+        log_debug("    Adding weight change %d to post-neuron %u",
+						weight_change, neuron_index);
+
+        // Get post event history of this neuron
+        post_event_history_t *history = &post_event_history[neuron_index];
+
+        // Add a new history trace into the buffer of post synaptic events
+        post_events_add(history, weight_change, pre_spike, synapse_type);
+    }
+}
+
+bool synapse_dynamics_process_plastic_synapses(
+        synapse_row_plastic_data_t *plastic_region_address,
+        synapse_row_fixed_part_t *fixed_region,
+        weight_t *ring_buffers, uint32_t time, uint32_t colour_delay,
+        bool *write_back) {
+
+    // If the flag is set, this is neuromodulation
+    if (plastic_region_address->is_update) {
+        process_weight_update(plastic_region_address, fixed_region);
+        *write_back = false;
+        return true;
+    }
+
+    // Extract separate arrays of plastic synapses (from plastic region),
+    // Control words (from fixed region) and number of plastic synapses
+    updatable_synapse_t *plastic_words = plastic_region_address->synapses;
+    const control_t *control_words = synapse_row_plastic_controls(fixed_region);
+    size_t n_plastic_synapses = synapse_row_num_plastic_controls(fixed_region);
+
+    num_plastic_pre_synaptic_events += n_plastic_synapses;
+    uint32_t pre_spike = plastic_region_address->pre_spike;
+
+    log_debug("Checking for weight changes for pre-neuron %u", pre_spike);
+
+    // Loop through plastic synapses
+    for (; n_plastic_synapses > 0; n_plastic_synapses--) {
+        // Get next control word (auto incrementing)
+        uint32_t control_word = *control_words++;
+        uint32_t changed = 0;
+        plastic_words[0] = process_plastic_synapse(pre_spike, control_word,
+                ring_buffers, time, colour_delay, plastic_words[0], &changed);
+        plastic_words++;
+        if (changed) {
+            *write_back = true;
+        }
+    }
+    return true;
+}
+
+input_t synapse_dynamics_get_intrinsic_bias(
+        UNUSED uint32_t time, UNUSED index_t neuron_index) {
+    return ZERO;
+}
+
+uint32_t synapse_dynamics_get_plastic_pre_synaptic_events(void) {
+    return num_plastic_pre_synaptic_events;
+}
+
+uint32_t synapse_dynamics_get_plastic_saturation_count(void) {
+    return plastic_saturation_count;
+}

--- a/neural_modelling/src/synapse_expander/matrix_generator.c
+++ b/neural_modelling/src/synapse_expander/matrix_generator.c
@@ -26,6 +26,7 @@
 #include "matrix_generators/matrix_generator_static.h"
 #include "matrix_generators/matrix_generator_stdp.h"
 #include "matrix_generators/matrix_generator_neuromodulation.h"
+#include "matrix_generators/matrix_generator_weight_changer.h"
 #include <delay_extension/delay_extension.h>
 
 //! The "hashes" for synaptic matrix generators
@@ -36,6 +37,8 @@ enum {
     PLASTIC_MATRIX_GENERATOR,
     //! Generate a synaptic matrix for Neuromodulation
     NEUROMODULATION_MATRIX_GENERATOR,
+	//! Generate a synaptic matrix for weight change
+	WEIGHT_CHANGER_MATRIX_GENERATOR,
     /**
      * \brief The number of known generators
      */
@@ -86,7 +89,11 @@ static const struct matrix_generator_info matrix_generators[] = {
     {NEUROMODULATION_MATRIX_GENERATOR,
             matrix_generator_neuromodulation_initialize,
             matrix_generator_neuromodulation_write_synapse,
-            matrix_generator_neuromodulation_free}
+            matrix_generator_neuromodulation_free},
+    {WEIGHT_CHANGER_MATRIX_GENERATOR,
+		matrix_generator_changer_initialize,
+		matrix_generator_changer_write_synapse,
+		matrix_generator_changer_free}
 };
 
 matrix_generator_t matrix_generator_init(uint32_t hash, void **in_region,

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_stdp.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_stdp.h
@@ -85,6 +85,9 @@ typedef struct matrix_generator_stdp {
     uint32_t n_half_words_per_pp_synapse;
     //! The index of the half-word that will contain the weight
     uint32_t weight_half_word;
+    //! Whether to write the pre-neuron index in the first word of the header
+    //! space (used for externally changeable synapses)
+    uint32_t first_word_is_pre_index;
 } matrix_generator_stdp_data_t;
 
 /**
@@ -138,16 +141,22 @@ static row_fixed_t *get_stdp_fixed_row(row_plastic_t *plastic_row,
  */
 static void setup_stdp_rows(uint32_t *matrix, uint32_t n_rows,
         uint32_t n_half_words_per_pp_header, uint32_t n_half_words_per_pp_synapse,
-        uint32_t max_row_n_synapses, uint32_t max_row_n_words) {
+        uint32_t max_row_n_synapses, uint32_t max_row_n_words,
+		uint32_t first_header_word_is_pre_index) {
 
     // Set all the header half-words to 0 and set all the sizes
     uint32_t plastic_words = plastic_half_words(n_half_words_per_pp_header,
             n_half_words_per_pp_synapse, max_row_n_synapses) >> 1;
     for (uint32_t i = 0; i < n_rows; i++) {
         row_plastic_t *row = get_row(matrix, max_row_n_words, i);
-        // Use word writing for efficiency
+        // Use word writing for efficiency (and to write the first word)
         uint32_t *data = (uint32_t *) &row->plastic_plastic_data[0];
-        for (uint32_t j = 0; j < plastic_words; j++) {
+		if (first_header_word_is_pre_index) {
+			data[0] = i;
+		} else {
+			data[0] = 0;
+		}
+        for (uint32_t j = 1; j < plastic_words; j++) {
             data[j] = 0;
         }
         row->plastic_plastic_size = plastic_words;
@@ -210,7 +219,7 @@ void *matrix_generator_stdp_initialize(void **region, void *synaptic_matrix) {
         setup_stdp_rows(obj->synaptic_matrix, obj->n_pre_neurons,
                 obj->n_half_words_per_pp_row_header,
                 obj->n_half_words_per_pp_synapse, obj->max_row_n_synapses,
-                obj->max_row_n_words);
+                obj->max_row_n_words, obj->first_word_is_pre_index);
     } else {
         obj->synaptic_matrix = NULL;
     }
@@ -221,7 +230,8 @@ void *matrix_generator_stdp_initialize(void **region, void *synaptic_matrix) {
                 obj->n_pre_neurons * (obj->max_stage - 1),
                 obj->n_half_words_per_pp_row_header,
                 obj->n_half_words_per_pp_synapse,
-                obj->max_delayed_row_n_synapses, obj->max_delayed_row_n_words);
+                obj->max_delayed_row_n_synapses, obj->max_delayed_row_n_words,
+				obj->first_word_is_pre_index);
     } else {
         obj->delayed_synaptic_matrix = NULL;
     }

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_weight_changer.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_weight_changer.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2017 The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief Weight-changer synaptic matrix implementation
+ */
+
+#include <stdbool.h>
+#include <debug.h>
+#include <delay_extension/delay_extension.h>
+#include "matrix_generator_common.h"
+#include <synapse_expander/generator_types.h>
+#include <utils.h>
+
+typedef struct {
+    union {
+        //! The address of the synaptic matrix (once initialised)
+        uint32_t *synaptic_matrix;
+        //! The offset of the synaptic matrix (as read from SDRAM)
+        uint32_t synaptic_matrix_offset;
+    };
+    uint32_t max_row_n_words;
+    uint32_t max_row_n_synapses;
+    uint32_t n_pre_neurons;
+    uint32_t synapse_type;
+    uint32_t synapse_type_bits;
+    uint32_t synapse_index_bits;
+} matrix_generator_weight_changer;
+
+//! The layout of the initial plastic synapse part of the row
+typedef struct {
+    uint32_t plastic_plastic_size;   //!< the plastic-plastic size within the row
+    uint32_t pre_spike: 31;
+    uint32_t is_update: 1;
+} row_changer_plastic_t;
+
+//! The layout of the fixed synapse region of the row; the fixed-fixed region is empty
+typedef struct {
+    uint32_t fixed_fixed_size;      //!< the fixed-fixed size within the fixed region
+    uint32_t fixed_plastic_size;    //!< the fixed-plastic size within the fixed region
+    int32_t fixed_plastic_data[];  //!< the fixed-plastic data within the fixed region
+} row_changer_fixed_t;
+
+/**
+ * \brief Get a synaptic row for a given neuron
+ * \param[in] synaptic_matrix the address of the synaptic matrix
+ * \param[in] max_row_n_words the maximum number of words (excluding headers)
+ *                            in each row of the table
+ * \param[in] pre_index the index of the pre-neuron relative to the start of the
+ *                      matrix
+ * \return A pointer to the row of the matrix to write to
+ */
+static row_changer_plastic_t *get_changer_row(uint32_t *synaptic_matrix,
+		uint32_t max_row_n_words, uint32_t pre_index) {
+    uint32_t idx = pre_index * (max_row_n_words + N_HEADER_WORDS);
+    return (row_changer_plastic_t *) &synaptic_matrix[idx];
+}
+
+/**
+ * \brief Get the fixed part of a row that comes after the plastic part.
+ * \param[in] plastic_row A pointer to the row to find the fixed part of
+ * \return A pointer to the fixed part of the matrix to write to
+ */
+static row_changer_fixed_t *get_changer_fixed_row(row_changer_plastic_t *plastic_row) {
+    return (row_changer_fixed_t *) &plastic_row[1];
+}
+
+/**
+ * \brief Set up the rows so that they are ready for writing to
+ * \param[in] matrix The base address of the matrix to set up
+ * \param[in] n_rows The number of rows in the matrix
+ * \param[in] max_row_n_words The maximum number of words used by a row
+ */
+static void setup_changer_rows(uint32_t *matrix, uint32_t n_rows,
+		uint32_t max_row_n_words) {
+    for (uint32_t i = 0; i < n_rows; i++) {
+        row_changer_plastic_t *row = get_changer_row(matrix, max_row_n_words, i);
+        row->plastic_plastic_size = 1;
+        row->pre_spike = i;
+        row->is_update = 1;
+        row_changer_fixed_t *fixed = get_changer_fixed_row(row);
+        fixed->fixed_fixed_size = 0;
+        fixed->fixed_plastic_size = 0;
+    }
+}
+
+
+/**
+ * \brief Initialise the Changer synaptic matrix generator
+ * \param[in,out] region: Region to read parameters from.  Should be updated
+ *                        to position just after parameters after calling.
+ * \param[in] synaptic_matrix: The base address of the synaptic matrix
+ * \return A data item to be passed in to other functions later on
+ */
+void *matrix_generator_changer_initialize(void **region,
+        void *synaptic_matrix) {
+    // Allocate memory for the parameters
+    matrix_generator_weight_changer *conf =
+            spin1_malloc(sizeof(matrix_generator_weight_changer));
+
+    // Copy the parameters in
+    matrix_generator_weight_changer *params_sdram = *region;
+    *conf = *params_sdram;
+    *region = &params_sdram[1];
+
+    // Offsets are in words
+    uint32_t *syn_mat = synaptic_matrix;
+    conf->synaptic_matrix = &(syn_mat[conf->synaptic_matrix_offset]);
+    setup_changer_rows(conf->synaptic_matrix, conf->n_pre_neurons,
+    		conf->max_row_n_words);
+
+    return conf;
+}
+
+/**
+ * \brief Free any data for the matrix generator
+ * \param[in] generator: The generator to free
+ */
+void matrix_generator_changer_free(void *generator) {
+    sark_free(generator);
+}
+
+static uint32_t build_changer_word(
+        uint32_t type, uint32_t post_index, uint32_t synapse_type_bits,
+        uint32_t synapse_index_bits, int16_t weight) {
+    uint32_t synapse_index_mask = (1 << synapse_index_bits) - 1;
+    uint32_t synapse_type_mask = (1 << synapse_type_bits) - 1;
+
+    uint32_t wrd = post_index & synapse_index_mask;
+    wrd |= (type & synapse_type_mask) << synapse_index_bits;
+    // The weight position is fixed
+    wrd |= weight << 16;
+
+    return wrd;
+}
+
+static bool matrix_generator_changer_write_synapse(void *generator,
+        uint32_t pre_index, uint16_t post_index, accum weight,
+        UNUSED uint16_t delay, unsigned long accum weight_scale) {
+    matrix_generator_weight_changer *conf = generator;
+    row_changer_plastic_t *plastic_row = get_changer_row(conf->synaptic_matrix,
+            conf->max_row_n_words, pre_index);
+    row_changer_fixed_t *fixed_row = get_changer_fixed_row(plastic_row);
+    uint32_t pos = fixed_row->fixed_plastic_size;
+    if (pos >= conf->max_row_n_synapses) {
+        log_warning("Row %u at 0x%08x, 0x%08x of matrix 0x%08x is already full (%u of %u)",
+                pre_index, plastic_row, fixed_row, conf->synaptic_matrix, pos,
+				conf->max_row_n_synapses);
+        return false;
+    }
+    uint16_t scaled_weight = rescale_weight(weight, weight_scale);
+    int16_t signed_weight = (int16_t) scaled_weight;
+    if (weight < 0) {
+        signed_weight = -signed_weight;
+    }
+    fixed_row->fixed_plastic_size = pos + 1;
+	fixed_row->fixed_plastic_data[pos] = build_changer_word(conf->synapse_type,
+			post_index, conf->synapse_type_bits, conf->synapse_index_bits,
+			signed_weight);
+    return true;
+}

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_weight_changer.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_weight_changer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 The University of Manchester
+ * Copyright (c) 2024 The University of Manchester
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_weight_changer.h
+++ b/neural_modelling/src/synapse_expander/matrix_generators/matrix_generator_weight_changer.h
@@ -39,6 +39,7 @@ typedef struct {
     uint32_t synapse_type;
     uint32_t synapse_type_bits;
     uint32_t synapse_index_bits;
+    uint32_t row_offset;
 } matrix_generator_weight_changer;
 
 //! The layout of the initial plastic synapse part of the row
@@ -86,11 +87,11 @@ static row_changer_fixed_t *get_changer_fixed_row(row_changer_plastic_t *plastic
  * \param[in] max_row_n_words The maximum number of words used by a row
  */
 static void setup_changer_rows(uint32_t *matrix, uint32_t n_rows,
-		uint32_t max_row_n_words) {
+		uint32_t max_row_n_words, uint32_t row_offset) {
     for (uint32_t i = 0; i < n_rows; i++) {
         row_changer_plastic_t *row = get_changer_row(matrix, max_row_n_words, i);
         row->plastic_plastic_size = 1;
-        row->pre_spike = i;
+        row->pre_spike = i + row_offset;
         row->is_update = 1;
         row_changer_fixed_t *fixed = get_changer_fixed_row(row);
         fixed->fixed_fixed_size = 0;
@@ -121,7 +122,7 @@ void *matrix_generator_changer_initialize(void **region,
     uint32_t *syn_mat = synaptic_matrix;
     conf->synaptic_matrix = &(syn_mat[conf->synaptic_matrix_offset]);
     setup_changer_rows(conf->synaptic_matrix, conf->n_pre_neurons,
-    		conf->max_row_n_words);
+    		conf->max_row_n_words, conf->row_offset);
 
     return conf;
 }

--- a/spynnaker/pyNN/extra_models/__init__.py
+++ b/spynnaker/pyNN/extra_models/__init__.py
@@ -18,7 +18,9 @@ from spynnaker.pyNN.models.neuron.plasticity.stdp.timing_dependence import (
     TimingDependenceVogels2011 as Vogels2011Rule,
     TimingDependencePfisterSpikeTriplet as PfisterSpikeTriplet)
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
-    SynapseDynamicsNeuromodulation as Neuromodulation)
+    SynapseDynamicsNeuromodulation as Neuromodulation,
+    SynapseDynamicsWeightChangable as WeightChangeable,
+    SynapseDynamicsWeightChanger as WeightChanger)
 from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence import (
     WeightDependenceAdditiveTriplet)
 from spynnaker.pyNN.models.neuron.builds import (
@@ -62,5 +64,8 @@ __all__ = [
     'IFTruncDelta',
 
     # Connectors
-    'AllButMeConnector'
+    'AllButMeConnector',
+
+    # Weight changeable synapse dynamics
+    'WeightChangeable', 'WeightChanger'
     ]

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/__init__.py
@@ -31,6 +31,8 @@ from .synapse_dynamics_utils import (
     calculate_spike_pair_additive_stdp_weight,
     calculate_spike_pair_multiplicative_stdp_weight)
 from .synapse_dynamics_neuromodulation import SynapseDynamicsNeuromodulation
+from .synapse_dynamics_weight_changable import SynapseDynamicsWeightChangable
+from .synapse_dynamics_weight_changer import SynapseDynamicsWeightChanger
 
 
 __all__ = ("AbstractGenerateOnMachine", "AbstractPlasticSynapseDynamics",
@@ -46,4 +48,5 @@ __all__ = ("AbstractGenerateOnMachine", "AbstractPlasticSynapseDynamics",
            "SynapseDynamicsStructuralSTDP",
            # Neuromodulation
            "SynapseDynamicsNeuromodulation",
-           "AbstractSupportsSignedWeights")
+           "AbstractSupportsSignedWeights",
+           "SynapseDynamicsWeightChanger", "SynapseDynamicsWeightChangable")

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_generate_on_machine.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_generate_on_machine.py
@@ -33,6 +33,7 @@ class MatrixGeneratorID(Enum):
     STATIC_MATRIX = 0
     STDP_MATRIX = 1
     NEUROMODULATION_MATRIX = 2
+    CHANGE_WEIGHT_MATRIX = 3
 
 
 class AbstractGenerateOnMachine(object, metaclass=AbstractBase):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
     from spynnaker.pyNN.models.neural_projections.connectors import (
         AbstractConnector)
     from spynnaker.pyNN.models.neural_projections import SynapseInformation
+    from spynnaker.pyNN.models.neural_projections import (
+        ProjectionApplicationEdge)
 
 logger = FormatAdapter(logging.getLogger(__name__))
 
@@ -377,3 +379,22 @@ class AbstractSynapseDynamics(object, metaclass=AbstractBase):
         """
         # By default, we can only support the maximum row length per core
         return POP_TABLE_MAX_ROW_LENGTH
+
+    def validate_connection(
+            self, application_edge: ProjectionApplicationEdge,
+            synapse_info: SynapseInformation):
+        """
+        Checks that the edge supports the connector.  Returns nothing; it
+        is assumed that an Exception will be raised if anything is wrong.
+
+        By default this checks only that the views are not used
+        on multi-dimensional vertices.
+
+        :param application_edge: The edge of the connection
+        :type application_edge:
+            ~pacman.model.graphs.application.ApplicationEdge
+        :param SynapseInformation synapse_info: The synaptic information
+        """
+        # By default, just ask the connector
+        synapse_info.connector.validate_connection(
+            application_edge, synapse_info)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -607,6 +607,7 @@ class SynapseDynamicsSTDP(
             n_half_words += 1
             half_word = 0
         write_row_number_to_header = 0
+        row_offset = 0
         return numpy.array([
             synaptic_matrix_offset, delayed_matrix_offset,
             max_row_info.undelayed_max_n_synapses,
@@ -616,13 +617,13 @@ class SynapseDynamicsSTDP(
             n_synapse_index_bits, app_edge.n_delay_stages + 1,
             max_delay, max_delay_bits, app_edge.pre_vertex.n_atoms,
             max_pre_atoms_per_core, self._n_header_bytes // BYTES_PER_SHORT,
-            n_half_words, half_word, write_row_number_to_header],
+            n_half_words, half_word, write_row_number_to_header, row_offset],
             dtype=uint32)
 
     @property
     @overrides(AbstractGenerateOnMachine.gen_matrix_params_size_in_bytes)
     def gen_matrix_params_size_in_bytes(self) -> int:
-        return 18 * BYTES_PER_WORD
+        return 19 * BYTES_PER_WORD
 
     @property
     @overrides(AbstractPlasticSynapseDynamics.changes_during_run)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -40,6 +40,8 @@ from .synapse_dynamics_static import SynapseDynamicsStatic
 from .synapse_dynamics_stdp import SynapseDynamicsSTDP
 from .synapse_dynamics_structural_stdp import SynapseDynamicsStructuralSTDP
 from .abstract_synapse_dynamics import AbstractSynapseDynamics
+from .synapse_dynamics_weight_changable import SynapseDynamicsWeightChangable
+from .synapse_dynamics_weight_changer import SynapseDynamicsWeightChanger
 
 if TYPE_CHECKING:
     from pacman.model.graphs import AbstractVertex
@@ -156,6 +158,12 @@ class SynapseDynamicsStructuralStatic(SynapseDynamicsStatic, _Common):
     @overrides(AbstractStaticSynapseDynamics.merge)
     def merge(self, synapse_dynamics: AbstractSynapseDynamics
               ) -> AbstractSynapseDynamics:
+        if isinstance(synapse_dynamics, (SynapseDynamicsWeightChangable,
+                                         SynapseDynamicsWeightChanger)):
+            raise SynapticConfigurationException(
+                "Weight Changer and Structural Plasticity are not currently"
+                " compatible")
+
         # If the dynamics is structural, check if same as this
         if isinstance(synapse_dynamics, AbstractSynapseDynamicsStructural):
             if not self.is_same_as(synapse_dynamics):

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -37,6 +37,8 @@ from .synapse_dynamics_structural_common import (
     DEFAULT_F_REW, DEFAULT_INITIAL_WEIGHT, DEFAULT_INITIAL_DELAY,
     DEFAULT_S_MAX, SynapseDynamicsStructuralCommon)
 from .synapse_dynamics_neuromodulation import SynapseDynamicsNeuromodulation
+from .synapse_dynamics_weight_changable import SynapseDynamicsWeightChangable
+from .synapse_dynamics_weight_changer import SynapseDynamicsWeightChanger
 
 if TYPE_CHECKING:
     from pacman.model.graphs import AbstractVertex
@@ -172,6 +174,13 @@ class SynapseDynamicsStructuralSTDP(
     @overrides(AbstractPlasticSynapseDynamics.merge)
     def merge(self, synapse_dynamics: AbstractSynapseDynamics
               ) -> SynapseDynamicsStructuralSTDP:
+
+        if isinstance(synapse_dynamics, (SynapseDynamicsWeightChangable,
+                                         SynapseDynamicsWeightChanger)):
+            raise SynapticConfigurationException(
+                "Weight Changer and Structural Plasticity are not currently"
+                " compatible")
+
         # If dynamics is Neuromodulation, merge with other neuromodulation,
         # and then return ourselves, as neuromodulation can't be used by
         # itself

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
-from typing import Any, Iterable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy
 from numpy import floating, integer, uint8, uint16, uint32
@@ -26,9 +26,7 @@ from spinn_front_end_common.interface.ds import DataSpecificationBase
 from spinn_front_end_common.utilities.constants import (
     BYTES_PER_WORD, BYTES_PER_SHORT)
 
-from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.exceptions import (
-    SynapticConfigurationException, InvalidParameterType)
+from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractConnector)
 from spynnaker.pyNN.types import Weight_Types

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 from typing import Iterable, List, Optional, Tuple, Dict, TYPE_CHECKING, cast
+import logging
 
 import numpy
 from numpy import floating, integer, uint8, uint16, uint32
@@ -21,6 +22,7 @@ from numpy.typing import NDArray
 from pyNN.standardmodels.synapses import StaticSynapse
 
 from spinn_utilities.overrides import overrides
+from spinn_utilities.log import FormatAdapter
 
 from spinn_front_end_common.interface.ds import DataSpecificationBase
 from spinn_front_end_common.utilities.constants import (
@@ -56,6 +58,8 @@ NEUROMODULATION_TARGETS = {
     "reward": 0,
     "punishment": 1
 }
+
+logger = FormatAdapter(logging.getLogger(__name__))
 
 
 class SynapseDynamicsWeightChangable(
@@ -242,6 +246,10 @@ class SynapseDynamicsWeightChangable(
             pp_data: List[NDArray[uint32]], fp_size: NDArray[uint32],
             fp_data: List[NDArray[uint32]],
             max_atoms_per_core: int) -> ConnectionsArray:
+        logger.warn("Weights are only changed when a pre-spike arrives after a"
+                    " change-spike has been received, and so the weights might"
+                    " not be as expected")
+
         # pylint: disable=too-many-arguments
         n_rows = len(fp_size)
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -127,6 +127,7 @@ class SynapseDynamicsWeightChangable(
         if not self.is_same_as(synapse_dynamics):
             raise SynapticConfigurationException(
                 "Multiple WeightChangables must have the same min and max")
+        return self
 
     @overrides(AbstractPlasticSynapseDynamics.get_value)
     def get_value(self, key: str) -> Any:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -158,7 +158,8 @@ class SynapseDynamicsWeightChangable(
 
     @overrides(AbstractPlasticSynapseDynamics.
                get_parameters_sdram_usage_in_bytes)
-    def get_parameters_sdram_usage_in_bytes(self, n_neurons, n_synapse_types):
+    def get_parameters_sdram_usage_in_bytes(
+            self, n_neurons: int, n_synapse_types: int) -> int:
         """
         :param int n_neurons:
         :param int n_synapse_types:
@@ -190,7 +191,7 @@ class SynapseDynamicsWeightChangable(
 
     @overrides(AbstractPlasticSynapseDynamics.
                get_n_words_for_plastic_connections)
-    def get_n_words_for_plastic_connections(self, n_connections):
+    def get_n_words_for_plastic_connections(self, n_connections: int) -> int:
         """
         :param int n_connections:
         :rtype: int

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -99,7 +99,13 @@ class SynapseDynamicsWeightChangable(
         self.__synapse_info_to_index: Dict[SynapseInformation, int] = dict()
         self.__next_index = 0
 
-        if (weight_min >= weight_max):
+        if weight_min < 0.0:
+            raise SynapticConfigurationException(
+                "The minimum weight must be greater than or equal to 0")
+        if weight_max < 0.0:
+            raise SynapticConfigurationException(
+                "The maximum weight must be greater than or equal to 0")
+        if weight_min >= weight_max:
             raise SynapticConfigurationException(
                 "The minimum weight must be less than the maximum")
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -1,0 +1,363 @@
+# Copyright (c) 2015 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+from typing import Any, Iterable, List, Optional, Tuple, TYPE_CHECKING
+
+import numpy
+from numpy import floating, integer, uint8, uint16, uint32
+from numpy.typing import NDArray
+
+from pyNN.standardmodels.synapses import StaticSynapse
+
+from spinn_utilities.overrides import overrides
+
+from spinn_front_end_common.interface.ds import DataSpecificationBase
+from spinn_front_end_common.utilities.constants import (
+    BYTES_PER_WORD, BYTES_PER_SHORT)
+
+from spynnaker.pyNN.data import SpynnakerDataView
+from spynnaker.pyNN.exceptions import (
+    SynapticConfigurationException, InvalidParameterType)
+from spynnaker.pyNN.models.neural_projections.connectors import (
+    AbstractConnector)
+from spynnaker.pyNN.types import Weight_Types
+from spynnaker.pyNN.types import Weight_Delay_In_Types as _In_Types
+from spynnaker.pyNN.utilities.utility_calls import get_n_bits
+from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
+    NUMPY_CONNECTORS_DTYPE)
+from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
+from .abstract_generate_on_machine import (
+    AbstractGenerateOnMachine, MatrixGeneratorID)
+from .synapse_dynamics_weight_changer import SynapseDynamicsWeightChanger
+
+if TYPE_CHECKING:
+    from spynnaker.pyNN.models.neural_projections import (
+        ProjectionApplicationEdge, SynapseInformation)
+    from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
+        ConnectionsArray)
+    from spynnaker.pyNN.models.neuron.synapse_io import MaxRowInfo
+    from .abstract_synapse_dynamics import AbstractSynapseDynamics
+
+# How large are the time-stamps stored with each event
+TIME_STAMP_BYTES = BYTES_PER_WORD
+
+# The targets of neuromodulation
+NEUROMODULATION_TARGETS = {
+    "reward": 0,
+    "punishment": 1
+}
+
+
+class SynapseDynamicsWeightChangable(
+        AbstractPlasticSynapseDynamics, AbstractGenerateOnMachine):
+    """
+    The dynamics of a synapse that can be changed simply by the sending of an
+    external signal.
+    """
+
+    __slots__ = (
+
+        # The maximum weight
+        "__weight_max",
+
+        # The minimum weight
+        "__weight_min")
+
+    def __init__(
+            self,
+            weight_min: float, weight_max: float,
+            weight: _In_Types = StaticSynapse.default_parameters['weight'],
+            delay: _In_Types = None):
+        """
+        :param float weight:
+        :param delay: Use ``None`` to get the simulator default minimum delay.
+        :type delay: float or None
+        """
+        super().__init__(delay=delay, weight=weight)
+        self.__weight_max = weight_max
+        self.__weight_min = weight_min
+
+    @overrides(AbstractPlasticSynapseDynamics.merge)
+    def merge(self, synapse_dynamics: AbstractSynapseDynamics
+              ) -> AbstractSynapseDynamics:
+        # If dynamics is a WeightChanger, return ourselves, as
+        # WeightChanger can't be used by itself
+        if isinstance(synapse_dynamics, SynapseDynamicsWeightChanger):
+            synapse_dynamics.set_changable(self)
+            return self
+
+        raise SynapticConfigurationException(
+            "Only a single incoming WeightChangable can be added")
+
+    @overrides(AbstractPlasticSynapseDynamics.get_value)
+    def get_value(self, key: str) -> Any:
+        for obj in [self.__timing_dependence, self.__weight_dependence, self]:
+            if hasattr(obj, key):
+                return getattr(obj, key)
+        raise InvalidParameterType(
+            f"Type {type(self)} does not have parameter {key}")
+
+    @overrides(AbstractPlasticSynapseDynamics.set_value)
+    def set_value(self, key: str, value: Any):
+        for obj in [self.__timing_dependence, self.__weight_dependence, self]:
+            if hasattr(obj, key):
+                setattr(obj, key, value)
+                SpynnakerDataView.set_requires_mapping()
+                return
+        raise InvalidParameterType(
+            f"Type {type(self)} does not have parameter {key}")
+
+    @overrides(AbstractPlasticSynapseDynamics.is_same_as)
+    def is_same_as(self, synapse_dynamics: AbstractSynapseDynamics) -> bool:
+        return False
+
+    def get_vertex_executable_suffix(self) -> str:
+        """
+        :rtype: str
+        """
+        return "_weight_change"
+
+    def get_parameters_sdram_usage_in_bytes(self, n_neurons, n_synapse_types):
+        """
+        :param int n_neurons:
+        :param int n_synapse_types:
+        :rtype: int
+        """
+        # The count of items, plus min and max for each synapse type
+        return BYTES_PER_WORD + (BYTES_PER_SHORT * 2 * n_synapse_types)
+
+    @overrides(AbstractPlasticSynapseDynamics.write_parameters)
+    def write_parameters(
+            self, spec: DataSpecificationBase, region: int,
+            global_weight_scale: float,
+            synapse_weight_scales: NDArray[floating]):
+        spec.comment("Writing Plastic Parameters")
+
+        # Switch focus to the region:
+        spec.switch_write_focus(region)
+
+        spec.write_value(len(synapse_weight_scales))
+        min_weights = (
+            synapse_weight_scales * global_weight_scale *
+            self.__weight_min)
+        max_weights = (
+            synapse_weight_scales * global_weight_scale *
+            self.__weight_max)
+        weights = numpy.dstack((min_weights, max_weights)).flatten().astype(
+            uint16).view(uint32)
+        spec.write_array(weights)
+
+    def get_n_words_for_plastic_connections(self, n_connections):
+        """
+        :param int n_connections:
+        :rtype: int
+        """
+        n_words = n_connections // 2
+        if n_connections % 2 != 0:
+            n_words += 1
+        # PP has 1 header and then a half-word-weight per connection
+        # FP has a half-word per connection for the other elements
+        return 1 + n_words * 2
+
+    @overrides(AbstractPlasticSynapseDynamics.get_plastic_synaptic_data)
+    def get_plastic_synaptic_data(
+            self, connections: ConnectionsArray,
+            connection_row_indices: NDArray[integer], n_rows: int,
+            n_synapse_types: int,
+            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+                List[NDArray[uint32]], List[NDArray[uint32]],
+                NDArray[uint32], NDArray[uint32]]:
+        n_synapse_type_bits = get_n_bits(n_synapse_types)
+        n_neuron_id_bits = get_n_bits(max_atoms_per_core)
+        neuron_id_mask = (1 << n_neuron_id_bits) - 1
+
+        # Get the fixed data
+        fixed_plastic = (
+            (connections["delay"].astype(uint16) <<
+             (n_neuron_id_bits + n_synapse_type_bits)) |
+            (connections["synapse_type"].astype(uint16) << n_neuron_id_bits) |
+            (connections["target"].astype(uint16) & neuron_id_mask))
+        fixed_plastic_rows = self.convert_per_connection_data_to_rows(
+            connection_row_indices, n_rows,
+            fixed_plastic.view(dtype=uint8).reshape((-1, 2)),
+            max_n_synapses)
+        fp_size = self.get_n_items(fixed_plastic_rows, BYTES_PER_SHORT)
+        fp_data = self.get_words(fixed_plastic_rows)
+
+        # Convert the plastic data into groups of bytes per connection and
+        # then into rows
+        plastic_plastic = numpy.rint(
+            numpy.abs(connections["weight"])).astype(uint16)
+        plastic_plastic_bytes = plastic_plastic.view(dtype=uint8).reshape(
+            (-1, BYTES_PER_SHORT))
+        plastic_plastic_row_data = self.convert_per_connection_data_to_rows(
+            connection_row_indices, n_rows, plastic_plastic_bytes,
+            max_n_synapses)
+
+        plastic_headers = numpy.arange(n_rows, dtype=uint32).view(
+            uint8).reshape((-1, BYTES_PER_WORD))
+        plastic_plastic_rows = [
+            numpy.concatenate((
+                plastic_headers[i], plastic_plastic_row_data[i]))
+            for i in range(n_rows)]
+        pp_size = self.get_n_items(plastic_plastic_rows, BYTES_PER_WORD)
+        pp_data = self.get_words(plastic_plastic_rows)
+
+        return fp_data, pp_data, fp_size, pp_size
+
+    @overrides(
+        AbstractPlasticSynapseDynamics.get_n_plastic_plastic_words_per_row)
+    def get_n_plastic_plastic_words_per_row(
+            self, pp_size: NDArray[uint32]) -> NDArray[integer]:
+        # pp_size is in words, so return
+        return pp_size
+
+    @overrides(
+        AbstractPlasticSynapseDynamics.get_n_fixed_plastic_words_per_row)
+    def get_n_fixed_plastic_words_per_row(
+            self, fp_size: NDArray[uint32]) -> NDArray[integer]:
+        # fp_size is in half-words
+        return numpy.ceil(fp_size / 2.0).astype(dtype=uint32)
+
+    @overrides(AbstractPlasticSynapseDynamics.get_n_synapses_in_rows)
+    def get_n_synapses_in_rows(self, pp_size: NDArray[uint32],
+                               fp_size: NDArray[uint32]) -> NDArray[integer]:
+        # Each fixed-plastic synapse is a half-word and fp_size is in half
+        # words so just return it
+        return fp_size
+
+    @overrides(AbstractPlasticSynapseDynamics.read_plastic_synaptic_data)
+    def read_plastic_synaptic_data(
+            self, n_synapse_types: int, pp_size: NDArray[uint32],
+            pp_data: List[NDArray[uint32]], fp_size: NDArray[uint32],
+            fp_data: List[NDArray[uint32]],
+            max_atoms_per_core: int) -> ConnectionsArray:
+        # pylint: disable=too-many-arguments
+        n_rows = len(fp_size)
+
+        n_synapse_type_bits = get_n_bits(n_synapse_types)
+        n_neuron_id_bits = get_n_bits(max_atoms_per_core)
+        neuron_id_mask = (1 << n_neuron_id_bits) - 1
+
+        data_fixed = numpy.concatenate([
+            fp_data[i].view(dtype=uint16)[0:fp_size[i]]
+            for i in range(n_rows)])
+        pp_without_headers = [
+            row.view(dtype=uint8)[BYTES_PER_WORD:] for row in pp_data]
+        pp_half_words = numpy.concatenate(
+            [pp[:size * BYTES_PER_SHORT]
+             for pp, size in zip(pp_without_headers, fp_size)]).view(uint16)
+
+        connections = numpy.zeros(
+            data_fixed.size, dtype=NUMPY_CONNECTORS_DTYPE)
+        connections["source"] = numpy.concatenate(
+            [numpy.repeat(i, fp_size[i]) for i in range(len(fp_size))])
+        connections["target"] = data_fixed & neuron_id_mask
+        connections["weight"] = pp_half_words
+        connections["delay"] = data_fixed >> (
+            n_neuron_id_bits + n_synapse_type_bits)
+        return connections
+
+    @overrides(AbstractPlasticSynapseDynamics.get_weight_mean)
+    def get_weight_mean(self, connector: AbstractConnector,
+                        synapse_info: SynapseInformation) -> float:
+        # Because the weights could all be changed to the maximum, the mean
+        # has to be given as the maximum for scaling
+        return self.get_weight_maximum(connector, synapse_info)
+
+    @overrides(AbstractPlasticSynapseDynamics.get_weight_variance)
+    def get_weight_variance(
+           self, connector: AbstractConnector, weights: Weight_Types,
+            synapse_info: SynapseInformation) -> float:
+        # Because the weights could all be changed to the maximum, the variance
+        # has to be given as no variance
+        return 0.0
+
+    @overrides(AbstractPlasticSynapseDynamics.get_weight_maximum)
+    def get_weight_maximum(self, connector: AbstractConnector,
+                           synapse_info: SynapseInformation) -> float:
+        return self.__weight_max
+
+    @overrides(AbstractPlasticSynapseDynamics.get_parameter_names)
+    def get_parameter_names(self) -> Iterable[str]:
+        yield 'weight'
+        yield 'delay'
+
+    @overrides(AbstractPlasticSynapseDynamics.get_max_synapses)
+    def get_max_synapses(self, n_words: int) -> int:
+        # Subtract the header size that will always exist
+        n_words_space = n_words - BYTES_PER_WORD
+
+        # The remaining space is divided equally into plastic plastic and fixed
+        # plastic, but these have to be word aligned, so e.g. 5 words space
+        # would be 2.5 words per section, which allows for 5 connections in
+        # theory, but 5 connections would require word alignment at 3 words per
+        # section, so we round down instead and get 4 connections
+        return 2 * (n_words_space // 2)
+
+    @property
+    @overrides(AbstractGenerateOnMachine.gen_matrix_id)
+    def gen_matrix_id(self) -> int:
+        # We can use the STDP generation routine, with the addition that
+        # each row header has the pre-neuron-id in it (i.e. the row number)
+        return MatrixGeneratorID.STDP_MATRIX.value
+
+    @overrides(AbstractGenerateOnMachine.gen_matrix_params)
+    def gen_matrix_params(
+            self, synaptic_matrix_offset: int, delayed_matrix_offset: int,
+            app_edge: ProjectionApplicationEdge,
+            synapse_info: SynapseInformation, max_row_info: MaxRowInfo,
+            max_pre_atoms_per_core: int, max_post_atoms_per_core: int
+            ) -> NDArray[uint32]:
+        vertex = app_edge.post_vertex
+        n_synapse_type_bits = get_n_bits(
+            vertex.neuron_impl.get_n_synapse_types())
+        n_synapse_index_bits = get_n_bits(max_post_atoms_per_core)
+        max_delay = app_edge.post_vertex.splitter.max_support_delay()
+        max_delay_bits = get_n_bits(max_delay)
+        half_word = 0
+        n_half_words = 1
+        header_half_words = 2
+        write_row_number_to_header = 1
+        return numpy.array([
+            synaptic_matrix_offset, delayed_matrix_offset,
+            max_row_info.undelayed_max_n_synapses,
+            max_row_info.delayed_max_n_synapses,
+            max_row_info.undelayed_max_words, max_row_info.delayed_max_words,
+            synapse_info.synapse_type, n_synapse_type_bits,
+            n_synapse_index_bits, app_edge.n_delay_stages + 1,
+            max_delay, max_delay_bits, app_edge.pre_vertex.n_atoms,
+            max_pre_atoms_per_core, header_half_words,
+            n_half_words, half_word, write_row_number_to_header],
+            dtype=uint32)
+
+    @property
+    @overrides(AbstractGenerateOnMachine.gen_matrix_params_size_in_bytes)
+    def gen_matrix_params_size_in_bytes(self) -> int:
+        return 18 * BYTES_PER_WORD
+
+    @property
+    @overrides(AbstractPlasticSynapseDynamics.changes_during_run)
+    def changes_during_run(self) -> bool:
+        return True
+
+    @property
+    @overrides(AbstractPlasticSynapseDynamics.is_combined_core_capable)
+    def is_combined_core_capable(self) -> bool:
+        return True
+
+    @property
+    @overrides(AbstractPlasticSynapseDynamics.pad_to_length)
+    def pad_to_length(self) -> Optional[int]:
+        return None

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -187,8 +187,9 @@ class SynapseDynamicsWeightChangable(
         n_words = n_connections // 2
         if n_connections % 2 != 0:
             n_words += 1
-        # PP has 1 header and then a half-word-weight per connection
-        # FP has a half-word per connection for the other elements
+        # plastic-plastic has 1 header and then a half-word-weight per
+        # connection
+        # fixed-plastic has a half-word per connection for the other elements
         return 1 + n_words * 2
 
     @overrides(AbstractPlasticSynapseDynamics.get_plastic_synaptic_data)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 The University of Manchester
+# Copyright (c) 2024 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -93,6 +93,10 @@ class SynapseDynamicsWeightChangable(
         self.__synapse_info_to_index: Dict[SynapseInformation, int] = dict()
         self.__next_index = 0
 
+        if (weight_min >= weight_max):
+            raise SynapticConfigurationException(
+                "The minimum weight must be less than the maximum")
+
     @property
     def weight_max(self) -> float:
         """ Get the maximum weight allowed to change to

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -97,13 +97,21 @@ class SynapseDynamicsWeightChangable(
 
     @property
     def weight_max(self) -> float:
+        """ Get the maximum weight allowed to change to
+        """
         return self.__weight_max
 
     @property
     def weight_min(self) -> float:
+        """ Get the minimum weight allowed to change to
+        """
         return self.__weight_min
 
     def get_synapse_info_index(self, synapse_info: SynapseInformation) -> int:
+        """ Get the row offset for the given synapse information.  Each synapse
+            information has a unique row offset which then allows for multiple
+            connections to be identified and kept separate.
+        """
         if synapse_info not in self.__synapse_info_to_index:
             self.__synapse_info_to_index[synapse_info] = self.__next_index
             self.__next_index += synapse_info.pre_vertex.n_atoms
@@ -115,6 +123,7 @@ class SynapseDynamicsWeightChangable(
         # If dynamics is a WeightChanger, return ourselves, as
         # WeightChanger can't be used by itself
         # Note: hack required to avoid circular import
+        # pylint: disable=import-outside-toplevel
         from .synapse_dynamics_weight_changer import (
             SynapseDynamicsWeightChanger)
         if isinstance(synapse_dynamics, SynapseDynamicsWeightChanger):
@@ -128,24 +137,6 @@ class SynapseDynamicsWeightChangable(
             raise SynapticConfigurationException(
                 "Multiple WeightChangables must have the same min and max")
         return self
-
-    @overrides(AbstractPlasticSynapseDynamics.get_value)
-    def get_value(self, key: str) -> Any:
-        for obj in [self.__timing_dependence, self.__weight_dependence, self]:
-            if hasattr(obj, key):
-                return getattr(obj, key)
-        raise InvalidParameterType(
-            f"Type {type(self)} does not have parameter {key}")
-
-    @overrides(AbstractPlasticSynapseDynamics.set_value)
-    def set_value(self, key: str, value: Any):
-        for obj in [self.__timing_dependence, self.__weight_dependence, self]:
-            if hasattr(obj, key):
-                setattr(obj, key, value)
-                SpynnakerDataView.set_requires_mapping()
-                return
-        raise InvalidParameterType(
-            f"Type {type(self)} does not have parameter {key}")
 
     @overrides(AbstractPlasticSynapseDynamics.is_same_as)
     def is_same_as(self, synapse_dynamics: AbstractSynapseDynamics) -> bool:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -246,9 +246,10 @@ class SynapseDynamicsWeightChangable(
             pp_data: List[NDArray[uint32]], fp_size: NDArray[uint32],
             fp_data: List[NDArray[uint32]],
             max_atoms_per_core: int) -> ConnectionsArray:
-        logger.warn("Weights are only changed when a pre-spike arrives after a"
-                    " change-spike has been received, and so the weights might"
-                    " not be as expected")
+        logger.warning(
+            "Weights are only changed when a pre-spike arrives after a"
+            " change-spike has been received, and so the weights might"
+            " not be as expected")
 
         # pylint: disable=too-many-arguments
         n_rows = len(fp_size)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -50,15 +50,6 @@ if TYPE_CHECKING:
     from spynnaker.pyNN.models.neuron.synapse_io import MaxRowInfo
     from .abstract_synapse_dynamics import AbstractSynapseDynamics
 
-# How large are the time-stamps stored with each event
-TIME_STAMP_BYTES = BYTES_PER_WORD
-
-# The targets of neuromodulation
-NEUROMODULATION_TARGETS = {
-    "reward": 0,
-    "punishment": 1
-}
-
 logger = FormatAdapter(logging.getLogger(__name__))
 
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
-from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Iterable, List, Optional, Tuple, Dict, TYPE_CHECKING, cast
 
 import numpy
 from numpy import floating, integer, uint8, uint16, uint32
@@ -90,7 +90,7 @@ class SynapseDynamicsWeightChangable(
         super().__init__(delay=delay, weight=weight)
         self.__weight_max = weight_max
         self.__weight_min = weight_min
-        self.__synapse_info_to_index = dict()
+        self.__synapse_info_to_index: Dict[SynapseInformation, int] = dict()
         self.__next_index = 0
 
     @property
@@ -354,7 +354,8 @@ class SynapseDynamicsWeightChangable(
         header_half_words = 2
         write_row_number_to_header = 1
         # We need to use the "global" dynamics object to get the offset
-        dynamics = app_edge.post_vertex.synapse_dynamics
+        dynamics = cast(SynapseDynamicsWeightChangable,
+                        app_edge.post_vertex.synapse_dynamics)
         row_offset = dynamics.get_synapse_info_index(synapse_info)
         return numpy.array([
             synaptic_matrix_offset, delayed_matrix_offset,

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -1,0 +1,275 @@
+# Copyright (c) 2021 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
+
+import numpy
+from numpy import floating, integer, uint8, uint32, int16
+from numpy.typing import NDArray
+
+from spinn_utilities.overrides import overrides
+from pacman.utilities.utility_calls import get_n_bits
+
+from spinn_front_end_common.interface.ds import DataSpecificationBase
+from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
+
+from spynnaker.pyNN.exceptions import (
+    SynapticConfigurationException, InvalidParameterType)
+from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
+    NUMPY_CONNECTORS_DTYPE)
+from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
+from .abstract_generate_on_machine import AbstractGenerateOnMachine
+from .abstract_generate_on_machine import MatrixGeneratorID
+
+if TYPE_CHECKING:
+    from spynnaker.pyNN.models.neural_projections import (
+        ProjectionApplicationEdge, SynapseInformation)
+    from spynnaker.pyNN.models.neuron.synapse_io import MaxRowInfo
+    from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
+        ConnectionsArray)
+    from spynnaker.pyNN.models.neural_projections.connectors import (
+        AbstractConnector)
+    from spynnaker.pyNN.types import Weight_Types
+    from .abstract_synapse_dynamics import AbstractSynapseDynamics
+
+
+class SynapseDynamicsWeightChanger(
+        AbstractPlasticSynapseDynamics, AbstractGenerateOnMachine):
+    """
+    Synapses that target a weight change
+    """
+
+    __slots__ = ["__changable"]
+
+    def __init__(self, weight_change: float):
+        """
+        :param float weight_change:
+            The positive or negative change in weight to apply on each spike
+        """
+        super().__init__(delay=1, weight=weight_change)
+        self.__changable = None
+
+    def set_changable(self, changable):
+        if self.__changable is not None:
+            raise SynapticConfigurationException(
+                "A changer can only affect a single changeable projection")
+        self.__changable = changable
+
+    @overrides(AbstractPlasticSynapseDynamics.merge)
+    def merge(self, synapse_dynamics: AbstractSynapseDynamics
+              ) -> AbstractSynapseDynamics:
+        # This must replace something that supports weight change,
+        # so it can't be the first thing to be merged!
+        raise SynapticConfigurationException(
+            "Weight Changer synapses can only be added where an existing"
+            " projection has already been added which supports"
+            " weight changes")
+
+    @overrides(AbstractPlasticSynapseDynamics.is_same_as)
+    def is_same_as(self, synapse_dynamics: AbstractSynapseDynamics) -> bool:
+        # Shouldn't ever come up, but if it does, it is False!
+        return False
+
+    @overrides(AbstractPlasticSynapseDynamics.get_vertex_executable_suffix)
+    def get_vertex_executable_suffix(self) -> str:
+        return "_weight_change"
+
+    @overrides(AbstractPlasticSynapseDynamics
+               .get_parameters_sdram_usage_in_bytes)
+    def get_parameters_sdram_usage_in_bytes(
+            self, n_neurons: int, n_synapse_types: int) -> int:
+        # Should never be asked!
+        return 0
+
+    @overrides(AbstractPlasticSynapseDynamics.write_parameters)
+    def write_parameters(
+            self, spec: DataSpecificationBase, region: int,
+            global_weight_scale: float,
+            synapse_weight_scales: NDArray[floating]):
+        # Should never be asked!
+        pass
+
+    @overrides(AbstractPlasticSynapseDynamics.get_value)
+    def get_value(self, key: str) -> float:
+        if hasattr(self, key):
+            return getattr(self, key)
+        raise InvalidParameterType(
+            f"Type {type(self)} does not have parameter {key}")
+
+    @overrides(AbstractPlasticSynapseDynamics.set_value)
+    def set_value(self, key: str, value: float):
+        if hasattr(self, key):
+            setattr(self, key, value)
+        raise InvalidParameterType(
+            f"Type {type(self)} does not have parameter {key}")
+
+    @overrides(AbstractPlasticSynapseDynamics
+               .get_n_words_for_plastic_connections)
+    def get_n_words_for_plastic_connections(self, n_connections: int) -> int:
+        # 1 for flag and pre-spike identifier
+        pp_size_words = 1
+        # 1 for each connection
+        fp_size_words = n_connections
+        return pp_size_words + fp_size_words
+
+    @overrides(AbstractPlasticSynapseDynamics.get_plastic_synaptic_data)
+    def get_plastic_synaptic_data(
+            self, connections: ConnectionsArray,
+            connection_row_indices: NDArray[integer], n_rows: int,
+            n_synapse_types: int,
+            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+                NDArray[uint32], NDArray[uint32], NDArray[uint32],
+                NDArray[uint32]]:
+        # pylint: disable=too-many-arguments
+        weights = numpy.rint(numpy.abs(connections["weight"]))
+        n_neuron_id_bits = get_n_bits(max_atoms_per_core)
+        neuron_id_mask = (1 << n_neuron_id_bits) - 1
+        fixed_plastic = (
+            ((weights.astype(uint32) & 0xFFFF) << 16) |
+            (connections["synapse_type"].astype(uint32) << n_neuron_id_bits) |
+            (connections["target"] & neuron_id_mask))
+        fixed_plastic_rows = self.convert_per_connection_data_to_rows(
+            connection_row_indices, n_rows,
+            fixed_plastic.view(dtype=uint8).reshape((-1, BYTES_PER_WORD)),
+            max_n_synapses)
+
+        flags = 0x80000000 | numpy.arange(n_rows, dtype=uint32)
+
+        fp_size = self.get_n_items(fixed_plastic_rows, BYTES_PER_WORD)
+        fp_data = numpy.vstack([
+            fixed_row.view(uint32) for fixed_row in fixed_plastic_rows])
+        pp_data = flags.astype(uint32)
+        pp_size = numpy.ones(n_rows, dtype=uint32)
+
+        return fp_data, pp_data, fp_size, pp_size
+
+    @overrides(
+        AbstractPlasticSynapseDynamics.get_n_plastic_plastic_words_per_row)
+    def get_n_plastic_plastic_words_per_row(
+            self, pp_size: NDArray[integer]) -> NDArray[integer]:
+        # pp_size is in words, so just return
+        return pp_size
+
+    @overrides(
+        AbstractPlasticSynapseDynamics.get_n_fixed_plastic_words_per_row)
+    def get_n_fixed_plastic_words_per_row(
+            self, fp_size: NDArray[integer]) -> NDArray[integer]:
+        # fp_size is in words, so just return
+        return fp_size
+
+    @overrides(AbstractPlasticSynapseDynamics.get_n_synapses_in_rows)
+    def get_n_synapses_in_rows(
+            self, pp_size: NDArray[integer],
+            fp_size: NDArray[integer]) -> NDArray[integer]:
+        # Each fixed-plastic synapse is a word and fp_size is in words so just
+        # return it
+        return fp_size
+
+    @overrides(AbstractPlasticSynapseDynamics.read_plastic_synaptic_data)
+    def read_plastic_synaptic_data(
+            self, n_synapse_types: int,
+            pp_size: NDArray[uint32], pp_data: List[NDArray[uint32]],
+            fp_size: NDArray[uint32], fp_data: List[NDArray[uint32]],
+            max_atoms_per_core: int) -> ConnectionsArray:
+        data = numpy.concatenate(fp_data)
+        weight = ((data >> 16) & 0xFFFF).astype(int16)
+        n_neuron_id_bits = get_n_bits(max_atoms_per_core)
+        neuron_id_mask = (1 << n_neuron_id_bits) - 1
+        connections = numpy.zeros(data.size, dtype=NUMPY_CONNECTORS_DTYPE)
+        connections["source"] = numpy.concatenate(
+            [numpy.repeat(i, fp_size[i]) for i in range(len(fp_size))])
+        connections["target"] = data & neuron_id_mask
+        connections["weight"] = weight
+        connections["delay"] = 1
+        return connections
+
+    @overrides(AbstractPlasticSynapseDynamics.get_parameter_names)
+    def get_parameter_names(self) -> Iterable[str]:
+        yield 'weight_change'
+
+    @property
+    def weight_change(self) -> float:
+        return self.__weight_change
+
+    @overrides(AbstractPlasticSynapseDynamics.get_max_synapses)
+    def get_max_synapses(self, n_words: int) -> int:
+        # One word is static, the rest is for synapses
+        return n_words - 1
+
+    @property
+    @overrides(AbstractGenerateOnMachine.gen_matrix_id)
+    def gen_matrix_id(self) -> int:
+        return MatrixGeneratorID.CHANGE_WEIGHT_MATRIX.value
+
+    @overrides(AbstractGenerateOnMachine.gen_matrix_params)
+    def gen_matrix_params(
+            self, synaptic_matrix_offset: int, delayed_matrix_offset: int,
+            app_edge: ProjectionApplicationEdge,
+            synapse_info: SynapseInformation, max_row_info: MaxRowInfo,
+            max_pre_atoms_per_core: int,
+            max_post_atoms_per_core: int) -> NDArray[uint32]:
+        # pylint: disable=unused-argument
+        vertex = app_edge.post_vertex
+        n_synapse_type_bits = get_n_bits(
+            vertex.neuron_impl.get_n_synapse_types())
+        n_synapse_index_bits = get_n_bits(max_post_atoms_per_core)
+        return numpy.array([
+            synaptic_matrix_offset, max_row_info.undelayed_max_words,
+            max_row_info.undelayed_max_n_synapses,
+            app_edge.pre_vertex.n_atoms, synapse_info.synapse_type,
+            n_synapse_type_bits, n_synapse_index_bits], dtype=uint32)
+
+    @property
+    @overrides(AbstractGenerateOnMachine.
+               gen_matrix_params_size_in_bytes)
+    def gen_matrix_params_size_in_bytes(self) -> int:
+        return 7 * BYTES_PER_WORD
+
+    @property
+    @overrides(AbstractPlasticSynapseDynamics.changes_during_run)
+    def changes_during_run(self) -> bool:
+        return False
+
+    @property
+    @overrides(AbstractPlasticSynapseDynamics.pad_to_length)
+    def pad_to_length(self) -> None:
+        return None
+
+    @overrides(AbstractPlasticSynapseDynamics.get_synapse_id_by_target)
+    def get_synapse_id_by_target(self, target: str) -> Optional[int]:
+        return 0
+
+    @property
+    @overrides(AbstractPlasticSynapseDynamics.is_combined_core_capable)
+    def is_combined_core_capable(self) -> bool:
+        return True
+
+    @overrides(AbstractPlasticSynapseDynamics.get_weight_maximum)
+    def get_weight_maximum(
+            self, connector: AbstractConnector,
+            synapse_info: SynapseInformation) -> float:
+        return self.__changable.get_weight_maximum(connector, synapse_info)
+
+    @overrides(AbstractPlasticSynapseDynamics.get_weight_mean)
+    def get_weight_mean(
+            self, connector: AbstractConnector,
+            synapse_info: SynapseInformation) -> float:
+        return self.__changable.get_weight_mean(connector, synapse_info)
+
+    @overrides(AbstractPlasticSynapseDynamics.get_weight_variance)
+    def get_weight_variance(
+            self, connector: AbstractConnector, weights: Weight_Types,
+            synapse_info: SynapseInformation) -> float:
+        return self.__changable.get_weight_variance(
+            connector, weights, synapse_info)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import annotations
-from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING
+from typing import Iterable, List, Optional, Tuple, TYPE_CHECKING, cast
 
 import numpy
 from numpy import floating, integer, uint8, uint32, int16
@@ -70,7 +70,11 @@ class SynapseDynamicsWeightChanger(
                 "A changer can only affect a changeable projection")
         # Note: we store the post vertex here rather than the dynamics, as the
         # dynamics can change over time
-        self.__post_vertex = self.__synapse_info.post_vertex
+        # Import here required to avoid circular imports
+        # pylint: disable=import-outside-toplevel
+        from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+        self.__post_vertex = cast(AbstractPopulationVertex,
+                                  self.__synapse_info.post_vertex)
 
     @overrides(AbstractPlasticSynapseDynamics.merge)
     def merge(self, synapse_dynamics: AbstractSynapseDynamics
@@ -227,7 +231,8 @@ class SynapseDynamicsWeightChanger(
             vertex.neuron_impl.get_n_synapse_types())
         n_synapse_index_bits = get_n_bits(max_post_atoms_per_core)
         # We need to use the "global" dynamics object to get the offset
-        dynamics = app_edge.post_vertex.synapse_dynamics
+        dynamics = cast(SynapseDynamicsWeightChangable,
+                        app_edge.post_vertex.synapse_dynamics)
         row_offset = dynamics.get_synapse_info_index(self.__synapse_info)
         return numpy.array([
             synaptic_matrix_offset, max_row_info.undelayed_max_words,

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 The University of Manchester
+# Copyright (c) 2024 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -202,11 +202,7 @@ class SynapseDynamicsWeightChanger(
 
     @overrides(AbstractPlasticSynapseDynamics.get_parameter_names)
     def get_parameter_names(self) -> Iterable[str]:
-        yield 'weight_change'
-
-    @property
-    def weight_change(self) -> float:
-        return self.__weight_change
+        yield 'weight'
 
     @overrides(AbstractPlasticSynapseDynamics.get_max_synapses)
     def get_max_synapses(self, n_words: int) -> int:

--- a/spynnaker/pyNN/models/projection.py
+++ b/spynnaker/pyNN/models/projection.py
@@ -190,7 +190,7 @@ class Projection(object):
                 self.__projection_edge, SPIKE_PARTITION_ID)
 
         # Ensure the connector is happy
-        connector.validate_connection(
+        synapse_dynamics.validate_connection(
             self.__projection_edge, self.__synapse_information)
 
         # add projection to the SpiNNaker control system

--- a/spynnaker_integration_tests/test_various/test_weight_changer.py
+++ b/spynnaker_integration_tests/test_various/test_weight_changer.py
@@ -13,61 +13,167 @@
 # limitations under the License.
 
 import pyNN.spiNNaker as sim
+import numpy
 
 
-def test_weight_changer():
+def test_weight_changer_limits():
     sim.setup(timestep=1.0)
+    n_neurons = 5
+    n_changes = 6
+    time_diff = 4
+    n_cycles = n_neurons * time_diff
 
-    # Set up so that there is a pre-spike after each change and that each
+    # Set up so that there is a pre-spike after each change set and that each
     # change happens to each neuron separately
-    pre_times = [[j * 5 + i + 0.25 for j in range(5)] for i in range(1, 6)]
-    change_times = [[j * 5 + i for j in range(5)] for i in range(1, 6)]
+    changes_1 = [[j * n_cycles + i * time_diff + 0
+                  for j in range(n_changes)] for i in range(n_neurons)]
+    changes_2 = [[j * n_cycles + i * time_diff + 1
+                  for j in range(n_changes)] for i in range(n_neurons)]
+    pre_times = [[j * n_cycles + i * time_diff + 2
+                  for j in range(n_changes)] for i in range(n_neurons)]
 
-    print(change_times)
+    print(changes_1)
+    print(changes_2)
+    print(pre_times)
 
     pre = sim.Population(5, sim.SpikeSourceArray(spike_times=pre_times))
-    post_1 = sim.Population(5, sim.IF_curr_exp())
-    post_2 = sim.Population(5, sim.IF_curr_exp())
-    changer = sim.Population(5, sim.SpikeSourceArray(spike_times=change_times))
+    post = sim.Population(5, sim.IF_curr_exp())
+    changer_1 = sim.Population(
+        5, sim.SpikeSourceArray(spike_times=changes_1))
+    changer_2 = sim.Population(
+        5, sim.SpikeSourceArray(spike_times=changes_2))
 
     changable_proj_1 = sim.Projection(
-        pre, post_1, sim.OneToOneConnector(),
-        sim.extra_models.WeightChangeable(1.0, 3.0, weight=2.0, delay=1.0))
+        pre, post, sim.OneToOneConnector(),
+        sim.extra_models.WeightChangeable(0.25, 4.5, weight=2.0, delay=1.0))
     changable_proj_2 = sim.Projection(
-        pre, post_2, sim.OneToOneConnector(),
-        sim.extra_models.WeightChangeable(0.25, 2.0, weight=1.0, delay=1.0))
+        pre, post, sim.OneToOneConnector(),
+        sim.extra_models.WeightChangeable(0.25, 4.5, weight=1.5, delay=1.0))
 
     change_proj_1 = sim.Projection(
-        changer, post_1, sim.OneToOneConnector(),
+        changer_1, post, sim.OneToOneConnector(),
         sim.extra_models.WeightChanger(
             weight_change=0.5, projection=changable_proj_1))
     change_proj_2 = sim.Projection(
-        changer, post_2, sim.OneToOneConnector(),
+        changer_2, post, sim.OneToOneConnector(),
         sim.extra_models.WeightChanger(
             weight_change=-0.25, projection=changable_proj_2))
 
     weights_1 = []
     weights_2 = []
 
-    sim.run(0.5)
+    sim.run(0)
 
     print(change_proj_1.get('weight', 'list'))
     print(change_proj_2.get('weight', 'list'))
 
-    for i in range(26):
-        sim.run(1)
+    # Get weights at start
+    weights_1.append(
+        changable_proj_1.get('weight', 'list', with_address=False))
+    weights_2.append(
+        changable_proj_2.get('weight', 'list', with_address=False))
 
-        weights_1.append(changable_proj_1.get('weight', 'list'))
-        weights_2.append(changable_proj_2.get('weight', 'list'))
+    # Do initial run to get past first changes and pre-spike
+    sim.run(time_diff - 1)
+
+    # Do the rest of the runs (already done one)
+    for i in range((n_neurons * n_changes) - 1):
+        weights_1.append(
+            changable_proj_1.get('weight', 'list', with_address=False))
+        weights_2.append(
+            changable_proj_2.get('weight', 'list', with_address=False))
+
+        sim.run(time_diff)
+
+    # Get final weights
+    weights_1.append(
+        changable_proj_1.get('weight', 'list', with_address=False))
+    weights_2.append(
+        changable_proj_2.get('weight', 'list', with_address=False))
 
     sim.end()
 
+    next_weights = [2.0 for _ in range(n_neurons)]
+    change = 0
     for w in weights_1:
-        print(w)
-    print()
+        assert numpy.array_equal(w, next_weights)
+        if next_weights[change] < 4.5:
+            next_weights[change] += 0.5
+        change = (change + 1) % n_neurons
+
+    next_weights = [1.5 for _ in range(n_neurons)]
+    change = 0
     for w in weights_2:
-        print(w)
+        assert numpy.array_equal(w, next_weights)
+        if next_weights[change] > 0.25:
+            next_weights[change] -= 0.25
+        change = (change + 1) % n_neurons
+
+
+def test_weight_changer_diffs():
+    sim.setup(timestep=1.0)
+
+    # Pre spikes at 5ms intervals
+    pre_times = [5, 10, 15]
+    # For change 1, do one in segment 1, none in segment 2, two in segment 3
+    changes_1 = [1, 12, 13]
+    # For change 2, do none in segment 1, two in segment 2, one in segment 3
+    changes_2 = [7, 8, 12]
+
+    pre = sim.Population(1, sim.SpikeSourceArray(spike_times=pre_times))
+    post = sim.Population(1, sim.IF_curr_exp())
+    changer_1 = sim.Population(
+        1, sim.SpikeSourceArray(spike_times=changes_1))
+    changer_2 = sim.Population(
+        1, sim.SpikeSourceArray(spike_times=changes_2))
+
+    changable_proj_1 = sim.Projection(
+        pre, post, sim.OneToOneConnector(),
+        sim.extra_models.WeightChangeable(0, 5, weight=2.5, delay=1.0))
+    changable_proj_2 = sim.Projection(
+        pre, post, sim.OneToOneConnector(),
+        sim.extra_models.WeightChangeable(0, 5, weight=3.0, delay=1.0),
+        receptor_type='inhibitory')
+
+    change_proj_1 = sim.Projection(
+        changer_1, post, sim.OneToOneConnector(),
+        sim.extra_models.WeightChanger(
+            weight_change=-0.75, projection=changable_proj_1))
+    change_proj_2 = sim.Projection(
+        changer_2, post, sim.OneToOneConnector(),
+        sim.extra_models.WeightChanger(
+            weight_change=0.25, projection=changable_proj_2),
+        receptor_type='inhibitory')
+
+    weights_1 = []
+    weights_2 = []
+
+    sim.run(0)
+
+    print(change_proj_1.get('weight', 'list'))
+    print(change_proj_2.get('weight', 'list'))
+
+    # Get weights at start
+    weights_1.append(
+        changable_proj_1.get('weight', 'list', with_address=False)[0])
+    weights_2.append(
+        changable_proj_2.get('weight', 'list', with_address=False)[0])
+
+    last_time = 0
+    for pre_time in pre_times:
+        sim.run((pre_time - last_time) + 1)
+        last_time = pre_time + 1
+
+        weights_1.append(
+            changable_proj_1.get('weight', 'list', with_address=False)[0])
+        weights_2.append(
+            changable_proj_2.get('weight', 'list', with_address=False)[0])
+
+    sim.end()
+
+    assert numpy.array_equal(weights_1, [2.5, 1.75, 1.75, 0.25])
+    assert numpy.array_equal(weights_2, [3.0, 3.0, 3.50, 3.75])
 
 
 if __name__ == "__main__":
-    test_weight_changer()
+    test_weight_changer_diffs()

--- a/spynnaker_integration_tests/test_various/test_weight_changer.py
+++ b/spynnaker_integration_tests/test_various/test_weight_changer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 The University of Manchester
+# Copyright (c) 2024 The University of Manchester
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spynnaker_integration_tests/test_various/test_weight_changer.py
+++ b/spynnaker_integration_tests/test_various/test_weight_changer.py
@@ -43,6 +43,11 @@ def test_weight_changer_limits():
     changer_2 = sim.Population(
         5, sim.SpikeSourceArray(spike_times=changes_2))
 
+    pre.set_max_atoms_per_core(4)
+    post.set_max_atoms_per_core(3)
+    changer_1.set_max_atoms_per_core(2)
+    changer_2.set_max_atoms_per_core(1)
+
     changable_proj_1 = sim.Projection(
         pre, post, sim.OneToOneConnector(),
         sim.extra_models.WeightChangeable(0.25, 4.5, weight=2.0, delay=1.0))
@@ -176,4 +181,4 @@ def test_weight_changer_diffs():
 
 
 if __name__ == "__main__":
-    test_weight_changer_diffs()
+    test_weight_changer_limits()

--- a/spynnaker_integration_tests/test_various/test_weight_changer.py
+++ b/spynnaker_integration_tests/test_various/test_weight_changer.py
@@ -39,10 +39,12 @@ def test_weight_changer():
 
     change_proj_1 = sim.Projection(
         changer, post_1, sim.OneToOneConnector(),
-        sim.extra_models.WeightChanger(weight_change=0.5))
+        sim.extra_models.WeightChanger(
+            weight_change=0.5, projection=changable_proj_1))
     change_proj_2 = sim.Projection(
         changer, post_2, sim.OneToOneConnector(),
-        sim.extra_models.WeightChanger(weight_change=-0.25))
+        sim.extra_models.WeightChanger(
+            weight_change=-0.25, projection=changable_proj_2))
 
     weights_1 = []
     weights_2 = []

--- a/spynnaker_integration_tests/test_various/test_weight_changer.py
+++ b/spynnaker_integration_tests/test_various/test_weight_changer.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyNN.spiNNaker as sim
+
+
+def test_weight_changer():
+    sim.setup(timestep=1.0)
+
+    # Set up so that there is a pre-spike after each change and that each
+    # change happens to each neuron separately
+    pre_times = [[j * 5 + i + 0.25 for j in range(5)] for i in range(1, 6)]
+    change_times = [[j * 5 + i for j in range(5)] for i in range(1, 6)]
+
+    print(change_times)
+
+    pre = sim.Population(5, sim.SpikeSourceArray(spike_times=pre_times))
+    post_1 = sim.Population(5, sim.IF_curr_exp())
+    post_2 = sim.Population(5, sim.IF_curr_exp())
+    changer = sim.Population(5, sim.SpikeSourceArray(spike_times=change_times))
+
+    changable_proj_1 = sim.Projection(
+        pre, post_1, sim.OneToOneConnector(),
+        sim.extra_models.WeightChangeable(1.0, 3.0, weight=2.0, delay=1.0))
+    changable_proj_2 = sim.Projection(
+        pre, post_2, sim.OneToOneConnector(),
+        sim.extra_models.WeightChangeable(0.25, 2.0, weight=1.0, delay=1.0))
+
+    change_proj_1 = sim.Projection(
+        changer, post_1, sim.OneToOneConnector(),
+        sim.extra_models.WeightChanger(weight_change=0.5))
+    change_proj_2 = sim.Projection(
+        changer, post_2, sim.OneToOneConnector(),
+        sim.extra_models.WeightChanger(weight_change=-0.25))
+
+    weights_1 = []
+    weights_2 = []
+
+    sim.run(0.5)
+
+    print(change_proj_1.get('weight', 'list'))
+    print(change_proj_2.get('weight', 'list'))
+
+    for i in range(26):
+        sim.run(1)
+
+        weights_1.append(changable_proj_1.get('weight', 'list'))
+        weights_2.append(changable_proj_2.get('weight', 'list'))
+
+    sim.end()
+
+    for w in weights_1:
+        print(w)
+    print()
+    for w in weights_2:
+        print(w)
+
+
+if __name__ == "__main__":
+    test_weight_changer()


### PR DESCRIPTION
Allow an external weight change from a different connection.  This is a bit like STDP with neuromodulation, but much simpler.  A projection can be "WeightChangable" which is the "STDP" part.  This can then also have a "WeightChanger" projection which is like the neuromodulation; this takes the WeightChangable projection as a parameter, and the source Population must have the same number of neurons as the Projection it affects, and must of course target the same target Population and receptor type (this is checked).  The WeightChanger connections are then set up so that they affect a specific pre-post pair of neurons.  When the Pre-Population of the WeightChanger spikes, the weight is changed by the specified amount (which can be positive or negative) on any connection that matches the same pre-post pairing in the target.

Tested with:
 - https://github.com/SpiNNakerManchester/IntegrationTests/pull/293