### PR TITLE
Abstract provides defaults

### DIFF
--- a/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
@@ -21,7 +21,7 @@ from pacman.model.graphs.application.abstract import (
     AbstractOneAppOneMachineVertex)
 from spinn_front_end_common.abstract_models import (
     AbstractVertexWithEdgeToDependentVertices)
-from spynnaker.pyNN.models.defaults import defaults
+from spynnaker.pyNN.models.defaults import AbstractProvidesDefaults
 from spynnaker.pyNN.models.common import PopulationApplicationVertex
 from .machine_munich_motor_device import MachineMunichMotorDevice
 
@@ -35,11 +35,11 @@ class _MunichMotorDevice(ApplicationSpiNNakerLinkVertex):
             label="External Munich Motor", board_address=board_address)
 
 
-@defaults
 class MunichMotorDevice(
         AbstractOneAppOneMachineVertex,
         AbstractVertexWithEdgeToDependentVertices,
-        PopulationApplicationVertex):
+        PopulationApplicationVertex,
+        AbstractProvidesDefaults):
     """
     An Omnibot motor control device. This has a real vertex and an
     external device vertex.

--- a/spynnaker/pyNN/models/abstract_pynn_model.py
+++ b/spynnaker/pyNN/models/abstract_pynn_model.py
@@ -15,21 +15,20 @@ from __future__ import annotations
 from collections import defaultdict
 import sys
 from typing import (
-    Any, Callable, cast, Dict, FrozenSet, Optional, Mapping, Sequence, Tuple,
-    TYPE_CHECKING)
+    Any, Dict, Optional, Sequence, Tuple, TYPE_CHECKING)
 import numpy
 from pyNN import descriptions
 from spinn_utilities.classproperty import classproperty
 from spinn_utilities.abstract_base import (
     AbstractBase, abstractmethod)
-from spynnaker.pyNN.models.defaults import get_map_from_init
+from spynnaker.pyNN.models.defaults import AbstractProvidesDefaults
 from spynnaker.pyNN.exceptions import SpynnakerException
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.common.population_application_vertex import (
         PopulationApplicationVertex)
 
 
-class AbstractPyNNModel(object, metaclass=AbstractBase):
+class AbstractPyNNModel(AbstractProvidesDefaults, metaclass=AbstractBase):
     """
     A Model that can be passed in to a Population object in PyNN.
     """
@@ -88,44 +87,6 @@ class AbstractPyNNModel(object, metaclass=AbstractBase):
         :rtype: int
         """
         return sys.maxsize
-
-    @staticmethod
-    def __get_init_params_and_svars(the_cls: type) -> Tuple[
-            Callable, Optional[FrozenSet[str]], Optional[FrozenSet[str]]]:
-        init = getattr(the_cls, "__init__")
-        while hasattr(init, "_method"):
-            init = getattr(init, "_method")
-        params = None
-        if hasattr(init, "_parameters"):
-            params = getattr(init, "_parameters")
-        svars = None
-        if hasattr(init, "_state_variables"):
-            svars = getattr(init, "_state_variables")
-        return init, params, svars
-
-    @classproperty
-    def default_parameters(  # pylint: disable=no-self-argument
-            cls) -> Mapping[str, Any]:
-        """
-        Get the default values for the parameters of the model.
-
-        :rtype: dict(str, Any)
-        """
-        init, params, svars = cls.__get_init_params_and_svars(cast(type, cls))
-        return get_map_from_init(init, skip=svars, include=params)
-
-    @classproperty
-    def default_initial_values(  # pylint: disable=no-self-argument
-            cls) -> Mapping[str, Any]:
-        """
-        Get the default initial values for the state variables of the model.
-
-        :rtype: dict(str, Any)
-        """
-        init, params, svars = cls.__get_init_params_and_svars(cast(type, cls))
-        if params is None and svars is None:
-            return {}
-        return get_map_from_init(init, skip=params, include=svars)
 
     @classmethod
     def get_parameter_names(cls) -> Sequence[str]:

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -209,9 +209,9 @@ class AbstractProvidesDefaults(object):
         default_args = ([] if init_args.args is None else
                         init_args.args[n_args - n_defaults:])
         if init_args.defaults is None:
-           default_values = []
+            default_values = []
         else:
-           default_values = init_args.defaults
+            default_values = init_args.defaults
 
         # get the keys based on the decorators
         if hasattr(init, "_parameters"):

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -189,6 +189,12 @@ def defaults(cls: type) -> type:
 
 
 class AbstractProvidesDefaults(object):
