### PR TITLE
Csv write fix

### DIFF
--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -1159,7 +1159,7 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
 
     def __read_and_csv_data(
             self, pop_label: str, variable: str, csv_writer: CSVWriter,
-            view_indexes: ViewIndices, t_stop: float):
+            view_indexes: ViewIndices, t_stop: float, allow_missing=False):
         """
         Reads the data for one variable and adds it to the CSV file.
 
@@ -1178,7 +1178,11 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
         """
         metadata = self.__get_recording_metadata(pop_label, variable)
         if metadata is None:
-            return
+            if allow_missing:
+                return
+            else:
+                raise ConfigurationException(
+                    f"No data for {pop_label=} {variable=}")
 
         (rec_id, data_type, buffer_type, t_start, sampling_interval_ms,
          pop_size, units, n_colour_bits) = metadata
@@ -1271,7 +1275,7 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
 
     def csv_segment(
             self, csv_file: str, pop_label: str, variables: Names,
-            view_indexes: ViewIndices = None):
+            view_indexes: ViewIndices, allow_missing: bool):
         """
         Writes the data including metadata to a CSV file.
 
@@ -1304,8 +1308,8 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
                 csv_writer, segment_number, rec_datetime)
 
             for variable in self.__clean_variables(variables, pop_label):
-                self.__read_and_csv_data(
-                    pop_label, variable, csv_writer, view_indexes, t_stop)
+                self.__read_and_csv_data(pop_label, variable, csv_writer,
+                                         view_indexes, t_stop, allow_missing)
 
     def csv_block_metadata(
             self, csv_file: str, pop_label: str,

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -1079,7 +1079,9 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
         self.__get_segment_info()
         metadata = self.__get_recording_metadata(pop_label, SPIKES)
         if metadata is None:
-            return {}
+            if SpynnakerDataView.is_ran_last():
+                raise ConfigurationException(
+                    f"{pop_label} did not record spikes")
 
         (rec_id, _, buffered_type, _, _, pop_size, _,
          n_colour_bits) = metadata
@@ -1291,7 +1293,7 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
             If the recording metadata not setup correctly
         """
         if not os.path.isfile(csv_file):
-            raise SpynnakerException("PLease call csv_block_metadata first")
+            raise SpynnakerException("Please call csv_block_metadata first")
         with open(csv_file, 'a', newline='', encoding="utf-8") as csvfile:
             csv_writer = csv.writer(csvfile, delimiter=',', quotechar='"',
                                     quoting=csv.QUOTE_MINIMAL)

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -1079,9 +1079,8 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
         self.__get_segment_info()
         metadata = self.__get_recording_metadata(pop_label, SPIKES)
         if metadata is None:
-            if SpynnakerDataView.is_ran_last():
-                raise ConfigurationException(
-                    f"{pop_label} did not record spikes")
+            raise ConfigurationException(
+                f"{pop_label} did not record spikes")
 
         (rec_id, _, buffered_type, _, _, pop_size, _,
          n_colour_bits) = metadata
@@ -1159,7 +1158,7 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
 
     def __read_and_csv_data(
             self, pop_label: str, variable: str, csv_writer: CSVWriter,
-            view_indexes: ViewIndices, t_stop: float, allow_missing=False):
+            view_indexes: ViewIndices, t_stop: float, allow_missing: bool):
         """
         Reads the data for one variable and adds it to the CSV file.
 
@@ -1175,6 +1174,8 @@ class NeoBufferDatabase(BufferDatabase, NeoCsv):
         :param view_indexes:
         :type view_indexes: None, ~numpy.array or list(int)
         :param float t_stop:
+        :param allow_missing: Flag to say if data for missing variable
+            should raise an exception
         """
         metadata = self.__get_recording_metadata(pop_label, variable)
         if metadata is None:

