### PR TITLE
Test None default cfg

### DIFF
--- a/unittests/test_using_virtual_board/test_none_defaults/spynnaker.cfg
+++ b/unittests/test_using_virtual_board/test_none_defaults/spynnaker.cfg
@@ -1,0 +1,15 @@
+[Machine]
+version = None
+versions = ANY
+virtual_board = True
+machineName = None
+spalloc_server  = None
+remote_spinnaker_url  = None
+time_scale_factor = None
+enable_advanced_monitor_support = False
+
+[Buffers]
+use_auto_pause_and_resume = False
+
+[Mode]
+mode = All

--- a/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
+++ b/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
@@ -22,15 +22,14 @@ class TestSimple(BaseTestCase):
 
     def test_simple(self):
         sim.setup(timestep=1.0, n_boards_required=1)
-        machine = sim.get_machine()
+        sim.get_machine()
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
 
         pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")
         input_pop = sim.Population(
             1, sim.SpikeSourceArray(spike_times=[0]), label="input")
-        input_proj = sim.Projection(input_pop, pop_1, sim.OneToOneConnector(),
-                                    synapse_type=sim.StaticSynapse(weight=5,
-                                                                   delay=1))
+        sim.Projection(input_pop, pop_1, sim.OneToOneConnector(),
+                       synapse_type=sim.StaticSynapse(weight=5, delay=1))
         pop_1.record(["spikes", "v"])
         simtime = 10
         sim.run(simtime)

--- a/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
+++ b/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pyNN.spiNNaker as sim
+from spinnaker_testbase import BaseTestCase
+
+
+class TestSimple(BaseTestCase):
+
+    # NO unittest_setup() as sim.setup is called
+
+    def test_simple(self):
+        sim.setup(timestep=1.0, n_boards_required=1)
+        machine = sim.get_machine()
+        sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
+
+        pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")
+        input_pop = sim.Population(
+            1, sim.SpikeSourceArray(spike_times=[0]), label="input")
+        input_proj = sim.Projection(input_pop, pop_1, sim.OneToOneConnector(),
+                                    synapse_type=sim.StaticSynapse(weight=5,
+                                                                   delay=1))
+        pop_1.record(["spikes", "v"])
+        simtime = 10
+        sim.run(simtime)
+        pop_1.get_data(variables=["spikes", "v"])
+        sim.end()


### PR DESCRIPTION
test for https://github.com/SpiNNakerManchester/SpiNNFrontEndCommon/pull/1244

Only failed i(None spalloc issues) in the microcircuit_model Integration Tests
This was because that was the first place the none default
use_auto_pause_and_resume = False
was used.

This adds a test with many of the cfg default values inverted.

the above pr failed this test until fixed,