+    """
+    Provides the default_parameters and default_initial_values properties
+
+    These will be filled in based on the @default_parameters and
+    @default_initial_values decorators with values read from the init.
+    """
 
     @classmethod
     def __fill_in_defaults(cls):
@@ -276,7 +282,7 @@ class AbstractProvidesDefaults(object):
         this will be all the init parameters with a default value
         less any defined in @default_parameters
 
-        If neither decorator is used this will be an emptuy Mapping
+        If neither decorator is used this will be an empty Mapping
         """
         cls.__fill_in_defaults()
         return cls.default_initial_values

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -70,6 +70,7 @@ def get_map_from_init(
                    (include is None or arg in include))}
     return MappingProxyType(as_dict)
 
+
 def default_parameters(parameters: Iterable[str]) -> Callable:
     """
     Specifies arguments which are parameters.  Only works on the
@@ -186,6 +187,7 @@ def defaults(cls: type) -> type:
         cls.default_initial_values = get_map_from_init(init, include=svars)
     return cls
 
+
 class AbstractProvidesDefaults(object):
 
     @classmethod
@@ -206,7 +208,10 @@ class AbstractProvidesDefaults(object):
         n_args = 0 if init_args.args is None else len(init_args.args)
         default_args = ([] if init_args.args is None else
                         init_args.args[n_args - n_defaults:])
-        default_values = [] if init_args.defaults is None else init_args.defaults
+        if init_args.defaults is None:
+           default_values = []
+        else:
+           default_values = init_args.defaults
 
         # get the keys based on the decorators
         if hasattr(init, "_parameters"):

