### PR TITLE
Imutable defaults

### DIFF
--- a/spynnaker/pyNN/models/abstract_pynn_model.py
+++ b/spynnaker/pyNN/models/abstract_pynn_model.py
@@ -15,14 +15,14 @@ from __future__ import annotations
 from collections import defaultdict
 import sys
 from typing import (
-    Any, Callable, Dict, FrozenSet, Optional, Sequence, Tuple, cast,
+    Any, Callable, cast, Dict, FrozenSet, Optional, Mapping, Sequence, Tuple,
     TYPE_CHECKING)
 import numpy
 from pyNN import descriptions
 from spinn_utilities.classproperty import classproperty
 from spinn_utilities.abstract_base import (
     AbstractBase, abstractmethod)
-from spynnaker.pyNN.models.defaults import get_dict_from_init
+from spynnaker.pyNN.models.defaults import get_map_from_init
 from spynnaker.pyNN.exceptions import SpynnakerException
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.common.population_application_vertex import (
@@ -105,18 +105,18 @@ class AbstractPyNNModel(object, metaclass=AbstractBase):
 
     @classproperty
     def default_parameters(  # pylint: disable=no-self-argument
-            cls) -> Dict[str, Any]:
+            cls) -> Mapping[str, Any]:
         """
         Get the default values for the parameters of the model.
 
         :rtype: dict(str, Any)
         """
         init, params, svars = cls.__get_init_params_and_svars(cast(type, cls))
-        return get_dict_from_init(init, skip=svars, include=params)
+        return get_map_from_init(init, skip=svars, include=params)
 
     @classproperty
     def default_initial_values(  # pylint: disable=no-self-argument
-            cls) -> Dict[str, Any]:
+            cls) -> Mapping[str, Any]:
         """
         Get the default initial values for the state variables of the model.
 
@@ -125,7 +125,7 @@ class AbstractPyNNModel(object, metaclass=AbstractBase):
         init, params, svars = cls.__get_init_params_and_svars(cast(type, cls))
         if params is None and svars is None:
             return {}
-        return get_dict_from_init(init, skip=params, include=svars)
+        return get_map_from_init(init, skip=params, include=svars)
 
     @classmethod
     def get_parameter_names(cls) -> Sequence[str]:

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -62,10 +62,10 @@ def get_map_from_init(
         _check_args(skip, default_args, init_method)
 
     as_dict = {arg: value
-            for arg, value in zip(default_args, default_values)
-            if ((arg != "self") and
-                (skip is None or arg not in skip) and
-                (include is None or arg in include))}
+               for arg, value in zip(default_args, default_values)
+               if ((arg != "self") and
+                   (skip is None or arg not in skip) and
+                   (include is None or arg in include))}
     return MappingProxyType(as_dict)
 
 

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -61,11 +61,12 @@ def get_map_from_init(
     if skip is not None:
         _check_args(skip, default_args, init_method)
 
-    return MappingProxyType({arg: value
+    as_dict = {arg: value
             for arg, value in zip(default_args, default_values)
             if ((arg != "self") and
                 (skip is None or arg not in skip) and
-                (include is None or arg in include))})
+                (include is None or arg in include))}
+    return MappingProxyType(as_dict)
 
 
 def default_parameters(parameters: Iterable[str]) -> Callable:

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -18,7 +18,8 @@ Decorators to support default argument handling.
 
 import inspect
 import logging
-from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional
+from types import MappingProxyType
+from typing import Any, Callable, FrozenSet, Iterable, List, Mapping, Optional
 from spinn_utilities.log import FormatAdapter
 
 logger = FormatAdapter(logging.getLogger(__name__))
@@ -34,10 +35,10 @@ def _check_args(
                 f"no default value provided in {init_method}")
 
 
-def get_dict_from_init(
+def get_map_from_init(
         init_method: Callable,
         skip: Optional[FrozenSet[str]] = None,
-        include: Optional[FrozenSet[str]] = None) -> Dict[str, Any]:
+        include: Optional[FrozenSet[str]] = None) -> Mapping[str, Any]:
     """
     Get an argument initialisation dictionary by examining an
     ``__init__`` method or function.
@@ -46,7 +47,6 @@ def get_dict_from_init(
     :param frozenset(str) skip: The arguments to be skipped, if any
     :param frozenset(str) include: The arguments that must be present, if any
     :return: an initialisation dictionary
-    :rtype: dict(str, Any)
     """
     init_args = inspect.getfullargspec(init_method)
     n_defaults = 0 if init_args.defaults is None else len(init_args.defaults)
@@ -61,11 +61,11 @@ def get_dict_from_init(
     if skip is not None:
         _check_args(skip, default_args, init_method)
 
-    return {arg: value
+    return MappingProxyType({arg: value
             for arg, value in zip(default_args, default_values)
             if ((arg != "self") and
                 (skip is None or arg not in skip) and
-                (include is None or arg in include))}
+                (include is None or arg in include))})
 
 
 def default_parameters(parameters: Iterable[str]) -> Callable:
@@ -169,15 +169,15 @@ def defaults(cls: type) -> type:
     if hasattr(init, "_state_variables"):
         svars = getattr(init, "_state_variables")
     if params is None and svars is None:
-        cls.default_parameters = get_dict_from_init(init)
+        cls.default_parameters = get_map_from_init(init)
         cls.default_initial_values = {}
     elif params is None:
-        cls.default_parameters = get_dict_from_init(init, skip=svars)
-        cls.default_initial_values = get_dict_from_init(init, include=svars)
+        cls.default_parameters = get_map_from_init(init, skip=svars)
+        cls.default_initial_values = get_map_from_init(init, include=svars)
     elif svars is None:
-        cls.default_parameters = get_dict_from_init(init, include=params)
-        cls.default_initial_values = get_dict_from_init(init, skip=params)
+        cls.default_parameters = get_map_from_init(init, include=params)
+        cls.default_initial_values = get_map_from_init(init, skip=params)
     else:
-        cls.default_parameters = get_dict_from_init(init, include=params)
-        cls.default_initial_values = get_dict_from_init(init, include=svars)
+        cls.default_parameters = get_map_from_init(init, include=params)
+        cls.default_initial_values = get_map_from_init(init, include=svars)
     return cls


### PR DESCRIPTION
Both our implementations of PyNN models default parameters have the disadvantage that they return a dict which appears mutable but that these changes do not affect future init of that model.

The method using spynnaker/pyNN/models/defaults.py is both neater and considerably easier to type!

This pr makes these methods return a immutable Mapping so if the user does something we do not support it fails fast