### PR TITLE
  # type: ignore[arg-type]

### DIFF
--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -182,8 +182,9 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine,
                                     self.__n_post)],
                                   fmt="%u,%u,%u")
                     for post_neuron in self.__post_neurons:
-                        numpy.savetxt(  # type: ignore[arg-type]
-                            file_handle, post_neuron,
+                        numpy.savetxt(
+                            file_handle,  # type: ignore[arg-type]
+                            post_neuron,
                             fmt=("%u," * (self.__n_post - 1) + "%u"))
 
         return self.__post_neurons

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py
@@ -176,13 +176,13 @@ class FixedNumberPostConnector(AbstractGenerateConnectorOnMachine,
                            f"_fixednumberpost-conn.csv"
                 print('Output post-connectivity to ', filename)
                 with open(filename, 'w', encoding="utf-8") as file_handle:
-                    numpy.savetxt(file_handle,
+                    numpy.savetxt(file_handle,  # type: ignore[arg-type]
                                   [(synapse_info.n_pre_neurons,
                                     synapse_info.n_post_neurons,
                                     self.__n_post)],
                                   fmt="%u,%u,%u")
                     for post_neuron in self.__post_neurons:
-                        numpy.savetxt(
+                        numpy.savetxt(  # type: ignore[arg-type]
                             file_handle, post_neuron,
                             fmt=("%u," * (self.__n_post - 1) + "%u"))
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -182,9 +182,9 @@ class FixedNumberPreConnector(AbstractGenerateConnectorOnMachine,
                                     self.__n_pre)],
                                   fmt="%u,%u,%u")
                     for pre_neuron in self.__pre_neurons:
-                        numpy.savetxt(  # type: ignore[arg-type]
-                            file_handle, pre_neuron[None, :],
-                            fmt=("%u," * (self.__n_pre - 1) + "%u"))
+                        numpy.savetxt(file_handle,  # type: ignore[arg-type]
+                                      pre_neuron[None, :],
+                                      fmt=("%u," * (self.__n_pre - 1) + "%u"))
 
         return self.__pre_neurons
 

--- a/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py
@@ -176,13 +176,13 @@ class FixedNumberPreConnector(AbstractGenerateConnectorOnMachine,
                            f"{synapse_info.post_population.label}" \
                            f"_fixednumberpre-conn.csv"
                 with open(filename, 'w', encoding="utf-8") as file_handle:
-                    numpy.savetxt(file_handle,
+                    numpy.savetxt(file_handle,  # type: ignore[arg-type]
                                   [(synapse_info.n_pre_neurons,
                                     synapse_info.n_post_neurons,
                                     self.__n_pre)],
                                   fmt="%u,%u,%u")
                     for pre_neuron in self.__pre_neurons:
-                        numpy.savetxt(
+                        numpy.savetxt(  # type: ignore[arg-type]
                             file_handle, pre_neuron[None, :],
                             fmt=("%u," * (self.__n_pre - 1) + "%u"))
 


### PR DESCRIPTION
Ignores:
spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py:179: error: Argument 1 to "savetxt" has incompatible type "TextIOWrapper[_WrappedBuffer]"; expected "str | PathLike[str] | str | PathLike[str] | SupportsWrite[bytes] | SupportsWrite[bytes]"  [arg-type]
spynnaker/pyNN/models/neural_projections/connectors/fixed_number_pre_connector.py:186: error: Argument 1 to "savetxt" has incompatible type "TextIOWrapper[_WrappedBuffer]"; expected "str | PathLike[str] | str | PathLike[str] | SupportsWrite[bytes] | SupportsWrite[bytes]"  [arg-type]
spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py:179: error: Argument 1 to "savetxt" has incompatible type "TextIOWrapper[_WrappedBuffer]"; expected "str | PathLike[str] | str | PathLike[str] | SupportsWrite[bytes] | SupportsWrite[bytes]"  [arg-type]
spynnaker/pyNN/models/neural_projections/connectors/fixed_number_post_connector.py:186: error: Argument 1 to "savetxt" has incompatible type "TextIOWrapper[_WrappedBuffer]"; expected "str | PathLike[str] | str | PathLike[str] | SupportsWrite[bytes] | SupportsWrite[bytes]"  [arg-type]

I assume this is an error in the lastest numpy release but am not sure enough to know for sure so just ignoring