--- a/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_offset_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/one_to_one_offset_connector.py
@@ -200,6 +200,9 @@ class OneToOneOffsetConnector(
         n_values = self.__n_neurons_per_group
         if n_values is None:
             n_values = synapse_info.n_pre_neurons
+        assert self.__offset >= 0
+        assert self.__wrap >= 0
+        assert n_values >= 0
         return numpy.array([self.__offset, int(self.__wrap), n_values],
                            dtype=uint32)
 

--- a/spynnaker/pyNN/models/neuron/builds/eif_cond_alpha_isfa_ista.py
+++ b/spynnaker/pyNN/models/neuron/builds/eif_cond_alpha_isfa_ista.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.models.defaults import defaults, default_initial_values
+from spynnaker.pyNN.models.defaults import (
+    AbstractProvidesDefaults, default_initial_values)
 
 
 # pylint: disable=wrong-spelling-in-docstring
-@defaults
-class EIFConductanceAlphaPopulation(object):
+class EIFConductanceAlphaPopulation(AbstractProvidesDefaults):
     """
     Exponential integrate and fire neuron with spike triggered and
     sub-threshold adaptation currents (isfa, ista reps.)

--- a/spynnaker/pyNN/models/neuron/builds/hh_cond_exp.py
+++ b/spynnaker/pyNN/models/neuron/builds/hh_cond_exp.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.models.defaults import defaults, default_initial_values
+from spynnaker.pyNN.models.defaults import (
+    AbstractProvidesDefaults, default_initial_values)
 
 
-@defaults
-class HHCondExp(object):
+class HHCondExp(AbstractProvidesDefaults):
     """
     Single-compartment Hodgkin-Huxley model with exponentially decaying
     current input.

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_alpha.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.models.defaults import defaults, default_initial_values
+from spynnaker.pyNN.models.defaults import (
+    AbstractProvidesDefaults, default_initial_values)
 
-
-@defaults
-class IFCondAlpha(object):
+class IFCondAlpha(AbstractProvidesDefaults):
     """
     Leaky integrate and fire neuron with an alpha-shaped current input.
 

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_alpha.py
@@ -16,6 +16,7 @@ from spynnaker.pyNN.exceptions import SpynnakerException
 from spynnaker.pyNN.models.defaults import (
     AbstractProvidesDefaults, default_initial_values)
 
+
 class IFCondAlpha(AbstractProvidesDefaults):
     """
     Leaky integrate and fire neuron with an alpha-shaped current input.

--- a/spynnaker/pyNN/models/neuron/builds/if_facets_hardware1.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_facets_hardware1.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from spynnaker.pyNN.exceptions import SpynnakerException
-from spynnaker.pyNN.models.defaults import defaults, default_initial_values
+from spynnaker.pyNN.models.defaults import (
+    AbstractProvidesDefaults, default_initial_values)
 
 
-@defaults
-class IFFacetsConductancePopulation(object):
+class IFFacetsConductancePopulation(AbstractProvidesDefaults):
     """
     Leaky integrate and fire neuron with conductance-based synapses and
     fixed threshold as it is resembled by the FACETS Hardware Stage 1.

--- a/unittests/model_tests/neuron/test_abstract_neuron_impl.py
+++ b/unittests/model_tests/neuron/test_abstract_neuron_impl.py
@@ -19,11 +19,10 @@ from spynnaker.pyNN.config_setup import unittest_setup
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spynnaker.pyNN.models.neuron.abstract_pynn_neuron_model import (
     AbstractPyNNNeuronModel)
-from spynnaker.pyNN.models.defaults import default_initial_values, defaults
+from spynnaker.pyNN.models.defaults import default_initial_values
 from spynnaker.pyNN.exceptions import SpynnakerException
 
 
-@defaults
 class _MyPyNNModelImpl(AbstractPyNNModel):
 
     default_population_parameters = {}

--- a/unittests/model_tests/neuron/test_defaults.py
+++ b/unittests/model_tests/neuron/test_defaults.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spynnaker.pyNN.config_setup import unittest_setup
 from spynnaker.pyNN.models.defaults import (
     AbstractProvidesDefaults, default_parameters, default_initial_values)

--- a/unittests/model_tests/neuron/test_defaults.py
+++ b/unittests/model_tests/neuron/test_defaults.py
@@ -15,7 +15,7 @@
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spynnaker.pyNN.config_setup import unittest_setup
 from spynnaker.pyNN.models.defaults import (
-    defaults, default_parameters, default_initial_values)
+    AbstractProvidesDefaults, default_parameters, default_initial_values)
 from testfixtures import LogCapture  # type: ignore[import]
 import re
 # pylint: disable=no-member
@@ -24,8 +24,7 @@ import re
 def test_nothing():
     unittest_setup()
 
-    @defaults
-    class _AClass(object):
+    class _AClass(AbstractProvidesDefaults):
         def __init__(self, param_1=1, param_2=2, param_3=3):
             pass
     assert (_AClass.default_parameters == {
@@ -36,8 +35,7 @@ def test_nothing():
 def test_parameters():
     unittest_setup()
 
-    @defaults
-    class _AClass(object):
+    class _AClass(AbstractProvidesDefaults):
 
         @default_parameters({"param_1"})
         def __init__(self, param_1=1, param_2=2, param_3=3):
@@ -49,8 +47,7 @@ def test_parameters():
 def test_state_variables():
     unittest_setup()
 
-    @defaults
-    class _AClass(object):
+    class _AClass(AbstractProvidesDefaults):
 
         @default_initial_values({"param_1"})
         def __init__(self, param_1=1, param_2=2, param_3=3):
@@ -62,16 +59,14 @@ def test_state_variables():
 def test_both():
     unittest_setup()
 
-    @defaults
-    class _AClass(object):
+    class _AClass(AbstractProvidesDefaults):
 
         @default_parameters({"param_1"})
         @default_initial_values({"param_2"})
         def __init__(self, param_1=1, param_2=2, param_3=3):
             pass
 
-    @defaults
-    class _AnotherClass(object):
+    class _AnotherClass(AbstractProvidesDefaults):
 
         @default_initial_values({"param_1"})
         @default_parameters({"param_2"})
@@ -100,8 +95,9 @@ def test_abstract():
         def default_initial_values():
             pass
 
-    @defaults
-    class _AClass(BaseClass):
+    #@defaults
+    #class _AClass(BaseClass):
+    class _AClass(AbstractProvidesDefaults):
 
         default_parameters = None
         default_initial_values = None
@@ -109,23 +105,22 @@ def test_abstract():
         def __init__(self, param="test"):
             pass
 
-    assert _AClass.default_parameters == {"param": "test"}
-    assert _AClass.default_initial_values == {}
+    # this no longer works
+    #assert _AClass.default_parameters == {"param": "test"}
+    #assert _AClass.default_initial_values == {}
     _AClass()
 
 
 def test_setting_state_variables():
     unittest_setup()
 
-    @defaults
-    class _AClass(object):
+    class _AClass(AbstractProvidesDefaults):
 
         @default_parameters({"param_1"})
         def __init__(self, param_1=1, param_2=2, param_3=3):
             pass
 
-    @defaults
-    class _AnotherClass(object):
+    class _AnotherClass(AbstractProvidesDefaults):
 
         @default_initial_values({"param_1"})
         def __init__(self, param_1=1, param_2=2, param_3=3):
@@ -151,6 +146,85 @@ def test_setting_state_variables():
         _check_warnings(lc, [], ["param_1", "param_2", "param_3"])
         _AnotherClass(param_3=3)
 
+from spinn_utilities.classproperty import classproperty
+from typing import (
+    Any, Callable, cast, Dict, FrozenSet, Optional, Mapping, Sequence,
+    Tuple, TYPE_CHECKING)
+from spynnaker.pyNN.models.defaults import get_map_from_init
+import inspect
+import logging
+from types import MappingProxyType
+
+class AbstractDefaults(object):
+
+    #def __init__(self,*args, **kwargs):
+    #        print("arges", args, "kwargs", kwargs)
+
+    @staticmethod
+    def __get_init_params_and_svars(the_cls: type) -> Tuple[
+        Callable, Optional[FrozenSet[str]], Optional[FrozenSet[str]]]:
+        init = getattr(the_cls, "__init__")
+        while hasattr(init, "_method"):
+            init = getattr(init, "_method")
+        params = None
+        if hasattr(init, "_parameters"):
+            params = getattr(init, "_parameters")
+        svars = None
+        if hasattr(init, "_state_variables"):
+            svars = getattr(init, "_state_variables")
+        return init, params, svars
+
+    @classproperty
+    def default_parameters(  # pylint: disable=no-self-argument
+            cls) -> Mapping[str, Any]:
+        """
+        Get the default values for the parameters of the model.
+
+        :rtype: dict(str, Any)
+        """
+        print("default_parameters")
+        init, params, svars = cls.__get_init_params_and_svars(
+            cast(type, cls))
+        cls.default_parameters = get_map_from_init(
+            init, skip=svars, include=params)
+        return cls.default_parameters
+
+    @classproperty
+    def default_initial_values(  # pylint: disable=no-self-argument
+            cls) -> Mapping[str, Any]:
+        """
+        Get the default initial values for the state variables of the model.
+
+        :rtype: dict(str, Any)
+        """
+        print("default_initial_values")
+        init, params, svars = cls.__get_init_params_and_svars(
+            cast(type, cls))
+        if params is None and svars is None:
+            return {}
+        cls.default_initial_values = get_map_from_init(init, skip=params, include=svars)
+        return cls.default_initial_values
+#class BClass(AbstractDefaults):
+class BClass(AbstractProvidesDefaults):
+
+    @default_parameters({"param_1"})
+    @default_initial_values({"param_2"})
+    def __init__(self, param_1=1, param_2=2, param_3=3):
+        pass
+
+
+def test_check_weird():
+    unittest_setup()
+
+    bc = BClass()
+    print(1)
+    a = BClass.default_parameters
+    b = BClass.default_initial_values
+    print(a, b)
+    print(2)
+    a1 = bc.default_parameters
+    b1 = bc.default_initial_values
+    print(a1, b1)
 
 def _check_warnings(lc, expected, not_expected):
     line_matcher = re.compile(

--- a/unittests/model_tests/neuron/test_defaults.py
+++ b/unittests/model_tests/neuron/test_defaults.py
@@ -78,39 +78,6 @@ def test_both():
     assert _AnotherClass.default_initial_values == {"param_1": 1}
 
 
-def test_abstract():
-    unittest_setup()
-
-    class BaseClass(object, metaclass=AbstractBase):
-
-        @property
-        @staticmethod
-        @abstractmethod
-        def default_parameters():
-            pass
-
-        @property
-        @staticmethod
-        @abstractmethod
-        def default_initial_values():
-            pass
-
-    #@defaults
-    #class _AClass(BaseClass):
-    class _AClass(AbstractProvidesDefaults):
-
-        default_parameters = None
-        default_initial_values = None
-
-        def __init__(self, param="test"):
-            pass
-
-    # this no longer works
-    #assert _AClass.default_parameters == {"param": "test"}
-    #assert _AClass.default_initial_values == {}
-    _AClass()
-
-
 def test_setting_state_variables():
     unittest_setup()
 
@@ -146,85 +113,6 @@ def test_setting_state_variables():
         _check_warnings(lc, [], ["param_1", "param_2", "param_3"])
         _AnotherClass(param_3=3)
 
-from spinn_utilities.classproperty import classproperty
-from typing import (
-    Any, Callable, cast, Dict, FrozenSet, Optional, Mapping, Sequence,
-    Tuple, TYPE_CHECKING)
-from spynnaker.pyNN.models.defaults import get_map_from_init
-import inspect
-import logging
-from types import MappingProxyType
-
-class AbstractDefaults(object):
-
-    #def __init__(self,*args, **kwargs):
-    #        print("arges", args, "kwargs", kwargs)
-
-    @staticmethod
-    def __get_init_params_and_svars(the_cls: type) -> Tuple[
-        Callable, Optional[FrozenSet[str]], Optional[FrozenSet[str]]]:
-        init = getattr(the_cls, "__init__")
-        while hasattr(init, "_method"):
-            init = getattr(init, "_method")
-        params = None
-        if hasattr(init, "_parameters"):
-            params = getattr(init, "_parameters")
-        svars = None
-        if hasattr(init, "_state_variables"):
-            svars = getattr(init, "_state_variables")
-        return init, params, svars
-
-    @classproperty
-    def default_parameters(  # pylint: disable=no-self-argument
-            cls) -> Mapping[str, Any]:
-        """
-        Get the default values for the parameters of the model.
-
-        :rtype: dict(str, Any)
-        """
-        print("default_parameters")
-        init, params, svars = cls.__get_init_params_and_svars(
-            cast(type, cls))
-        cls.default_parameters = get_map_from_init(
-            init, skip=svars, include=params)
-        return cls.default_parameters
-
-    @classproperty
-    def default_initial_values(  # pylint: disable=no-self-argument
-            cls) -> Mapping[str, Any]:
-        """
-        Get the default initial values for the state variables of the model.
-
-        :rtype: dict(str, Any)
-        """
-        print("default_initial_values")
-        init, params, svars = cls.__get_init_params_and_svars(
-            cast(type, cls))
-        if params is None and svars is None:
-            return {}
-        cls.default_initial_values = get_map_from_init(init, skip=params, include=svars)
-        return cls.default_initial_values
-#class BClass(AbstractDefaults):
-class BClass(AbstractProvidesDefaults):
-
-    @default_parameters({"param_1"})
-    @default_initial_values({"param_2"})
-    def __init__(self, param_1=1, param_2=2, param_3=3):
-        pass
-
-
-def test_check_weird():
-    unittest_setup()
-
-    bc = BClass()
-    print(1)
-    a = BClass.default_parameters
-    b = BClass.default_initial_values
-    print(a, b)
-    print(2)
-    a1 = bc.default_parameters
-    b1 = bc.default_initial_values
-    print(a1, b1)
 
 def _check_warnings(lc, expected, not_expected):
     line_matcher = re.compile(

--- a/unittests/test_populations/test_vertex.py
+++ b/unittests/test_populations/test_vertex.py
@@ -19,7 +19,7 @@ from spynnaker.pyNN.config_setup import unittest_setup
 from spynnaker.pyNN.models.neuron import (
     AbstractPopulationVertex, AbstractPyNNNeuronModelStandard)
 from spynnaker.pyNN.models.neuron.synapse_types import AbstractSynapseType
-from spynnaker.pyNN.models.defaults import default_initial_values, defaults
+from spynnaker.pyNN.models.defaults import default_initial_values
 from spynnaker.pyNN.models.neuron.implementations import (
     AbstractStandardNeuronComponent)
 
@@ -84,7 +84,6 @@ class _MyNeuronModel(AbstractStandardNeuronComponent):
         return None
 
 
-@defaults
 class FooBar(AbstractPyNNNeuronModelStandard):
     @default_initial_values({"foo", "bar"})
     def __init__(self, foo=1, bar=11):


### PR DESCRIPTION
In master there are two ways that the decorators @default_parameters and @default_initial_values are converted to a mapping of the values in the init.  Making these properties

@defaults
This calculated the mappings when the class is imported (even if not used)
The resulting mapping replace the calculate functions so the calculation is only done once!
This style also did not have properties for mypy to find 

AbstractPyNNModel
This calculated the mapping every time the property was called
Only worked for classes that extended AbstractPyNNModel

This PR merges the best of both solutions into AbstractProvidesDefaults
AbstractPyNNModel and any class which used to be decorated by @defaults now extends AbstractPyNNModel

The calculation of the mappings is delayed until either property is used.
Then BOTH properties are filled in (as the calculation uses a lot of sharable work)

Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/307

question.
Which should we do:
1. Keep @defaults but deprecate warning as now
2. Keep defaults but only to raise an error how to change

