### PR TITLE
invert the order in min as numpy uint32 cries if the second is not an int

### DIFF
--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -444,7 +444,7 @@ class SynapticMatrices(object):
             # if converted to an int, so we use U3232 here instead (as there
             # can be scales larger than U1616.max in conductance-based models)
             dtype = DataType.U3232
-            spec.write_value(data=min(w, dtype.max), data_type=dtype)
+            spec.write_value(data=min(dtype.max, w), data_type=dtype)
 
         spec.write_array(self.__generated_data)
         spec.write_array(self.__bit_field_key_map)

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -488,7 +488,7 @@ def test_pop_based_master_pop_table_standard(
             synaptic_matrix=None, pop_table=None, connection_builder=None)
         synaptic_matrices = SynapticMatrices(
             post_pop._vertex, regions, max_atoms_per_core=neurons_per_core,
-            weight_scales=[32, 32], all_syn_block_sz=10000000)
+            weight_scales=numpy.array([32, 32]), all_syn_block_sz=10000000)
         synaptic_matrices.generate_data()
         synaptic_matrices.write_synaptic_data(
             spec, post_vertex_slice, references)


### PR DESCRIPTION
numpy can not compare an unit32 and a Decimal.


import numpy

from decimal import Decimal

ni = numpy.array([1])

nf = numpy.array([1.0])

d = Decimal("4294967295.99999999976716935634613037109375")

print(min(d, nf[0]))

print(min(d, ni[0]))

print(min(nf[0], d))

print(min(ni[0], d))

gives:
1.0
1
1.0
Traceback (most recent call last):
  File "/home/brenninc/spinnaker/my_spinnaker/test.py", line 9, in <module>
    print(min(ni[0], d))
TypeError: argument must be an integer



 