### PR TITLE
Allow different partitions

### DIFF
--- a/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
+++ b/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
@@ -160,6 +160,8 @@ static inline updatable_synapse_t process_plastic_synapse(
             } else {
                 synapse.weight = (weight_t) new_weight;
             }
+			log_info("Weight changed to %d for pre-neuron %u, post-neuron %u",
+					synapse.weight, pre_spike, s.index);
             log_debug("        Weight now %d", synapse.weight);
             *changed = 1;
 
@@ -198,7 +200,7 @@ static inline void process_weight_update(
     const uint32_t *words = (uint32_t *) synapse_row_plastic_controls(fixed_region);
     uint32_t pre_spike = plastic_region_address->pre_spike;
 
-	log_debug("Weight change update for pre-neuron %u", pre_spike);
+	log_info("Weight change update for pre-neuron %u", pre_spike);
 
     // Loop through synapses
     for (; n_synapses > 0; n_synapses--) {
@@ -210,7 +212,7 @@ static inline void process_weight_update(
         uint32_t neuron_index = synapse_row_sparse_index(word,
         		synapse_index_mask);
 
-        log_debug("    Adding weight change %d to post-neuron %u",
+        log_info("    Adding weight change %d to post-neuron %u",
 						weight_change, neuron_index);
 
         // Get post event history of this neuron

--- a/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
+++ b/neural_modelling/src/neuron/plasticity/weight_change/synapse_dynamics_external_weight_change.c
@@ -160,8 +160,6 @@ static inline updatable_synapse_t process_plastic_synapse(
             } else {
                 synapse.weight = (weight_t) new_weight;
             }
-			log_info("Weight changed to %d for pre-neuron %u, post-neuron %u",
-					synapse.weight, pre_spike, s.index);
             log_debug("        Weight now %d", synapse.weight);
             *changed = 1;
 
@@ -200,7 +198,7 @@ static inline void process_weight_update(
     const uint32_t *words = (uint32_t *) synapse_row_plastic_controls(fixed_region);
     uint32_t pre_spike = plastic_region_address->pre_spike;
 
-	log_info("Weight change update for pre-neuron %u", pre_spike);
+	log_debug("Weight change update for pre-neuron %u", pre_spike);
 
     // Loop through synapses
     for (; n_synapses > 0; n_synapses--) {
@@ -212,7 +210,7 @@ static inline void process_weight_update(
         uint32_t neuron_index = synapse_row_sparse_index(word,
         		synapse_index_mask);
 
-        log_info("    Adding weight change %d to post-neuron %u",
+        log_debug("    Adding weight change %d to post-neuron %u",
 						weight_change, neuron_index);
 
         // Get post event history of this neuron

--- a/spynnaker/pyNN/__init__.py
+++ b/spynnaker/pyNN/__init__.py
@@ -52,6 +52,7 @@ from spinn_front_end_common.utilities.exceptions import (
 from spynnaker.pyNN.random_distribution import RandomDistribution
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
+from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
 # connections
 # noinspection PyUnresolvedReferences
@@ -357,7 +358,8 @@ def Projection(
         synapse_type: Optional[AbstractStaticSynapseDynamics] = None,
         source: None = None, receptor_type: str = "excitatory",
         space: Optional[Space] = None, label: Optional[str] = None,
-        download_synapses: bool = False) -> SpiNNakerProjection:
+        download_synapses: bool = False,
+        partition_id: str = SPIKE_PARTITION_ID) -> SpiNNakerProjection:
     """
     Used to support PEP 8 spelling correctly.
 
@@ -376,6 +378,7 @@ def Projection(
     :param label: the label
     :type label: str or None
     :param bool download_synapses: whether to download synapses
+    :param str partition_id: the partition id to use for the projection
     :return: a projection object for SpiNNaker
     :rtype: ~spynnaker.pyNN.models.projection.Projection
     """
@@ -384,7 +387,8 @@ def Projection(
         pre_synaptic_population=presynaptic_population,
         post_synaptic_population=postsynaptic_population, connector=connector,
         synapse_type=synapse_type, source=source, receptor_type=receptor_type,
-        space=space, label=label, download_synapses=download_synapses)
+        space=space, label=label, download_synapses=download_synapses,
+        partition_id=partition_id)
 
 
 def _create_overloaded_functions(spinnaker_simulator: SpiNNaker):

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
@@ -92,6 +92,8 @@ class ExternalDeviceLifControlVertex(
         # pylint: disable=too-many-arguments
         if drop_late_spikes is None:
             drop_late_spikes = False
+        extra_partition_ids = [
+            dev.device_control_partition_id for dev in devices]
         super().__init__(
             n_neurons=len(devices),
             label=f"ext_dev{devices}" if label is None else label,
@@ -102,7 +104,7 @@ class ExternalDeviceLifControlVertex(
             incoming_spike_buffer_size=incoming_spike_buffer_size,
             neuron_impl=neuron_impl, pynn_model=pynn_model,
             drop_late_spikes=drop_late_spikes, splitter=splitter, seed=seed,
-            n_colour_bits=n_colour_bits)
+            n_colour_bits=n_colour_bits, extra_partitions=extra_partition_ids)
 
         if not devices:
             raise ConfigurationException("No devices specified")

--- a/spynnaker/pyNN/external_devices_models/machine_munich_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/machine_munich_motor_device.py
@@ -153,7 +153,7 @@ class MachineMunichMotorDevice(
 
         # Get the key
         routing_info = SpynnakerDataView.get_routing_infos()
-        edge_key = routing_info.get_safe_first_key_from_pre_vertex(
+        edge_key = routing_info.get_key_from(
             placement.vertex, self.MOTOR_PARTITION_ID)
 
         # write params to memory

--- a/spynnaker/pyNN/external_devices_models/machine_munich_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/machine_munich_motor_device.py
@@ -30,7 +30,6 @@ from spinn_front_end_common.interface.simulation import simulation_utilities
 from spinn_front_end_common.utilities.constants import (
     SYSTEM_BYTES_REQUIREMENT, SIMULATION_N_BYTES, BYTES_PER_WORD)
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.exceptions import SpynnakerException
 
 
 class MachineMunichMotorDevice(

--- a/spynnaker/pyNN/external_devices_models/machine_munich_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/machine_munich_motor_device.py
@@ -154,11 +154,8 @@ class MachineMunichMotorDevice(
 
         # Get the key
         routing_info = SpynnakerDataView.get_routing_infos()
-        edge_key = routing_info.get_first_key_from_pre_vertex(
+        edge_key = routing_info.get_safe_first_key_from_pre_vertex(
             placement.vertex, self.MOTOR_PARTITION_ID)
-        if edge_key is None:
-            raise SpynnakerException(
-                "This motor should have one outgoing edge to the robot")
 
         # write params to memory
         spec.switch_write_focus(region=self._PARAMS_REGION)

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_retina_device.py
@@ -88,7 +88,7 @@ class PushBotSpiNNakerLinkRetinaDevice(
         :rtype: int
         """
         routing_info = SpynnakerDataView.get_routing_infos()
-        key = routing_info.get_safe_first_key_from_pre_vertex(
+        key = routing_info.get_key_from(
             self, SPIKE_PARTITION_ID)
         return key
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_retina_device.py
@@ -88,7 +88,7 @@ class PushBotSpiNNakerLinkRetinaDevice(
         :rtype: int
         """
         routing_info = SpynnakerDataView.get_routing_infos()
-        key = routing_info.get_first_key_from_pre_vertex(
+        key = routing_info.get_safe_first_key_from_pre_vertex(
             self, SPIKE_PARTITION_ID)
         return key
 

--- a/spynnaker/pyNN/external_devices_models/spif_output_device.py
+++ b/spynnaker/pyNN/external_devices_models/spif_output_device.py
@@ -170,7 +170,7 @@ class SPIFOutputDevice(
         :rtype: int
         """
         r_infos = SpynnakerDataView.get_routing_infos()
-        return r_infos.get_first_key_from_pre_vertex(
+        return r_infos.get_safe_first_key_from_pre_vertex(
             self.__incoming_partitions[index].pre_vertex,
             self.__incoming_partitions[index].identifier)
 
@@ -182,7 +182,7 @@ class SPIFOutputDevice(
         :rtype: int
         """
         r_infos = SpynnakerDataView.get_routing_infos()
-        return r_infos.get_routing_info_from_pre_vertex(
+        return r_infos.get_safe_routing_info_from_pre_vertex(
             self.__incoming_partitions[index].pre_vertex,
             self.__incoming_partitions[index].identifier).mask
 
@@ -190,7 +190,7 @@ class SPIFOutputDevice(
         """ Get the payload for the command to set the distiller mask
         """
         r_infos = SpynnakerDataView.get_routing_infos()
-        return ~r_infos.get_routing_info_from_pre_vertex(
+        return ~r_infos.get_safe_routing_info_from_pre_vertex(
             self.__incoming_partitions[index].pre_vertex,
             self.__incoming_partitions[index].identifier).mask & 0xFFFFFFFF
 
@@ -245,15 +245,13 @@ class SPIFOutputDevice(
                     atom_keys = m_vertex.app_vertex.get_atom_key_map(
                         m_vertex, part.identifier, routing_infos)
                 else:
-                    r_info = routing_infos.get_routing_info_from_pre_vertex(
-                        m_vertex, part.identifier)
-                    # r_info could be None if there are no outgoing edges,
-                    # at which point there is nothing to do here anyway
-                    if r_info is not None:
-                        vertex_slice = m_vertex.vertex_slice
-                        keys = get_keys(r_info.key, vertex_slice)
-                        start = vertex_slice.lo_atom
-                        atom_keys = [(i, k) for i, k in enumerate(keys, start)]
+                    r_info = \
+                        routing_infos.get_safe_routing_info_from_pre_vertex(
+                            m_vertex, part.identifier)
+                    vertex_slice = m_vertex.vertex_slice
+                    keys = get_keys(r_info.key, vertex_slice)
+                    start = vertex_slice.lo_atom
+                    atom_keys = [(i, k) for i, k in enumerate(keys, start)]
 
                 atom_keys_mapped = list((i, key | ((k & mask) >> shift))
                                         for i, k in atom_keys)

--- a/spynnaker/pyNN/external_devices_models/spif_output_device.py
+++ b/spynnaker/pyNN/external_devices_models/spif_output_device.py
@@ -170,7 +170,7 @@ class SPIFOutputDevice(
         :rtype: int
         """
         r_infos = SpynnakerDataView.get_routing_infos()
-        return r_infos.get_safe_first_key_from_pre_vertex(
+        return r_infos.get_key_from(
             self.__incoming_partitions[index].pre_vertex,
             self.__incoming_partitions[index].identifier)
 
@@ -182,7 +182,7 @@ class SPIFOutputDevice(
         :rtype: int
         """
         r_infos = SpynnakerDataView.get_routing_infos()
-        return r_infos.get_safe_routing_info_from_pre_vertex(
+        return r_infos.get_info_from(
             self.__incoming_partitions[index].pre_vertex,
             self.__incoming_partitions[index].identifier).mask
 
@@ -190,7 +190,7 @@ class SPIFOutputDevice(
         """ Get the payload for the command to set the distiller mask
         """
         r_infos = SpynnakerDataView.get_routing_infos()
-        return ~r_infos.get_safe_routing_info_from_pre_vertex(
+        return ~r_infos.get_info_from(
             self.__incoming_partitions[index].pre_vertex,
             self.__incoming_partitions[index].identifier).mask & 0xFFFFFFFF
 
@@ -246,7 +246,7 @@ class SPIFOutputDevice(
                         m_vertex, part.identifier, routing_infos)
                 else:
                     r_info = \
-                        routing_infos.get_safe_routing_info_from_pre_vertex(
+                        routing_infos.get_info_from(
                             m_vertex, part.identifier)
                     vertex_slice = m_vertex.vertex_slice
                     keys = get_keys(r_info.key, vertex_slice)

--- a/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
+++ b/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
@@ -28,14 +28,14 @@ from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
 
 
 def delay_support_adder() -> Tuple[
-        Sequence[DelayExtensionVertex], Sequence[ApplicationEdge]]:
+        Sequence[DelayExtensionVertex], Sequence[Tuple[ApplicationEdge, str]]]:
     """
     Adds the delay extensions to the application graph, now that all the
     splitter objects have been set.
 
     :return: The delay vertices and delay edges that were added
     :rtype: tuple(list(DelayExtensionVertex), list(DelayedApplicationEdge or
-        DelayAfferentApplicationEdge))
+        DelayAfferentApplicationEdge, str))
     """
     adder = _DelaySupportAdder()
     # pylint: disable=protected-access

--- a/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
+++ b/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
@@ -79,7 +79,8 @@ class _DelaySupportAdder(object):
             self._app_to_delay_map[vertex.partition] = vertex
             for edge in vertex.outgoing_edges:
                 self._delay_post_edge_map[
-                    vertex, edge.post_vertex, vertex.partition] = edge
+                    vertex, edge.post_vertex,
+                    vertex.partition.identifier] = edge
         progress.update(1)
 
         # go through all partitions.

--- a/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
+++ b/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
@@ -34,8 +34,6 @@ def delay_support_adder() -> Tuple[
     splitter objects have been set.
 
     :return: The delay vertices and delay edges that were added
-    :rtype: tuple(list(DelayExtensionVertex), list(DelayedApplicationEdge or
-        DelayAfferentApplicationEdge, str))
     """
     adder = _DelaySupportAdder()
     # pylint: disable=protected-access

--- a/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
+++ b/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
@@ -57,18 +57,19 @@ class _DelaySupportAdder(object):
         self._app_to_delay_map: Dict[
             ApplicationEdgePartition, DelayExtensionVertex] = dict()
         self._delay_post_edge_map: Dict[
-            Tuple[DelayExtensionVertex, AbstractPopulationVertex],
+            Tuple[DelayExtensionVertex, AbstractPopulationVertex, str],
             DelayedApplicationEdge] = dict()
-        self._new_edges: List[ApplicationEdge] = list()
+        self._new_edges: List[Tuple[ApplicationEdge, str]] = list()
         self._new_vertices: List[DelayExtensionVertex] = list()
 
     def add_delays(self) -> Tuple[
-            List[DelayExtensionVertex], List[ApplicationEdge]]:
+            List[DelayExtensionVertex], List[Tuple[ApplicationEdge, str]]]:
         """
         Adds the delay extensions to the application graph, now that all the
         splitter objects have been set.
 
-        :rtype: tuple(list(DelayExtensionVertex), list(DelayedApplicationEdge))
+        :rtype: tuple(list(DelayExtensionVertex),
+            list(Tuple(DelayedApplicationEdge, str)))
         """
         progress = ProgressBar(1 + SpynnakerDataView.get_n_partitions(),
                                "Adding delay extensions as required")
@@ -77,7 +78,8 @@ class _DelaySupportAdder(object):
                 DelayExtensionVertex):
             self._app_to_delay_map[vertex.partition] = vertex
             for edge in vertex.outgoing_edges:
-                self._delay_post_edge_map[vertex, edge.post_vertex] = edge
+                self._delay_post_edge_map[
+                    vertex, edge.post_vertex, vertex.partition] = edge
         progress.update(1)
 
         # go through all partitions.
@@ -109,11 +111,13 @@ class _DelaySupportAdder(object):
                 partition, edge, steps_per_stage, n_stages)
 
             # add the edge from the delay extension to the dest vertex
-            self._create_post_delay_edge(delay_app_vertex, edge)
+            self._create_post_delay_edge(
+                delay_app_vertex, edge, partition.identifier)
 
     def _create_post_delay_edge(
             self, delay_app_vertex: DelayExtensionVertex,
-            app_edge: ProjectionApplicationEdge):
+            app_edge: ProjectionApplicationEdge,
+            partition_id: str):
         """
         Creates the edge between delay extension and post vertex. Stores
         for future loading to the application graph when safe to do so.
@@ -121,10 +125,11 @@ class _DelaySupportAdder(object):
         :param DelayExtensionVertex delay_app_vertex: delay extension vertex
         :param ProjectionApplicationEdge app_edge:
             the undelayed application edge this is associated with.
+        :param str partition_id: the partition id of the edge
         """
         # check for post edge
         delayed_edge = self._delay_post_edge_map.get(
-            (delay_app_vertex, app_edge.post_vertex), None)
+            (delay_app_vertex, app_edge.post_vertex, partition_id), None)
         if delayed_edge is None:
             delay_edge = DelayedApplicationEdge(
                 delay_app_vertex, app_edge.post_vertex,
@@ -133,8 +138,9 @@ class _DelaySupportAdder(object):
                        f"to_{app_edge.post_vertex.label}"),
                 undelayed_edge=app_edge)
             self._delay_post_edge_map[
-                (delay_app_vertex, app_edge.post_vertex)] = delay_edge
-            self._new_edges.append(delay_edge)
+                delay_app_vertex, app_edge.post_vertex,
+                partition_id] = delay_edge
+            self._new_edges.append((delay_edge, partition_id))
             app_edge.delay_edge = delay_edge
             delay_app_vertex.add_outgoing_edge(delay_edge)
 
@@ -175,7 +181,8 @@ class _DelaySupportAdder(object):
             delay_pre_edge = DelayAfferentApplicationEdge(
                 app_edge.pre_vertex, delay_app_vertex,
                 label=f"{app_edge.pre_vertex.label}_to_DelayExtension")
-            self._new_edges.append(delay_pre_edge)
+            self._new_edges.append(
+                (delay_pre_edge, app_outgoing_edge_partition.identifier))
         else:
             delay_app_vertex.set_new_n_delay_stages_and_delay_per_stage(
                 n_delay_stages, delay_per_stage)

--- a/spynnaker/pyNN/models/common/local_only_2d_common.py
+++ b/spynnaker/pyNN/models/common/local_only_2d_common.py
@@ -89,7 +89,7 @@ def get_rinfo_for_spike_source(pre_vertex, partition_id):
     routing_info = SpynnakerDataView.get_routing_infos()
 
     # Find the routing information
-    r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+    r_info = routing_info.get_info_from(
             pre_vertex, partition_id)
 
     n_cores = len(r_info.vertex.splitter.get_out_going_vertices(partition_id))

--- a/spynnaker/pyNN/models/common/local_only_2d_common.py
+++ b/spynnaker/pyNN/models/common/local_only_2d_common.py
@@ -89,7 +89,7 @@ def get_rinfo_for_spike_source(pre_vertex, partition_id):
     routing_info = SpynnakerDataView.get_routing_infos()
 
     # Find the routing information
-    r_info = routing_info.get_routing_info_from_pre_vertex(
+    r_info = routing_info.get_safe_routing_info_from_pre_vertex(
             pre_vertex, partition_id)
 
     n_cores = len(r_info.vertex.splitter.get_out_going_vertices(partition_id))

--- a/spynnaker/pyNN/models/common/population_application_vertex.py
+++ b/spynnaker/pyNN/models/common/population_application_vertex.py
@@ -424,11 +424,8 @@ class PopulationApplicationVertex(ApplicationVertex, HasCustomAtomKeyMap):
     def get_atom_key_map(
             self, pre_vertex: MachineVertex, partition_id: str,
             routing_info: RoutingInfo) -> Iterable[Tuple[int, int]]:
-        base_key = routing_info.get_first_key_from_pre_vertex(
+        base_key = routing_info.get_safe_first_key_from_pre_vertex(
             pre_vertex, partition_id)
-        # This might happen if there are no edges
-        if base_key is None:
-            base_key = 0
         vertex_slice = pre_vertex.vertex_slice
         keys = get_keys(base_key, vertex_slice, self.n_colour_bits)
         return zip(vertex_slice.get_raster_ids(), keys)

--- a/spynnaker/pyNN/models/common/population_application_vertex.py
+++ b/spynnaker/pyNN/models/common/population_application_vertex.py
@@ -424,7 +424,7 @@ class PopulationApplicationVertex(ApplicationVertex, HasCustomAtomKeyMap):
     def get_atom_key_map(
             self, pre_vertex: MachineVertex, partition_id: str,
             routing_info: RoutingInfo) -> Iterable[Tuple[int, int]]:
-        base_key = routing_info.get_safe_first_key_from_pre_vertex(
+        base_key = routing_info.get_key_from(
             pre_vertex, partition_id)
         vertex_slice = pre_vertex.vertex_slice
         keys = get_keys(base_key, vertex_slice, self.n_colour_bits)

--- a/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/abstract_connector.py
@@ -42,7 +42,6 @@ from spynnaker.pyNN.types import (
     Delay_Types, is_scalar, Weight_Delay_Types, Weight_Types)
 from spynnaker.pyNN.utilities import utility_calls
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.neural_projections import (
@@ -678,7 +677,7 @@ class AbstractConnector(object, metaclass=AbstractBase):
         # whole source
         return [(m_vertex, [source_vertex])
                 for m_vertex in target_vertex.splitter.get_in_coming_vertices(
-                    SPIKE_PARTITION_ID)]
+                    s_info.partition_id)]
 
     def connect(self, projection: Projection):
         """

--- a/spynnaker/pyNN/models/neural_projections/connectors/convolution_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/convolution_connector.py
@@ -38,7 +38,6 @@ from spinn_front_end_common.utilities.constants import (
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.models.common.local_only_2d_common import get_div_const
 
 from .abstract_connector import AbstractConnector
@@ -368,14 +367,14 @@ class ConvolutionConnector(AbstractConnector):
             return super(ConvolutionConnector, self).get_connected_vertices(
                 s_info, source_vertex, target_vertex)
         pre_vertices = numpy.array(
-            source_vertex.splitter.get_out_going_vertices(SPIKE_PARTITION_ID))
+            source_vertex.splitter.get_out_going_vertices(s_info.partition_id))
         post_slice_ranges = self.__pre_as_post_slice_ranges(
             m_vertex.vertex_slice for m_vertex in pre_vertices)
         hlf_k_w, hlf_k_h = numpy.array(self.__kernel_weights.shape) // 2
 
         connected: List[Tuple[MachineVertex, List[MachineVertex]]] = []
         for post in target_vertex.splitter.get_in_coming_vertices(
-                SPIKE_PARTITION_ID):
+                s_info.partition_id):
             post_slice = post.vertex_slice
             post_slice_x = post_slice.get_slice(0)
             post_slice_y = post_slice.get_slice(1)

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_list_connector.py
@@ -34,7 +34,6 @@ from pacman.model.graphs.common import Slice
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.exceptions import InvalidParameterType
 from spynnaker.pyNN.types import Delay_Types, Weight_Delay_Types, Weight_Types
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
 from .abstract_connector import AbstractConnector
 from .abstract_generate_connector_on_host import (
@@ -508,9 +507,9 @@ class FromListConnector(AbstractConnector, AbstractGenerateConnectorOnHost):
         # Divide the targets into bins based on post slices
         post_slices = [m.vertex_slice
                        for m in target_vertex.splitter.get_in_coming_vertices(
-                           SPIKE_PARTITION_ID)]
+                           s_info.partition_id)]
         pre_vertices = source_vertex.splitter.get_out_going_vertices(
-            SPIKE_PARTITION_ID)
+            s_info.partition_id)
         pre_slices = [m.vertex_slice for m in pre_vertices]
 
         post_mapping = self.__id_to_m_vertex_index(
@@ -549,7 +548,7 @@ class FromListConnector(AbstractConnector, AbstractGenerateConnectorOnHost):
                       if (s_vert.vertex_slice.lo_atom,
                           m_vert.vertex_slice.lo_atom) in split_counts])
             for m_vert in target_vertex.splitter.get_in_coming_vertices(
-                SPIKE_PARTITION_ID)
+                s_info.partition_id)
         ]
 
     def _apply_parameters_to_synapse_type(

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -36,7 +36,6 @@ from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.types import (
     Delay_Types, Weight_Delay_Types, Weight_Types)
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
 from .abstract_connector import AbstractConnector
 from .abstract_generate_connector_on_machine import (
@@ -533,9 +532,9 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
         return [
             (t_vert,
              [s_vert for s_vert in src_splitter.get_out_going_vertices(
-                 SPIKE_PARTITION_ID) if self.__connects(s_vert, t_vert)])
+                 s_info.partition_id) if self.__connects(s_vert, t_vert)])
             for t_vert in target_vertex.splitter.get_in_coming_vertices(
-                SPIKE_PARTITION_ID)]
+                s_info.partition_id)]
 
     def __connects(self, src_machine_vertex: MachineVertex,
                    dest_machine_vertex: MachineVertex) -> bool:

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -523,9 +523,9 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
     def gen_connector_params_size_in_bytes(self) -> int:
         size = N_KERNEL_PARAMS * BYTES_PER_WORD
         if self._krn_weights is not None:
-            size += len(self._krn_weights) * BYTES_PER_WORD
+            size += sum(len(x) for x in self._krn_weights) * BYTES_PER_WORD
         if self._krn_delays is not None:
-            size += len(self._krn_delays) * BYTES_PER_WORD
+            size += sum(len(x) for x in self._krn_delays) * BYTES_PER_WORD
         return size
 
     @overrides(AbstractGenerateConnectorOnMachine.get_connected_vertices)

--- a/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/kernel_connector.py
@@ -52,7 +52,7 @@ _Kernel: TypeAlias = Union[
     float, int, List[float], NDArray[numpy.floating], RandomDistribution]
 
 HEIGHT, WIDTH = 0, 1
-N_KERNEL_PARAMS = 8
+N_KERNEL_PARAMS = 9
 
 
 class ConvolutionKernel(ndarray):
@@ -521,7 +521,12 @@ class KernelConnector(AbstractGenerateConnectorOnMachine,
     @overrides(
         AbstractGenerateConnectorOnMachine.gen_connector_params_size_in_bytes)
     def gen_connector_params_size_in_bytes(self) -> int:
-        return N_KERNEL_PARAMS * BYTES_PER_WORD
+        size = N_KERNEL_PARAMS * BYTES_PER_WORD
+        if self._krn_weights is not None:
+            size += len(self._krn_weights) * BYTES_PER_WORD
+        if self._krn_delays is not None:
+            size += len(self._krn_delays) * BYTES_PER_WORD
+        return size
 
     @overrides(AbstractGenerateConnectorOnMachine.get_connected_vertices)
     def get_connected_vertices(

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_connector.py
@@ -30,8 +30,6 @@ from pacman.model.graphs.common import Slice
 
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
-
 from .abstract_connector import AbstractConnector
 from .abstract_generate_connector_on_machine import (
     AbstractGenerateConnectorOnMachine, ConnectorIDs)
@@ -197,9 +195,9 @@ class OneToOneConnector(AbstractGenerateConnectorOnMachine,
             target_vertex: ApplicationVertex) -> Sequence[
                 Tuple[MachineVertex, Sequence[MachineVertex]]]:
         src_vtxs = source_vertex.splitter.get_out_going_vertices(
-            SPIKE_PARTITION_ID)
+            s_info.partition_id)
         tgt_vtxs = target_vertex.splitter.get_in_coming_vertices(
-            SPIKE_PARTITION_ID)
+            s_info.partition_id)
 
         # If doing a view, we must be single dimensional, so use old method
         if s_info.prepop_is_view or s_info.postpop_is_view:

--- a/spynnaker/pyNN/models/neural_projections/synapse_information.py
+++ b/spynnaker/pyNN/models/neural_projections/synapse_information.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
-from typing import List, Sequence, TYPE_CHECKING, Union
+from typing import List, Sequence, TYPE_CHECKING, Union, Optional
 from spinn_utilities.config_holder import get_config_bool
 from pacman.model.graphs.application import ApplicationVertex
 from spynnaker.pyNN.models.neural_projections.connectors import (
@@ -21,6 +21,7 @@ from spynnaker.pyNN.models.neural_projections.connectors import (
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     AbstractGenerateOnMachine)
 from spynnaker.pyNN.types import (Delay_Types, Weight_Types)
+from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.populations import Population, PopulationView
     from spynnaker.pyNN.models.neuron import ConnectionHolder
@@ -47,7 +48,8 @@ class SynapseInformation(object):
         "__delays",
         "__pre_run_connection_holders",
         "__synapse_type_from_dynamics",
-        "__download_on_pause")
+        "__download_on_pause",
+        "__partition_id")
 
     def __init__(self, connector: AbstractConnector,
                  pre_population: Union[Population, PopulationView],
@@ -58,7 +60,8 @@ class SynapseInformation(object):
                  synapse_type_from_dynamics: bool,
                  weights: Weight_Types = None,
                  delays: Delay_Types = None,
-                 download_on_pause: bool = False):
+                 download_on_pause: bool = False,
+                 partition_id: Optional[str] = None):
         """
         :param AbstractConnector connector:
             The connector connected to the synapse
@@ -82,6 +85,10 @@ class SynapseInformation(object):
         :type delays: float or list(float) or ~numpy.ndarray(float) or None
         :param bool download_on_pause:
             Whether to download the synapse matrix when the simulation pauses
+        :param partition_id:
+            The partition id for the application edge when not standard; if
+            None, the standard SPIKE_PARTITION_ID is used
+        :type partition_id: str or None
         """
         self.__connector = connector
         self.__pre_population = pre_population
@@ -96,6 +103,7 @@ class SynapseInformation(object):
         self.__delays = delays
         self.__synapse_type_from_dynamics = synapse_type_from_dynamics
         self.__download_on_pause = download_on_pause
+        self.__partition_id = partition_id or SPIKE_PARTITION_ID
 
         # Make a list of holders to be updated
         self.__pre_run_connection_holders: List[ConnectionHolder] = list()
@@ -309,3 +317,12 @@ class SynapseInformation(object):
             Whether to download the synapse matrix when the simulation pauses
         """
         self.__download_on_pause = download_on_pause
+
+    @property
+    def partition_id(self) -> str:
+        """
+        The partition id for the application edge
+
+        :rtype: str
+        """
+        return self.__partition_id

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -223,7 +223,8 @@ class AbstractPopulationVertex(
         "__read_initial_values",
         "__have_read_initial_values",
         "__last_parameter_read_time",
-        "__n_colour_bits")
+        "__n_colour_bits",
+        "__extra_partitions")
 
     #: recording region IDs
     _SPIKE_RECORDING_REGION = 0
@@ -254,7 +255,8 @@ class AbstractPopulationVertex(
             neuron_impl: AbstractNeuronImpl,
             pynn_model: AbstractPyNNNeuronModel, drop_late_spikes: bool,
             splitter: Optional[SplitterAbstractPopulationVertex],
-            seed: Optional[int], n_colour_bits: Optional[int]):
+            seed: Optional[int], n_colour_bits: Optional[int],
+            extra_partitions: Optional[List[str]]=None):
         """
         :param int n_neurons: The number of neurons in the population
         :param str label: The label on the population
@@ -282,6 +284,9 @@ class AbstractPopulationVertex(
             The Population seed, used to ensure the same random generation
             on each run.
         :param int n_colour_bits: The number of colour bits to use
+        :param extra_partitions:
+            Extra partitions that are to be sent by the vertex
+        :type extra_partitions: list(str) or None
         """
         # pylint: disable=too-many-arguments
         super().__init__(label, max_atoms_per_core, splitter)
@@ -387,6 +392,13 @@ class AbstractPopulationVertex(
         self.__read_initial_values = False
         self.__have_read_initial_values = False
         self.__last_parameter_read_time: Optional[float] = None
+        self.__extra_partitions = extra_partitions
+
+    @property
+    def extra_partitions(self) -> List[str]:
+        if self.__extra_partitions is None:
+            return []
+        return self.__extra_partitions
 
     @property  # type: ignore[override]
     @overrides(PopulationApplicationVertex.splitter)

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -396,6 +396,7 @@ class AbstractPopulationVertex(
 
     @property
     def extra_partitions(self) -> List[str]:
+        """ The extra partitions that are to be sent by the vertex. """
         if self.__extra_partitions is None:
             return []
         return self.__extra_partitions

--- a/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/abstract_population_vertex.py
@@ -256,7 +256,7 @@ class AbstractPopulationVertex(
             pynn_model: AbstractPyNNNeuronModel, drop_late_spikes: bool,
             splitter: Optional[SplitterAbstractPopulationVertex],
             seed: Optional[int], n_colour_bits: Optional[int],
-            extra_partitions: Optional[List[str]]=None):
+            extra_partitions: Optional[List[str]] = None):
         """
         :param int n_neurons: The number of neurons in the population
         :param str label: The label on the population

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 from math import ceil
 from typing import (
-    Dict, Iterable, List, cast, TYPE_CHECKING)
+    Dict, Iterable, List, Tuple, cast, TYPE_CHECKING)
 
 import numpy
 from numpy import floating, uint32
@@ -78,7 +78,8 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
         # Store the sources to avoid recalculation
         self.__cached_sources: Dict[ApplicationVertex, Dict[
-                PopulationApplicationVertex, List[Source]]] = dict()
+                Tuple(PopulationApplicationVertex, str),
+                List[Source]]] = dict()
 
     @property
     def _delay(self) -> float:
@@ -155,7 +156,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
         source_data = list()
         connector_data: List[NDArray[uint32]] = list()
         weight_data = list()
-        for pre_vertex, source_infos in sources.items():
+        for (pre_vertex, part_id), source_infos in sources.items():
 
             # Add connectors as needed
             first_conn_index = len(connector_data)
@@ -182,7 +183,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
             # Get the source routing information
             r_info, core_mask, mask_shift = get_rinfo_for_spike_source(
-                pre_vertex)
+                pre_vertex, part_id)
 
             # Get the width / height per core / last_core
             first_slice, last_slice = get_first_and_last_slice(pre_vertex)
@@ -249,7 +250,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
     def __get_sources_for_target(
             self, app_vertex: AbstractPopulationVertex) -> Dict[
-                PopulationApplicationVertex, List[Source]]:
+                Tuple(PopulationApplicationVertex, str), List[Source]]:
         """
         Get all the application vertex sources that will hit the given
         application vertex.
@@ -258,7 +259,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
         :return:
             A dict of source PopulationApplicationVertex to list of source
             information
-        :rtype: dict(PopulationApplicationVertex, list(Source))
+        :rtype: dict(tuple(PopulationApplicationVertex, str), list(Source))
         """
         sources = self.__cached_sources.get(app_vertex)
         if sources is None:

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
@@ -78,7 +78,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
         # Store the sources to avoid recalculation
         self.__cached_sources: Dict[ApplicationVertex, Dict[
-                Tuple(PopulationApplicationVertex, str),
+                Tuple[PopulationApplicationVertex, str],
                 List[Source]]] = dict()
 
     @property
@@ -250,7 +250,7 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
 
     def __get_sources_for_target(
             self, app_vertex: AbstractPopulationVertex) -> Dict[
-                Tuple(PopulationApplicationVertex, str), List[Source]]:
+                Tuple[PopulationApplicationVertex, str], List[Source]]:
         """
         Get all the application vertex sources that will hit the given
         application vertex.

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
@@ -74,7 +74,7 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
         """
         # Store the sources to avoid recalculation
         self.__cached_sources: Dict[ApplicationVertex, Dict[
-                Tuple(ApplicationVertex, str), List[Source]]] = dict()
+                Tuple[ApplicationVertex, str], List[Source]]] = dict()
 
         super().__init__(delay)
         if not isinstance(self.delay, (float, int)):

--- a/spynnaker/pyNN/models/neuron/population_machine_neurons.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_neurons.py
@@ -235,10 +235,10 @@ class PopulationMachineNeurons(
     def __find_default_key(self) -> Optional[int]:
         routing_info = SpynnakerDataView.get_routing_infos()
         if not self._pop_vertex.extra_partitions:
-            return routing_info.get_single_first_key_from_pre_vertex(
+            return routing_info.get_single_key_from(
                 cast(AbstractVertex, self))
         partition_ids = set(
-            routing_info.get_partitions_outgoing_from_vertex(
+            routing_info.get_partitions_from(
                 cast(AbstractVertex, self)))
         partition_ids = partition_ids - set(self._pop_vertex.extra_partitions)
         if len(partition_ids) > 1:
@@ -246,7 +246,7 @@ class PopulationMachineNeurons(
                 "Multiple outgoing partitions found, cannot determine key")
         if len(partition_ids) == 0:
             return None
-        return routing_info.get_safe_first_key_from_pre_vertex(
+        return routing_info.get_key_from(
             cast(AbstractVertex, self), next(iter(partition_ids)))
 
     def _rewrite_neuron_data_spec(self, spec: DataSpecificationReloader):

--- a/spynnaker/pyNN/models/neuron/population_machine_neurons.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_neurons.py
@@ -33,7 +33,6 @@ from spinn_front_end_common.interface.ds import (
 from spinn_front_end_common.interface.provenance import ProvenanceWriter
 
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from spynnaker.pyNN.models.abstract_models import AbstractNeuronExpandable
 from spynnaker.pyNN.models.current_sources import CurrentSourceIDs

--- a/spynnaker/pyNN/models/neuron/population_machine_neurons.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_neurons.py
@@ -219,8 +219,8 @@ class PopulationMachineNeurons(
         """
         # Get and store the key
         routing_info = SpynnakerDataView.get_routing_infos()
-        key = routing_info.get_first_key_from_pre_vertex(
-            cast(AbstractVertex, self), SPIKE_PARTITION_ID)
+        key = routing_info.get_single_first_key_from_pre_vertex(
+            cast(AbstractVertex, self))
         if key is not None:
             self._set_key(key)
 

--- a/spynnaker/pyNN/models/neuron/population_machine_neurons.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_neurons.py
@@ -14,7 +14,8 @@
 from __future__ import annotations
 from collections.abc import Container
 import ctypes
-from typing import List, NamedTuple, Sequence, Set, Union, cast, TYPE_CHECKING
+from typing import (
+    List, NamedTuple, Sequence, Set, Union, Optional, cast, TYPE_CHECKING)
 
 import numpy
 
@@ -231,13 +232,14 @@ class PopulationMachineNeurons(
         self._neuron_data.write_data(
             spec, self._vertex_slice, self._neuron_regions)
 
-    def __find_default_key(self) -> int:
+    def __find_default_key(self) -> Optional[int]:
         routing_info = SpynnakerDataView.get_routing_infos()
         if not self._pop_vertex.extra_partitions:
             return routing_info.get_single_first_key_from_pre_vertex(
                 cast(AbstractVertex, self))
         partition_ids = set(
-            routing_info.get_partitions_outgoing_from_vertex(self))
+            routing_info.get_partitions_outgoing_from_vertex(
+                cast(AbstractVertex, self)))
         partition_ids = partition_ids - set(self._pop_vertex.extra_partitions)
         if len(partition_ids) > 1:
             raise ValueError(
@@ -245,7 +247,7 @@ class PopulationMachineNeurons(
         if len(partition_ids) == 0:
             return None
         return routing_info.get_safe_first_key_from_pre_vertex(
-            self, next(iter(partition_ids)))
+            cast(AbstractVertex, self), next(iter(partition_ids)))
 
     def _rewrite_neuron_data_spec(self, spec: DataSpecificationReloader):
         """

--- a/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_common.py
+++ b/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_common.py
@@ -268,7 +268,7 @@ class PopulationSynapsesMachineVertexCommon(
         else:
             assert self.__partition_id is not None
             routing_info = SpynnakerDataView.get_routing_infos()
-            r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+            r_info = routing_info.get_info_from(
                 self.__neuron_vertex, self.__partition_id)
             spec.write_value(r_info.key)
             spec.write_value(r_info.mask)

--- a/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_common.py
+++ b/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_common.py
@@ -268,9 +268,8 @@ class PopulationSynapsesMachineVertexCommon(
         else:
             assert self.__partition_id is not None
             routing_info = SpynnakerDataView.get_routing_infos()
-            r_info = routing_info.get_routing_info_from_pre_vertex(
+            r_info = routing_info.get_safe_routing_info_from_pre_vertex(
                 self.__neuron_vertex, self.__partition_id)
-            assert r_info is not None
             spec.write_value(r_info.key)
             spec.write_value(r_info.mask)
             spec.write_value(~r_info.mask & 0xFFFFFFFF)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -304,9 +304,8 @@ class SynapseDynamicsStructuralCommon(
             spec.write_value(app_edge.pre_vertex.n_atoms)
             # Machine edge information
             for sub, m_vertex in enumerate(out_verts):
-                r_info = routing_info.get_routing_info_from_pre_vertex(
+                r_info = routing_info.get_safe_routing_info_from_pre_vertex(
                     m_vertex, synapse_info.partition_id)
-                assert r_info is not None
                 vertex_slice = m_vertex.vertex_slice
                 spec.write_value(r_info.key)
                 spec.write_value(r_info.mask)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -35,7 +35,6 @@ from spinn_front_end_common.utilities.constants import (
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.common import PopulationApplicationVertex
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
 from .abstract_synapse_dynamics_structural import (
     AbstractSynapseDynamicsStructural)
@@ -278,7 +277,7 @@ class SynapseDynamicsStructuralCommon(
 
             # Number of incoming vertices
             out_verts = app_edge.pre_vertex.splitter.get_out_going_vertices(
-                SPIKE_PARTITION_ID)
+                synapse_info.partition_id)
             spec.write_value(len(out_verts), data_type=DataType.UINT16)
 
             # Controls - currently just if this is a self connection or not
@@ -306,7 +305,7 @@ class SynapseDynamicsStructuralCommon(
             # Machine edge information
             for sub, m_vertex in enumerate(out_verts):
                 r_info = routing_info.get_routing_info_from_pre_vertex(
-                    m_vertex, SPIKE_PARTITION_ID)
+                    m_vertex, synapse_info.partition_id)
                 assert r_info is not None
                 vertex_slice = m_vertex.vertex_slice
                 spec.write_value(r_info.key)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -304,7 +304,7 @@ class SynapseDynamicsStructuralCommon(
             spec.write_value(app_edge.pre_vertex.n_atoms)
             # Machine edge information
             for sub, m_vertex in enumerate(out_verts):
-                r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+                r_info = routing_info.get_info_from(
                     m_vertex, synapse_info.partition_id)
                 vertex_slice = m_vertex.vertex_slice
                 spec.write_value(r_info.key)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -26,7 +26,6 @@ from pacman.model.graphs.common import Slice
 
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.types import Weight_Types
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.utilities.utility_calls import create_mars_kiss_seeds
 
 from .abstract_synapse_dynamics_structural import (
@@ -358,7 +357,7 @@ class SynapseDynamicsStructuralStatic(SynapseDynamicsStatic, _Common):
         # Things change, so assume all connected
         return [(m_vertex, [source_vertex])
                 for m_vertex in target_vertex.splitter.get_in_coming_vertices(
-                    SPIKE_PARTITION_ID)]
+                    s_info.partition_id)]
 
     @property
     @overrides(AbstractSynapseDynamics.is_combined_core_capable)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -25,7 +25,6 @@ from pacman.model.graphs.application import ApplicationVertex
 
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.types import Weight_Delay_In_Types as _In_Types
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.utilities.utility_calls import create_mars_kiss_seeds
 
 from .abstract_synapse_dynamics import AbstractSynapseDynamics
@@ -364,7 +363,7 @@ class SynapseDynamicsStructuralSTDP(
         # Things change, so assume all connected
         return [(m_vertex, [source_vertex])
                 for m_vertex in target_vertex.splitter.get_in_coming_vertices(
-                    SPIKE_PARTITION_ID)]
+                    s_info.partition_id)]
 
     @property
     @overrides(AbstractSynapseDynamics.is_combined_core_capable)

--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -289,8 +289,6 @@ class SynapticMatrices(object):
             app_edge = proj._projection_edge
             synapse_info = proj._synapse_information
             app_key_info = self.__app_key_and_mask(app_edge, synapse_info)
-            if app_key_info is None:
-                continue
             d_app_key_info = self.__delay_app_key_and_mask(
                 app_edge, synapse_info)
             app_matrix = SynapticMatrixApp(
@@ -490,10 +488,9 @@ class SynapticMatrices(object):
             The synapse information of the projection
         """
         routing_info = SpynnakerDataView.get_routing_infos()
-        r_info = routing_info.get_routing_info_from_pre_vertex(
+        r_info = routing_info.get_safe_routing_info_from_pre_vertex(
             app_edge.pre_vertex, s_info.partition_id)
-        if not isinstance(r_info, AppVertexRoutingInfo):
-            return None
+        assert isinstance(r_info, AppVertexRoutingInfo)
         return self.__get_app_key_and_mask(
             r_info, 1, app_edge.pre_vertex, s_info.partition_id)
 
@@ -513,10 +510,9 @@ class SynapticMatrices(object):
         if delay_edge is None:
             return None
         routing_info = SpynnakerDataView.get_routing_infos()
-        r_info = routing_info.get_routing_info_from_pre_vertex(
+        r_info = routing_info.get_safe_routing_info_from_pre_vertex(
             delay_edge.pre_vertex, s_info.partition_id)
-        if not isinstance(r_info, AppVertexRoutingInfo):
-            return None
+        assert isinstance(r_info, AppVertexRoutingInfo)
 
         # We use the app_edge pre-vertex max atoms here as the delay vertex
         # is split according to this

--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import (
-    Dict, List, NamedTuple, Optional, Sequence, Tuple, TYPE_CHECKING)
+    Dict, List, NamedTuple, Optional, Sequence, Tuple, TYPE_CHECKING, cast)
 
 import numpy
 from numpy import floating, uint32
@@ -40,6 +40,7 @@ from spynnaker.pyNN.utilities.bit_field_utilities import (
     get_sdram_for_bit_field_region, get_bitfield_key_map_data,
     write_bitfield_init_data)
 from spynnaker.pyNN.models.common import PopulationApplicationVertex
+from spynnaker.pyNN.models.spike_source import SpikeSourcePoissonVertex
 
 from .synaptic_matrix_app import SynapticMatrixApp
 
@@ -549,7 +550,8 @@ class SynapticMatrices(object):
         :rtype: list(~numpy.ndarray)
         """
         if self.__is_sdram_poisson_source(app_edge):
-            return app_edge.pre_vertex.read_connections(synapse_info)
+            return cast(SpikeSourcePoissonVertex, app_edge.pre_vertex)\
+                .read_connections(synapse_info)
         matrix = self.__matrices[app_edge, synapse_info]
         return matrix.get_connections(placement)
 

--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -478,7 +478,7 @@ class SynapticMatrices(object):
 
     def __app_key_and_mask(
             self, app_edge: ProjectionApplicationEdge,
-            s_info: SynapseInformation) -> Optional[AppKeyInfo]:
+            s_info: SynapseInformation) -> AppKeyInfo:
         """
         Get a key and mask for an incoming application vertex as a whole.
 

--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -491,7 +491,7 @@ class SynapticMatrices(object):
             The synapse information of the projection
         """
         routing_info = SpynnakerDataView.get_routing_infos()
-        r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+        r_info = routing_info.get_info_from(
             app_edge.pre_vertex, s_info.partition_id)
         assert isinstance(r_info, AppVertexRoutingInfo)
         return self.__get_app_key_and_mask(
@@ -513,7 +513,7 @@ class SynapticMatrices(object):
         if delay_edge is None:
             return None
         routing_info = SpynnakerDataView.get_routing_infos()
-        r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+        r_info = routing_info.get_info_from(
             delay_edge.pre_vertex, s_info.partition_id)
         assert isinstance(r_info, AppVertexRoutingInfo)
 

--- a/spynnaker/pyNN/models/neuron/synaptic_matrix_app.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrix_app.py
@@ -93,7 +93,7 @@ class SynapticMatrixApp(object):
             self, synapse_info: SynapseInformation,
             app_edge: ProjectionApplicationEdge, n_synapse_types: int,
             synaptic_matrix_region: int, max_atoms_per_core: int,
-            all_syn_block_sz: int, app_key_info: AppKeyInfo,
+            all_syn_block_sz: int, app_key_info: Optional[AppKeyInfo],
             delay_app_key_info: Optional[AppKeyInfo],
             weight_scales: NDArray[floating]):
         """

--- a/spynnaker/pyNN/models/spike_source/spike_source_array.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array.py
@@ -17,6 +17,7 @@ from spinn_utilities.overrides import overrides
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spynnaker.pyNN.models.common.types import Spikes
+from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from .spike_source_array_vertex import SpikeSourceArrayVertex
 
 
@@ -25,7 +26,8 @@ class SpikeSourceArray(AbstractPyNNModel):
     Model that creates a Spike Source Array Vertex
     """
     default_population_parameters = {
-        "splitter": None, "n_colour_bits": None}
+        "splitter": None, "n_colour_bits": None,
+        "partition_id": SPIKE_PARTITION_ID}
 
     def __init__(self, spike_times: Optional[Spikes] = None):
         if spike_times is None:
@@ -37,18 +39,20 @@ class SpikeSourceArray(AbstractPyNNModel):
     def create_vertex(
             self, n_neurons: int, label: str, *,
             splitter: Optional[AbstractSplitterCommon] = None,
-            n_colour_bits: Optional[int] = None) -> SpikeSourceArrayVertex:
+            n_colour_bits: Optional[int] = None,
+            partition_id: str = SPIKE_PARTITION_ID) -> SpikeSourceArrayVertex:
         """
         :param splitter:
         :type splitter:
             ~pacman.model.partitioner_splitters.AbstractSplitterCommon or None
         :param int n_colour_bits:
+        :param str partition_id:
         """
         # pylint: disable=arguments-differ
         max_atoms = self.get_model_max_atoms_per_dimension_per_core()
         return SpikeSourceArrayVertex(
             n_neurons, self.__spike_times, label, max_atoms, self, splitter,
-            n_colour_bits)
+            n_colour_bits, partition_id)
 
     @property
     def _spike_times(self) -> Spikes:

--- a/spynnaker/pyNN/models/spike_source/spike_source_array.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array.py
@@ -17,7 +17,6 @@ from spinn_utilities.overrides import overrides
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spynnaker.pyNN.models.common.types import Spikes
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from .spike_source_array_vertex import SpikeSourceArrayVertex
 
 
@@ -26,8 +25,7 @@ class SpikeSourceArray(AbstractPyNNModel):
     Model that creates a Spike Source Array Vertex
     """
     default_population_parameters = {
-        "splitter": None, "n_colour_bits": None,
-        "partition_id": SPIKE_PARTITION_ID}
+        "splitter": None, "n_colour_bits": None}
 
     def __init__(self, spike_times: Optional[Spikes] = None):
         if spike_times is None:
@@ -39,20 +37,18 @@ class SpikeSourceArray(AbstractPyNNModel):
     def create_vertex(
             self, n_neurons: int, label: str, *,
             splitter: Optional[AbstractSplitterCommon] = None,
-            n_colour_bits: Optional[int] = None,
-            partition_id: str = SPIKE_PARTITION_ID) -> SpikeSourceArrayVertex:
+            n_colour_bits: Optional[int] = None) -> SpikeSourceArrayVertex:
         """
         :param splitter:
         :type splitter:
             ~pacman.model.partitioner_splitters.AbstractSplitterCommon or None
         :param int n_colour_bits:
-        :param str partition_id:
         """
         # pylint: disable=arguments-differ
         max_atoms = self.get_model_max_atoms_per_dimension_per_core()
         return SpikeSourceArrayVertex(
             n_neurons, self.__spike_times, label, max_atoms, self, splitter,
-            n_colour_bits, partition_id)
+            n_colour_bits)
 
     @property
     def _spike_times(self) -> Spikes:

--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -39,7 +39,6 @@ from spynnaker.pyNN.models.abstract_models import SupportsStructure
 from spynnaker.pyNN.models.common import (
     ParameterHolder, PopulationApplicationVertex)
 from spynnaker.pyNN.models.common.types import (Names, Spikes)
-from spynnaker.pyNN.utilities import constants
 from spynnaker.pyNN.utilities.buffer_data_type import BufferDataType
 from spynnaker.pyNN.utilities.ranged import SpynnakerRangedList
 
@@ -116,7 +115,8 @@ class SpikeSourceArrayVertex(
             max_atoms_per_core: Union[int, Tuple[int, ...]],
             model: SpikeSourceArray,
             splitter: Optional[AbstractSplitterCommon],
-            n_colour_bits: Optional[int]):
+            n_colour_bits: Optional[int],
+            partition_id: str):
         # pylint: disable=too-many-arguments
         self.__model_name = "SpikeSourceArray"
         self.__model = model
@@ -134,7 +134,7 @@ class SpikeSourceArrayVertex(
             n_keys=n_neurons, label=label,
             max_atoms_per_core=max_atoms_per_core,
             send_buffer_times=_send_buffer_times(spike_times, time_step),
-            send_buffer_partition_id=constants.SPIKE_PARTITION_ID,
+            send_buffer_partition_id=partition_id,
             splitter=splitter)
 
         self._check_spike_density(spike_times)

--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -115,8 +115,7 @@ class SpikeSourceArrayVertex(
             max_atoms_per_core: Union[int, Tuple[int, ...]],
             model: SpikeSourceArray,
             splitter: Optional[AbstractSplitterCommon],
-            n_colour_bits: Optional[int],
-            partition_id: str):
+            n_colour_bits: Optional[int]):
         # pylint: disable=too-many-arguments
         self.__model_name = "SpikeSourceArray"
         self.__model = model
@@ -134,7 +133,6 @@ class SpikeSourceArrayVertex(
             n_keys=n_neurons, label=label,
             max_atoms_per_core=max_atoms_per_core,
             send_buffer_times=_send_buffer_times(spike_times, time_step),
-            send_buffer_partition_id=partition_id,
             splitter=splitter)
 
         self._check_spike_density(spike_times)

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -507,7 +507,7 @@ class SpikeSourcePoissonMachineVertex(
 
         # Write Key info for this core:
         routing_info = SpynnakerDataView.get_routing_infos()
-        key = routing_info.get_single_first_key_from_pre_vertex(self)
+        key = routing_info.get_single_key_from(self)
         keys: Union[Sequence[int], numpy.ndarray]
         if key is None:
             spec.write_value(0)
@@ -520,7 +520,7 @@ class SpikeSourcePoissonMachineVertex(
         incoming_mask = 0
         if self._pop_vertex.incoming_control_edge is not None:
             routing_info = SpynnakerDataView.get_routing_infos()
-            r_info = routing_info.get_safe_routing_info_from_pre_vertex(
+            r_info = routing_info.get_info_from(
                 self._pop_vertex.incoming_control_edge.pre_vertex,
                 LIVE_POISSON_CONTROL_PARTITION_ID)
             incoming_mask = ~r_info.mask & 0xFFFFFFFF

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -63,6 +63,8 @@ from spynnaker.pyNN.models.abstract_models import (
     ReceivesSynapticInputsOverSDRAM)
 from spynnaker.pyNN.utilities.constants import (
     LIVE_POISSON_CONTROL_PARTITION_ID)
+from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
+    NUMPY_CONNECTORS_DTYPE, ConnectionsArray)
 
 if TYPE_CHECKING:
     from .spike_source_poisson_vertex import SpikeSourcePoissonVertex
@@ -605,6 +607,32 @@ class SpikeSourcePoissonMachineVertex(
                     # Skip the start and duration as they can't change
                     offset += PARAMS_WORDS_PER_RATE * BYTES_PER_WORD
                 self._pop_vertex.rates.set_value_by_id(i, numpy.array(rates))
+
+    def read_connections(
+            self, synapse_info: SynapseInformation) -> ConnectionsArray:
+        size = self.vertex_slice.n_atoms * SDRAM_EDGE_PARAMS_BYTES_PER_WEIGHT
+        placement = SpynnakerDataView().get_placement_of_vertex(self)
+        addr = locate_memory_region_for_placement(
+            placement, self._PoissonSpikeSourceRegions.SDRAM_EDGE_PARAMS)
+        addr += SDRAM_EDGE_PARAMS_BASE_BYTES
+        data = SpynnakerDataView().read_memory(
+            placement.x, placement.y, addr, size)
+        weights_encoded = numpy.frombuffer(data, dtype=uint16).astype(float)
+        weight_scales = (
+                next(iter(cast(AbstractEdgePartition,
+                               self.__sdram_partition).edges))
+                .post_vertex.weight_scales)
+        weights = weights_encoded / weight_scales[synapse_info.synapse_type]
+        connections = numpy.zeros(
+            self.vertex_slice.n_atoms, dtype=NUMPY_CONNECTORS_DTYPE)
+        connections["source"] = numpy.arange(
+            self.vertex_slice.lo_atom, self.vertex_slice.hi_atom + 1)
+        connections["target"] = numpy.arange(
+            self.vertex_slice.lo_atom, self.vertex_slice.hi_atom + 1)
+        connections["weight"] = weights
+        connections["delay"] = \
+            SpynnakerDataView().get_simulation_time_step_ms()
+        return connections
 
     @overrides(SendsSynapticInputsOverSDRAM.sdram_requirement)
     def sdram_requirement(self, sdram_machine_edge: SDRAMMachineEdge) -> int:

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -506,8 +506,7 @@ class SpikeSourcePoissonMachineVertex(
 
         # Write Key info for this core:
         routing_info = SpynnakerDataView.get_routing_infos()
-        key = routing_info.get_first_key_from_pre_vertex(
-            self, constants.SPIKE_PARTITION_ID)
+        key = routing_info.get_single_first_key_from_pre_vertex(self)
         keys: Union[Sequence[int], numpy.ndarray]
         if key is None:
             spec.write_value(0)
@@ -520,11 +519,10 @@ class SpikeSourcePoissonMachineVertex(
         incoming_mask = 0
         if self._pop_vertex.incoming_control_edge is not None:
             routing_info = SpynnakerDataView.get_routing_infos()
-            r_info = routing_info.get_routing_info_from_pre_vertex(
+            r_info = routing_info.get_safe_routing_info_from_pre_vertex(
                 self._pop_vertex.incoming_control_edge.pre_vertex,
                 LIVE_POISSON_CONTROL_PARTITION_ID)
-            if r_info:
-                incoming_mask = ~r_info.mask & 0xFFFFFFFF
+            incoming_mask = ~r_info.mask & 0xFFFFFFFF
         spec.write_value(incoming_mask)
 
         # Write the number of seconds per timestep (unsigned long fract)

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -610,6 +610,13 @@ class SpikeSourcePoissonMachineVertex(
 
     def read_connections(
             self, synapse_info: SynapseInformation) -> ConnectionsArray:
+        """
+        Read the connections from the machine.
+
+        :param SynapseInformation synapse_info:
+            The synapse information being read
+        :return: The connections read back
+        """
         size = self.vertex_slice.n_atoms * SDRAM_EDGE_PARAMS_BYTES_PER_WEIGHT
         placement = SpynnakerDataView().get_placement_of_vertex(self)
         addr = locate_memory_region_for_placement(

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -61,7 +61,6 @@ from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.abstract_models import (
     AbstractMaxSpikes, SendsSynapticInputsOverSDRAM,
     ReceivesSynapticInputsOverSDRAM)
-from spynnaker.pyNN.utilities import constants
 from spynnaker.pyNN.utilities.constants import (
     LIVE_POISSON_CONTROL_PARTITION_ID)
 

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
@@ -46,6 +46,8 @@ from spynnaker.pyNN.models.common import (
     ParameterHolder, PopulationApplicationVertex)
 from spynnaker.pyNN.models.common.types import Names
 from spynnaker.pyNN.utilities.buffer_data_type import BufferDataType
+from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
+    ConnectionsArray)
 from .spike_source_poisson_machine_vertex import (
     SpikeSourcePoissonMachineVertex, _flatten, get_rates_bytes,
     get_sdram_edge_params_bytes, get_expander_rates_bytes, get_params_bytes)
@@ -53,6 +55,7 @@ if TYPE_CHECKING:
     from spinn_utilities.ranged.abstract_sized import Selector
     from .spike_source_poisson import SpikeSourcePoisson
     from .spike_source_poisson_variable import SpikeSourcePoissonVariable
+    from spynnaker.pyNN.models.neural_projections import SynapseInformation
     from spynnaker.pyNN.models.projection import Projection
     from spynnaker.pyNN.models.common.types import Values
 
@@ -693,3 +696,12 @@ class SpikeSourcePoissonVertex(
     @property
     def n_colour_bits(self) -> int:
         return self.__n_colour_bits
+
+    def read_connections(
+            self, synapse_info: SynapseInformation) -> List[ConnectionsArray]:
+        """ Read Poisson connections from the machine
+        """
+        connections = list()
+        for m_vertex in self.machine_vertices:
+            connections.append(m_vertex.read_connections(synapse_info))
+        return connections

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
@@ -700,6 +700,10 @@ class SpikeSourcePoissonVertex(
     def read_connections(
             self, synapse_info: SynapseInformation) -> List[ConnectionsArray]:
         """ Read Poisson connections from the machine
+
+        :param SynapseInformation synapse_info:
+            The synapse information of the data being read
+        :return: The set of connections from all machine vertices
         """
         connections = list()
         for m_vertex in self.machine_vertices:

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -295,16 +295,15 @@ class DelayExtensionMachineVertex(
         spec.comment("\n*** Spec for Delay Extension Instance ***\n\n")
 
         routing_infos = SpynnakerDataView.get_routing_infos()
-        key = routing_infos.get_first_key_from_pre_vertex(
+        key = routing_infos.get_single_first_key_from_pre_vertex(
             vertex, self.app_vertex.partition.identifier)
 
         srcs = self.app_vertex.source_vertex.splitter.get_out_going_vertices(
             self.app_vertex.partition.identifier)
         for source_vertex in srcs:
             if source_vertex.vertex_slice == self.vertex_slice:
-                r_info = routing_infos.get_routing_info_from_pre_vertex(
+                r_info = routing_infos.get_safe_routing_info_from_pre_vertex(
                     source_vertex, self.app_vertex.partition.identifier)
-                assert (r_info is not None)
                 incoming_key = r_info.key
                 incoming_mask = r_info.mask
                 break

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -31,7 +31,6 @@ from spinn_front_end_common.interface.simulation import simulation_utilities
 from spinn_front_end_common.utilities.constants import SIMULATION_N_BYTES
 
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 
 from .delay_extension_vertex import DelayExtensionVertex
 
@@ -297,14 +296,14 @@ class DelayExtensionMachineVertex(
 
         routing_infos = SpynnakerDataView.get_routing_infos()
         key = routing_infos.get_first_key_from_pre_vertex(
-            vertex, SPIKE_PARTITION_ID)
+            vertex, self.app_vertex.partition.identifier)
 
         srcs = self.app_vertex.source_vertex.splitter.get_out_going_vertices(
-            SPIKE_PARTITION_ID)
+            self.app_vertex.partition.identifier)
         for source_vertex in srcs:
             if source_vertex.vertex_slice == self.vertex_slice:
                 r_info = routing_infos.get_routing_info_from_pre_vertex(
-                    source_vertex, SPIKE_PARTITION_ID)
+                    source_vertex, self.app_vertex.partition.identifier)
                 assert (r_info is not None)
                 incoming_key = r_info.key
                 incoming_mask = r_info.mask

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -295,8 +295,7 @@ class DelayExtensionMachineVertex(
         spec.comment("\n*** Spec for Delay Extension Instance ***\n\n")
 
         routing_infos = SpynnakerDataView.get_routing_infos()
-        key = routing_infos.get_single_first_key_from_pre_vertex(
-            vertex, self.app_vertex.partition.identifier)
+        key = routing_infos.get_single_first_key_from_pre_vertex(vertex)
 
         srcs = self.app_vertex.source_vertex.splitter.get_out_going_vertices(
             self.app_vertex.partition.identifier)

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -295,13 +295,13 @@ class DelayExtensionMachineVertex(
         spec.comment("\n*** Spec for Delay Extension Instance ***\n\n")
 
         routing_infos = SpynnakerDataView.get_routing_infos()
-        key = routing_infos.get_single_first_key_from_pre_vertex(vertex)
+        key = routing_infos.get_single_key_from(vertex)
 
         srcs = self.app_vertex.source_vertex.splitter.get_out_going_vertices(
             self.app_vertex.partition.identifier)
         for source_vertex in srcs:
             if source_vertex.vertex_slice == self.vertex_slice:
-                r_info = routing_infos.get_safe_routing_info_from_pre_vertex(
+                r_info = routing_infos.get_info_from(
                     source_vertex, self.app_vertex.partition.identifier)
                 incoming_key = r_info.key
                 incoming_mask = r_info.mask

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector.py
@@ -16,7 +16,6 @@ from typing import Optional
 from spinn_utilities.overrides import overrides
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from .spike_injector_vertex import SpikeInjectorVertex
 
 _population_parameters = {

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector.py
@@ -23,8 +23,7 @@ _population_parameters = {
     "port": None,
     "virtual_key": None,
     "reserve_reverse_ip_tag": False,
-    "splitter": None,
-    "partition_id": SPIKE_PARTITION_ID
+    "splitter": None
 }
 
 
@@ -42,8 +41,8 @@ class SpikeInjector(AbstractPyNNModel):
             self, n_neurons: int, label: str, *,
             port: Optional[int] = None, virtual_key: Optional[int] = None,
             reserve_reverse_ip_tag: bool = False,
-            splitter: Optional[AbstractSplitterCommon] = None,
-            partition_id: str = SPIKE_PARTITION_ID) -> SpikeInjectorVertex:
+            splitter: Optional[AbstractSplitterCommon] = None) \
+            -> SpikeInjectorVertex:
         """
         :param int port:
         :param int virtual_key:
@@ -51,10 +50,9 @@ class SpikeInjector(AbstractPyNNModel):
         :param splitter:
         :type splitter:
             ~pacman.model.partitioner_splitters.AbstractSplitterCommon or None
-        :param str partition_id:
         """
         # pylint: disable=arguments-differ
         max_atoms_per_core = self.get_model_max_atoms_per_dimension_per_core()
         return SpikeInjectorVertex(
             n_neurons, label, port, virtual_key,
-            reserve_reverse_ip_tag, splitter, max_atoms_per_core, partition_id)
+            reserve_reverse_ip_tag, splitter, max_atoms_per_core)

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector.py
@@ -16,13 +16,15 @@ from typing import Optional
 from spinn_utilities.overrides import overrides
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
+from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from .spike_injector_vertex import SpikeInjectorVertex
 
 _population_parameters = {
     "port": None,
     "virtual_key": None,
     "reserve_reverse_ip_tag": False,
-    "splitter": None
+    "splitter": None,
+    "partition_id": SPIKE_PARTITION_ID
 }
 
 
@@ -40,8 +42,8 @@ class SpikeInjector(AbstractPyNNModel):
             self, n_neurons: int, label: str, *,
             port: Optional[int] = None, virtual_key: Optional[int] = None,
             reserve_reverse_ip_tag: bool = False,
-            splitter: Optional[AbstractSplitterCommon] = None
-            ) -> SpikeInjectorVertex:
+            splitter: Optional[AbstractSplitterCommon] = None,
+            partition_id: str = SPIKE_PARTITION_ID) -> SpikeInjectorVertex:
         """
         :param int port:
         :param int virtual_key:
@@ -49,9 +51,10 @@ class SpikeInjector(AbstractPyNNModel):
         :param splitter:
         :type splitter:
             ~pacman.model.partitioner_splitters.AbstractSplitterCommon or None
+        :param str partition_id:
         """
         # pylint: disable=arguments-differ
         max_atoms_per_core = self.get_model_max_atoms_per_dimension_per_core()
         return SpikeInjectorVertex(
             n_neurons, label, port, virtual_key,
-            reserve_reverse_ip_tag, splitter, max_atoms_per_core)
+            reserve_reverse_ip_tag, splitter, max_atoms_per_core, partition_id)

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
@@ -45,8 +45,7 @@ class SpikeInjectorVertex(
         "__structure")
 
     default_parameters = {
-        'label': "spikeInjector", 'port': None, 'virtual_key': None,
-        'partition_id': SPIKE_PARTITION_ID}
+        'label': "spikeInjector", 'port': None, 'virtual_key': None}
 
     SPIKE_RECORDING_REGION_ID = 0
 
@@ -56,14 +55,12 @@ class SpikeInjectorVertex(
             reserve_reverse_ip_tag: bool,
             splitter: Optional[AbstractSplitterCommon],
             max_atoms_per_core: Optional[
-                Union[int, Tuple[int, ...]]] = sys.maxsize,
-            partition_id: str = SPIKE_PARTITION_ID):
+                Union[int, Tuple[int, ...]]] = sys.maxsize):
         # pylint: disable=too-many-arguments
         super().__init__(
             n_keys=n_neurons, label=label, receive_port=port,
             virtual_key=virtual_key,
             reserve_reverse_ip_tag=reserve_reverse_ip_tag,
-            injection_partition_id=partition_id,
             splitter=splitter, max_atoms_per_core=max_atoms_per_core)
 
         # Set up for recording

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
@@ -45,7 +45,8 @@ class SpikeInjectorVertex(
         "__structure")
 
     default_parameters = {
-        'label': "spikeInjector", 'port': None, 'virtual_key': None}
+        'label': "spikeInjector", 'port': None, 'virtual_key': None,
+        'partition_id': SPIKE_PARTITION_ID}
 
     SPIKE_RECORDING_REGION_ID = 0
 
@@ -55,13 +56,14 @@ class SpikeInjectorVertex(
             reserve_reverse_ip_tag: bool,
             splitter: Optional[AbstractSplitterCommon],
             max_atoms_per_core: Optional[
-                Union[int, Tuple[int, ...]]] = sys.maxsize):
+                Union[int, Tuple[int, ...]]] = sys.maxsize,
+            partition_id: str = SPIKE_PARTITION_ID):
         # pylint: disable=too-many-arguments
         super().__init__(
             n_keys=n_neurons, label=label, receive_port=port,
             virtual_key=virtual_key,
             reserve_reverse_ip_tag=reserve_reverse_ip_tag,
-            injection_partition_id=SPIKE_PARTITION_ID,
+            injection_partition_id=partition_id,
             splitter=splitter, max_atoms_per_core=max_atoms_per_core)
 
         # Set up for recording

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
@@ -26,7 +26,6 @@ from spinn_front_end_common.utility_models import ReverseIpTagMultiCastSource
 from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.models.common import EIEIOSpikeRecorder
 from spynnaker.pyNN.utilities.buffer_data_type import BufferDataType
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.models.common import PopulationApplicationVertex
 from spynnaker.pyNN.models.abstract_models import SupportsStructure
 

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -52,7 +52,6 @@ from spynnaker.pyNN.extra_algorithms.connection_holder_finisher import (
     finish_connection_holders)
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
     spynnaker_splitter_selector)
-from spynnaker.pyNN.utilities import constants
 from spynnaker.pyNN.utilities.neo_buffer_database import NeoBufferDatabase
 
 

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -478,8 +478,8 @@ class SpiNNaker(AbstractSpinnakerBase, pynn_control.BaseState):
                 d_vertices, d_edges = delay_support_adder()
                 for vertex in d_vertices:
                     self.__writer.add_vertex(vertex)
-                for edge in d_edges:
-                    self.__writer.add_edge(edge, constants.SPIKE_PARTITION_ID)
+                for edge, partition_id in d_edges:
+                    self.__writer.add_edge(edge, partition_id)
                 return
             raise ConfigurationException(
                 f"Unexpected cfg setting delay_support_adder: {name}")

--- a/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
+++ b/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
@@ -272,8 +272,7 @@ class SpynnakerExternalDevicePluginManager(object):
         controller = ReverseIpTagMultiCastSource(
             n_keys=vertex.n_atoms, label=control_label,
             receive_port=receive_port,
-            reserve_reverse_ip_tag=reserve_reverse_ip_tag,
-            injection_partition_id=LIVE_POISSON_CONTROL_PARTITION_ID)
+            reserve_reverse_ip_tag=reserve_reverse_ip_tag)
         SpynnakerExternalDevicePluginManager.add_application_vertex(controller)
         edge = SpynnakerExternalDevicePluginManager.add_edge(
             controller, vertex, LIVE_POISSON_CONTROL_PARTITION_ID)

--- a/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
+++ b/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
@@ -82,7 +82,8 @@ class SpynnakerExternalDevicePluginManager(object):
             notify: bool = True, use_payload_prefix: bool = True,
             payload_prefix: Optional[int] = None, payload_right_shift: int = 0,
             number_of_packets_sent_per_time_step: int = 0,
-            translate_keys: bool = False):
+            translate_keys: bool = False,
+            partition_ids: Optional[Iterable[str]] = None):
         """
         Output the spikes from a given population from SpiNNaker as they
         occur in the simulation.
@@ -154,6 +155,9 @@ class SpynnakerExternalDevicePluginManager(object):
         # Use the mask to remove the colour from non-translated keys
         received_key_mask = 0xFFFFFFFF & ~((2 ** n_colour_bits) - 1)
 
+        if partition_ids is None:
+            partition_ids = [SPIKE_PARTITION_ID]
+
         params = LivePacketGatherParameters(
             port=port, hostname=host, tag=tag, strip_sdp=strip_sdp,
             use_prefix=use_prefix, key_prefix=key_prefix,
@@ -168,7 +172,7 @@ class SpynnakerExternalDevicePluginManager(object):
             translate_keys=translate_keys,
             translated_key_right_shift=translated_key_right_shift)
         SpynnakerExternalDevicePluginManager.update_live_packet_gather_tracker(
-            population._vertex, params, [SPIKE_PARTITION_ID])
+            population._vertex, params, partition_ids)
 
         if notify:
             SpynnakerExternalDevicePluginManager.add_database_socket_address(

--- a/spynnaker/pyNN/utilities/bit_field_utilities.py
+++ b/spynnaker/pyNN/utilities/bit_field_utilities.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 import math
-from typing import Iterable, Optional, TYPE_CHECKING
+from typing import Iterable, Optional, TYPE_CHECKING, Tuple
 
 import numpy
 from numpy import uint32
@@ -22,7 +22,6 @@ from numpy.typing import NDArray
 from spinn_front_end_common.interface.ds import DataSpecificationBase
 from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 from spynnaker.pyNN.data import SpynnakerDataView
 
 if TYPE_CHECKING:
@@ -43,20 +42,22 @@ BIT_IN_A_WORD = 32.0
 
 
 def _unique_edges(projections: Iterable[Projection]) -> Iterable[
-        ProjectionApplicationEdge]:
+        Tuple[ProjectionApplicationEdge, str]]:
     """
     Get the unique application edges of a collection of projections.
 
     :param iterable(~spynnaker.pyNN.models.projection.Projection) projections:
         The projections to examine.
-    :rtype: iterable(ProjectionApplicationEdge)
+    :rtype: iterable(tuple(ProjectionApplicationEdge, str))
     """
     seen_edges = set()
     for proj in projections:
-        edge = proj._projection_edge  # pylint: disable=protected-access
-        if edge not in seen_edges:
-            seen_edges.add(edge)
-            yield edge
+        # pylint: disable=protected-access
+        edge = proj._projection_edge
+        synapse_info = proj._synapse_information
+        if (edge, synapse_info.partition_id) not in seen_edges:
+            seen_edges.add((edge, synapse_info.partition_id))
+            yield edge, synapse_info.partition_id
 
 
 def get_sdram_for_bit_field_region(
@@ -72,7 +73,7 @@ def get_sdram_for_bit_field_region(
     :rtype: int
     """
     sdram = FILTER_HEADER_WORDS * BYTES_PER_WORD
-    for in_edge in _unique_edges(incoming_projections):
+    for in_edge, _part_id in _unique_edges(incoming_projections):
         n_atoms = in_edge.pre_vertex.n_atoms
         n_words_for_atoms = int(math.ceil(n_atoms / BIT_IN_A_WORD))
         sdram += (FILTER_INFO_WORDS + n_words_for_atoms) * BYTES_PER_WORD
@@ -96,7 +97,7 @@ def get_sdram_for_keys(incoming_projections: Iterable[Projection]) -> int:
     """
     # basic sdram
     sdram = 0
-    for in_edge in _unique_edges(incoming_projections):
+    for in_edge, _part_id in _unique_edges(incoming_projections):
         sdram += BYTES_PER_WORD
         if in_edge.n_delay_stages:
             sdram += BYTES_PER_WORD
@@ -117,14 +118,14 @@ def get_bitfield_key_map_data(
     # Gather the source vertices that target this core
     routing_infos = SpynnakerDataView.get_routing_infos()
     sources = []
-    for in_edge in _unique_edges(incoming_projections):
+    for in_edge, part_id in _unique_edges(incoming_projections):
         key = routing_infos.get_first_key_from_pre_vertex(
-            in_edge.pre_vertex, SPIKE_PARTITION_ID)
+            in_edge.pre_vertex, part_id)
         if key is not None:
             sources.append([key, in_edge.pre_vertex.n_atoms])
         if in_edge.delay_edge is not None:
             delay_key = routing_infos.get_first_key_from_pre_vertex(
-                in_edge.delay_edge.pre_vertex, SPIKE_PARTITION_ID)
+                in_edge.delay_edge.pre_vertex, part_id)
             if delay_key is not None:
                 n_delay_atoms = (
                     in_edge.pre_vertex.n_atoms * in_edge.n_delay_stages)

--- a/spynnaker/pyNN/utilities/bit_field_utilities.py
+++ b/spynnaker/pyNN/utilities/bit_field_utilities.py
@@ -135,11 +135,11 @@ def get_bitfield_key_map_data(
     routing_infos = SpynnakerDataView.get_routing_infos()
     sources = []
     for in_edge, part_id in _unique_edges(incoming_projections):
-        key = routing_infos.get_safe_first_key_from_pre_vertex(
+        key = routing_infos.get_key_from(
             in_edge.pre_vertex, part_id)
         sources.append([key, in_edge.pre_vertex.n_atoms])
         if in_edge.delay_edge is not None:
-            delay_key = routing_infos.get_safe_first_key_from_pre_vertex(
+            delay_key = routing_infos.get_key_from(
                 in_edge.delay_edge.pre_vertex, part_id)
             n_delay_atoms = (
                 in_edge.pre_vertex.n_atoms * in_edge.n_delay_stages)

--- a/spynnaker/pyNN/utilities/bit_field_utilities.py
+++ b/spynnaker/pyNN/utilities/bit_field_utilities.py
@@ -55,6 +55,10 @@ def _unique_edges(projections: Iterable[Projection]) -> Iterable[
         # pylint: disable=protected-access
         edge = proj._projection_edge
         synapse_info = proj._synapse_information
+        # If there are no outgoing vertices, we should discount this edge
+        if not edge.pre_vertex.splitter.get_out_going_vertices(
+                synapse_info.partition_id):
+            continue
         if (edge, synapse_info.partition_id) not in seen_edges:
             seen_edges.add((edge, synapse_info.partition_id))
             yield edge, synapse_info.partition_id

--- a/spynnaker/pyNN/utilities/bit_field_utilities.py
+++ b/spynnaker/pyNN/utilities/bit_field_utilities.py
@@ -41,7 +41,6 @@ FILTER_HEADER_WORDS = 2
 BIT_IN_A_WORD = 32.0
 
 
-
 def is_sdram_poisson_source(app_edge):
     """ Determine if a given app edge is a poisson source being sent over SDRAM
         as it can likely be discounted if so

--- a/spynnaker/pyNN/utilities/bit_field_utilities.py
+++ b/spynnaker/pyNN/utilities/bit_field_utilities.py
@@ -119,17 +119,15 @@ def get_bitfield_key_map_data(
     routing_infos = SpynnakerDataView.get_routing_infos()
     sources = []
     for in_edge, part_id in _unique_edges(incoming_projections):
-        key = routing_infos.get_first_key_from_pre_vertex(
+        key = routing_infos.get_safe_first_key_from_pre_vertex(
             in_edge.pre_vertex, part_id)
-        if key is not None:
-            sources.append([key, in_edge.pre_vertex.n_atoms])
+        sources.append([key, in_edge.pre_vertex.n_atoms])
         if in_edge.delay_edge is not None:
-            delay_key = routing_infos.get_first_key_from_pre_vertex(
+            delay_key = routing_infos.get_safe_first_key_from_pre_vertex(
                 in_edge.delay_edge.pre_vertex, part_id)
-            if delay_key is not None:
-                n_delay_atoms = (
-                    in_edge.pre_vertex.n_atoms * in_edge.n_delay_stages)
-                sources.append([delay_key, n_delay_atoms])
+            n_delay_atoms = (
+                in_edge.pre_vertex.n_atoms * in_edge.n_delay_stages)
+            sources.append([delay_key, n_delay_atoms])
 
     if not sources:
         return numpy.array([], dtype=uint32)

--- a/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
+++ b/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
@@ -36,11 +36,10 @@ class TestSendMultiplePartitions(BaseTestCase):
         sim.setup(1.0)
         source_1 = sim.Population(1, sim.SpikeSourceArray(spike_times=[0]))
         source_2 = sim.Population(
-            1, sim.SpikeSourceArray(spike_times=[5]), partition_id="Test")
+            1, sim.SpikeSourceArray(spike_times=[5]))
         injector = sim.Population(
             1, sim.external_devices.SpikeInjector(
-                database_notify_port_num=conn.local_port), label="Inject",
-            partition_id="Inject")
+                database_notify_port_num=conn.local_port), label="Inject")
         target = sim.Population(3, sim.IF_curr_exp())
         target.record("spikes")
         proj_1 = sim.Projection(
@@ -48,7 +47,7 @@ class TestSendMultiplePartitions(BaseTestCase):
             synapse_type=sim.StaticSynapse(weight=5.0))
         proj_2 = sim.Projection(
             source_2, target, sim.FromListConnector([(0, 1)]),
-            synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Bacon")
+            synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Test")
         proj_3 = sim.Projection(
             injector, target, sim.FromListConnector([(0, 2)]),
             synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Inject")

--- a/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
+++ b/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
@@ -48,7 +48,7 @@ class TestSendMultiplePartitions(BaseTestCase):
             synapse_type=sim.StaticSynapse(weight=5.0))
         proj_2 = sim.Projection(
             source_2, target, sim.FromListConnector([(0, 1)]),
-            synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Test")
+            synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Bacon")
         proj_3 = sim.Projection(
             injector, target, sim.FromListConnector([(0, 2)]),
             synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Inject")

--- a/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
+++ b/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+
+# Copyright (c) 2024 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from time import sleep
+import numpy
+from spinnaker_testbase import BaseTestCase
+import pyNN.spiNNaker as sim
+
+
+class TestSendMultiplePartitions(BaseTestCase):
+
+    def send_spike(self, label, conn):
+        sleep(0.1)
+        conn.send_spike(label, 0)
+
+    # Added to check that the delay expander runs; a previous fix
+    # for a related issue inadvertently turned it off for this type of case
+    def do_run(self):
+        conn = sim.external_devices.SpynnakerLiveSpikesConnection(
+            send_labels=["Inject"], local_port=None)
+        conn.add_start_callback("Inject", self.send_spike)
+
+        sim.setup(1.0)
+        source_1 = sim.Population(1, sim.SpikeSourceArray(spike_times=[0]))
+        source_2 = sim.Population(
+            1, sim.SpikeSourceArray(spike_times=[5]), partition_id="Test")
+        injector = sim.Population(
+            1, sim.external_devices.SpikeInjector(
+                database_notify_port_num=conn.local_port), label="Inject",
+            partition_id="Inject")
+        target = sim.Population(3, sim.IF_curr_exp())
+        target.record("spikes")
+        proj_1 = sim.Projection(
+            source_1, target, sim.FromListConnector([(0, 0)]),
+            synapse_type=sim.StaticSynapse(weight=5.0))
+        proj_2 = sim.Projection(
+            source_2, target, sim.FromListConnector([(0, 1)]),
+            synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Test")
+        proj_3 = sim.Projection(
+            injector, target, sim.FromListConnector([(0, 2)]),
+            synapse_type=sim.StaticSynapse(weight=5.0), partition_id="Inject")
+
+        sim.run(1000)
+
+        spikes = target.get_data("spikes").segments[0].spiketrains
+        weights_1 = proj_1.get("weight", format="list")
+        weights_2 = proj_2.get("weight", format="list")
+        weights_3 = proj_3.get("weight", format="list")
+
+        sim.end()
+
+        print(spikes)
+        print(weights_1)
+        print(weights_2)
+        print(weights_3)
+
+        # There should be a spike to each neuron
+        assert len(spikes[0]) == 1
+        assert len(spikes[1]) == 1
+        assert len(spikes[2]) == 1
+
+        assert numpy.array_equal(weights_1, ([0, 0, 5.0], ))
+        assert numpy.array_equal(weights_2, ([0, 1, 5.0], ))
+        assert numpy.array_equal(weights_3, ([0, 2, 5.0], ))
+
+    def test_run(self):
+        self.runsafe(self.do_run)

--- a/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
+++ b/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 from time import sleep
-import numpy
 from spinnaker_testbase import BaseTestCase
 import pyNN.spiNNaker as sim
 

--- a/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
+++ b/spynnaker_integration_tests/test_various/test_send_multiple_partitions.py
@@ -31,7 +31,7 @@ class TestSendMultiplePartitions(BaseTestCase):
     def do_run(self):
         conn = sim.external_devices.SpynnakerLiveSpikesConnection(
             send_labels=["Inject"], local_port=None)
-        conn.add_start_callback("Inject", self.send_spike)
+        conn.add_start_resume_callback("Inject", self.send_spike)
 
         sim.setup(1.0)
         source_1 = sim.Population(1, sim.SpikeSourceArray(spike_times=[0]))
@@ -67,13 +67,13 @@ class TestSendMultiplePartitions(BaseTestCase):
         print(weights_3)
 
         # There should be a spike to each neuron
-        assert len(spikes[0]) == 1
-        assert len(spikes[1]) == 1
-        assert len(spikes[2]) == 1
+        self.assertEqual(len(spikes[0]), 1)
+        self.assertEqual(len(spikes[1]), 1)
+        self.assertEqual(len(spikes[2]), 1)
 
-        assert numpy.array_equal(weights_1, ([0, 0, 5.0], ))
-        assert numpy.array_equal(weights_2, ([0, 1, 5.0], ))
-        assert numpy.array_equal(weights_3, ([0, 2, 5.0], ))
+        self.assertListEqual(list(weights_1), [[0, 0, 5.0]])
+        self.assertListEqual(list(weights_2), [[0, 1, 5.0]])
+        self.assertListEqual(list(weights_3), [[0, 2, 5.0]])
 
     def test_run(self):
         self.runsafe(self.do_run)

--- a/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
+++ b/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
@@ -15,7 +15,6 @@
 from testfixtures import LogCapture  # type: ignore[import]
 import unittest
 from spynnaker.pyNN.models.spike_source import SpikeSourceArrayVertex
-from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 import pyNN.spiNNaker as sim
 
 
@@ -29,7 +28,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             v = SpikeSourceArrayVertex(
                 n_neurons=5, spike_times=[], label="test",
                 max_atoms_per_core=None, model=None, splitter=None,
-                n_colour_bits=None, partition_id=SPIKE_PARTITION_ID)
+                n_colour_bits=None)
         found = False
         for record in lc.records:
             if "no spike" in str(record.msg):
@@ -45,14 +44,14 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
         v = SpikeSourceArrayVertex(
             n_neurons=5, spike_times=[1, 11, 22],
             label="test", max_atoms_per_core=None, model=None, splitter=None,
-            n_colour_bits=None, partition_id=SPIKE_PARTITION_ID)
+            n_colour_bits=None)
         v.set_parameter_values("spike_times", [2, 12, 32])
 
     def test_double_list(self):
         SpikeSourceArrayVertex(
             n_neurons=3, spike_times=[[1], [11], [22]],
             label="test", max_atoms_per_core=None, model=None, splitter=None,
-            n_colour_bits=None, partition_id=SPIKE_PARTITION_ID)
+            n_colour_bits=None)
 
     def test_big_double_list(self):
         spike_list1 = [1, 2, 6, 8, 9]
@@ -67,8 +66,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=spike_list,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None,
-                partition_id=SPIKE_PARTITION_ID)
+                splitter=None, n_colour_bits=None)
             found = False
             for record in lc.records:
                 msg = str(record.msg)
@@ -83,8 +81,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             v = SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=None,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None,
-                partition_id=SPIKE_PARTITION_ID)
+                splitter=None, n_colour_bits=None,)
             v.set_parameter_values("spike_times", [34] * 35)
             found = False
             for record in lc.records:
@@ -99,8 +96,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             SpikeSourceArrayVertex(
                 n_neurons=1, spike_times=[37] * 109,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None,
-                partition_id=SPIKE_PARTITION_ID)
+                splitter=None, n_colour_bits=None)
             found = False
             for record in lc.records:
                 msg = str(record.msg)

--- a/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
+++ b/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
@@ -67,7 +67,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=spike_list,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None, 
+                splitter=None, n_colour_bits=None,
                 partition_id=SPIKE_PARTITION_ID)
             found = False
             for record in lc.records:
@@ -83,7 +83,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             v = SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=None,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None, 
+                splitter=None, n_colour_bits=None,
                 partition_id=SPIKE_PARTITION_ID)
             v.set_parameter_values("spike_times", [34] * 35)
             found = False
@@ -99,7 +99,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             SpikeSourceArrayVertex(
                 n_neurons=1, spike_times=[37] * 109,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None, 
+                splitter=None, n_colour_bits=None,
                 partition_id=SPIKE_PARTITION_ID)
             found = False
             for record in lc.records:

--- a/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
+++ b/unittests/model_tests/neuron/test_spike_source/test_spike_source_array_vertex.py
@@ -15,6 +15,7 @@
 from testfixtures import LogCapture  # type: ignore[import]
 import unittest
 from spynnaker.pyNN.models.spike_source import SpikeSourceArrayVertex
+from spynnaker.pyNN.utilities.constants import SPIKE_PARTITION_ID
 import pyNN.spiNNaker as sim
 
 
@@ -28,7 +29,7 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             v = SpikeSourceArrayVertex(
                 n_neurons=5, spike_times=[], label="test",
                 max_atoms_per_core=None, model=None, splitter=None,
-                n_colour_bits=None)
+                n_colour_bits=None, partition_id=SPIKE_PARTITION_ID)
         found = False
         for record in lc.records:
             if "no spike" in str(record.msg):
@@ -44,14 +45,14 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
         v = SpikeSourceArrayVertex(
             n_neurons=5, spike_times=[1, 11, 22],
             label="test", max_atoms_per_core=None, model=None, splitter=None,
-            n_colour_bits=None)
+            n_colour_bits=None, partition_id=SPIKE_PARTITION_ID)
         v.set_parameter_values("spike_times", [2, 12, 32])
 
     def test_double_list(self):
         SpikeSourceArrayVertex(
             n_neurons=3, spike_times=[[1], [11], [22]],
             label="test", max_atoms_per_core=None, model=None, splitter=None,
-            n_colour_bits=None)
+            n_colour_bits=None, partition_id=SPIKE_PARTITION_ID)
 
     def test_big_double_list(self):
         spike_list1 = [1, 2, 6, 8, 9]
@@ -66,7 +67,8 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=spike_list,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None)
+                splitter=None, n_colour_bits=None, 
+                partition_id=SPIKE_PARTITION_ID)
             found = False
             for record in lc.records:
                 msg = str(record.msg)
@@ -81,7 +83,8 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             v = SpikeSourceArrayVertex(
                 n_neurons=3, spike_times=None,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None)
+                splitter=None, n_colour_bits=None, 
+                partition_id=SPIKE_PARTITION_ID)
             v.set_parameter_values("spike_times", [34] * 35)
             found = False
             for record in lc.records:
@@ -96,7 +99,8 @@ class TestSpikeSourceArrayVertex(unittest.TestCase):
             SpikeSourceArrayVertex(
                 n_neurons=1, spike_times=[37] * 109,
                 label="test", max_atoms_per_core=None, model=None,
-                splitter=None, n_colour_bits=None)
+                splitter=None, n_colour_bits=None, 
+                partition_id=SPIKE_PARTITION_ID)
             found = False
             for record in lc.records:
                 msg = str(record.msg)

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -57,7 +57,6 @@ from spynnaker.pyNN.extra_algorithms import delay_support_adder
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractGenerateConnectorOnMachine)
 from spynnaker.pyNN.config_setup import unittest_setup
-from spynnaker.pyNN.utilities import constants
 import pyNN.spiNNaker as p
 
 
@@ -142,9 +141,8 @@ def test_write_data_spec():
     d_vertices, d_edges = delay_support_adder()
     for vertex in d_vertices:
         writer.add_vertex(vertex)
-    for edge in d_edges:
-        writer.add_edge(
-            edge, constants.SPIKE_PARTITION_ID)
+    for edge, part_id in d_edges:
+        writer.add_edge(edge, part_id)
     splitter_partitioner()
     allocator = ZonedRoutingInfoAllocator()
     writer.set_routing_infos(allocator.allocate([]))
@@ -467,9 +465,8 @@ def test_pop_based_master_pop_table_standard(
     d_vertices, d_edges = delay_support_adder()
     for vertex in d_vertices:
         writer.add_vertex(vertex)
-    for edge in d_edges:
-        writer.add_edge(
-            edge, constants.SPIKE_PARTITION_ID)
+    for edge, part_id in d_edges:
+        writer.add_edge(edge, part_id)
     splitter_partitioner()
     allocator = ZonedRoutingInfoAllocator()
     writer.set_routing_infos(allocator.allocate([]))


### PR DESCRIPTION
Allow different partitions from the default SPIKE_PARTITION_ID to be used.  By default this on is used if not specified, and some models will only *send* with that partition id still, but this allows the reception of different partition ids at least, which makes it easier to integrate with other sending models.

Tested with SpiNNakerManchester/IntegrationTests#294 (failing only for unrelated reasons)