--- a/unittests/test_pop_views_assembly/test_csv.py
+++ b/unittests/test_pop_views_assembly/test_csv.py
@@ -62,7 +62,8 @@ class TestCSV(BaseTestCase):
         with NeoBufferDatabase(my_buffer) as db:
             db.csv_block_metadata(
                 my_csv, "pop_1", annotations={"foo": 12, "bar": 34})
-            db.csv_segment(my_csv, "pop_1", variables="all")
+            db.csv_segment(my_csv, "pop_1", variables="all",
+                           view_indexes=None, allow_missing=False)
 
         neo = NeoCsv().read_csv(my_csv)
         # All annotations converted to String and not back
@@ -88,7 +89,7 @@ class TestCSV(BaseTestCase):
             db.csv_block_metadata(my_csv, "pop_1", annotations=None)
             db.csv_segment(
                 my_csv, "pop_1", variables=["spikes", "v"],
-                view_indexes=[2, 4, 7, 8])
+                view_indexes=[2, 4, 7, 8], allow_missing=False)
 
         neo = NeoCsv().read_csv(my_csv)
 
@@ -109,7 +110,8 @@ class TestCSV(BaseTestCase):
         my_csv = os.path.join(my_dir, "test_over_view.csv")
         with NeoBufferDatabase(my_buffer) as db:
             db.csv_block_metadata(my_csv, "pop_1", annotations=None)
-            db.csv_segment(my_csv, "pop_1", variables="all")
+            db.csv_segment(my_csv, "pop_1", variables="all",
+                           view_indexes=None, allow_missing=False)
 
         neo = NeoCsv().read_csv(my_csv)
         spikes = neo_convertor.convert_spikes(neo)
@@ -129,8 +131,8 @@ class TestCSV(BaseTestCase):
         my_csv = os.path.join(my_dir, "test_over_sub_view.csv")
         with NeoBufferDatabase(my_buffer) as db:
             db.csv_block_metadata(my_csv, "pop_1", annotations=None)
-            db.csv_segment(
-                my_csv, "pop_1", variables="all", view_indexes=[2, 4])
+            db.csv_segment(my_csv, "pop_1", variables="all",
+                           view_indexes=[2, 4], allow_missing=False)
 
         neo = NeoCsv().read_csv(my_csv)
         spikes = neo_convertor.convert_spikes(neo)
@@ -150,8 +152,8 @@ class TestCSV(BaseTestCase):
         my_csv = os.path.join(my_dir, "test_no_intersection.csv")
         with NeoBufferDatabase(my_buffer) as db:
             db.csv_block_metadata(my_csv, "pop_1", annotations=None)
-            db.csv_segment(
-                my_csv, "pop_1", variables="all", view_indexes=[4, 6])
+            db.csv_segment(my_csv, "pop_1", variables="all",
+                           view_indexes=[4, 6], allow_missing=False)
 
         neo = NeoCsv().read_csv(my_csv)
         spikes = neo_convertor.convert_spikes(neo)
@@ -170,7 +172,8 @@ class TestCSV(BaseTestCase):
         my_csv = os.path.join(my_dir, "test_rewiring.csv")
         with NeoBufferDatabase(my_buffer) as db:
             db.csv_block_metadata(my_csv, "pop_1", annotations=None)
-            db.csv_segment(my_csv, "pop_1", variables="all")
+            db.csv_segment(my_csv, "pop_1", variables="all",
+                           view_indexes=None, allow_missing=False)
         neo = NeoCsv().read_csv(my_csv)
         formation_events = neo.segments[0].events[0]
         elimination_events = neo.segments[0].events[1]


### PR DESCRIPTION
fixes a big with write csv data when recording is started after a reset.

Set write data to act like get data
- previous segments may be empty
- previous segments may miss some variables
- get/write after a reset 
. fails if no previous data,
. return previous data
. does NOT check if all requested variables are set to record.
- get spike counts never includes previous data so fails after a rest

fixes the test by
- Deleting csv files from previous runs
- Added more checks on behaviour