### PR TITLE
rename AbstractPopulationVertex PopulationVerte

### DIFF
--- a/spynnaker/pyNN/__init__.py
+++ b/spynnaker/pyNN/__init__.py
@@ -472,7 +472,7 @@ def set_number_of_neurons_per_core(
     dimensions, it is recommended to set this to `None` here and then
     set the maximum on each Population.
 
-    :param type(AbstractPopulationVertex) neuron_type: neuron type
+    :param type(PopulationVertex) neuron_type: neuron type
     :param max_permitted: the number to set to
     :type max_permitted: int or tuple or None
     """

--- a/spynnaker/pyNN/external_devices/__init__.py
+++ b/spynnaker/pyNN/external_devices/__init__.py
@@ -63,7 +63,7 @@ from spynnaker.pyNN.models.utility_models.spike_injector import (
     SpikeInjector as ExternalDeviceSpikeInjector)
 from spynnaker.pyNN import protocols
 from spynnaker.pyNN.spinnaker import SpiNNaker
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.neuron import PopulationVertex
 
 
 # useful functions
@@ -184,13 +184,13 @@ __ethernet_control_connection: Optional[EthernetControlConnection] = None
 
 
 def __vtx(population: Population) -> Tuple[
-        AbstractPopulationVertex, AbstractEthernetController, str]:
+        PopulationVertex, AbstractEthernetController, str]:
     vertex = population._vertex  # pylint: disable=protected-access
-    if isinstance(vertex, AbstractPopulationVertex):
+    if isinstance(vertex, PopulationVertex):
         v = vertex
     else:
         raise TypeError(
-            "Vertex must be an instance of AbstractPopulationVertex")
+            "Vertex must be an instance of PopulationVertex")
     if isinstance(vertex, AbstractEthernetController):
         c = vertex
     else:

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
@@ -18,7 +18,7 @@ from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
     SplitterAbstractPopulationVertex)
 from spynnaker.pyNN.models.neuron import (
-    AbstractPopulationVertex, AbstractPyNNNeuronModelStandard)
+    PopulationVertex, AbstractPyNNNeuronModelStandard)
 from spynnaker.pyNN.models.defaults import (
     default_initial_values, default_parameters)
 from spynnaker.pyNN.models.neuron.input_types import InputTypeCurrent
@@ -115,7 +115,7 @@ class ExternalDeviceLifControl(AbstractPyNNNeuronModelStandard):
             drop_late_spikes: Optional[bool] = None,
             splitter: Optional[SplitterAbstractPopulationVertex] = None,
             seed: Optional[int] = None, n_colour_bits: Optional[int] = None,
-            n_steps_per_timestep: int = 1) -> AbstractPopulationVertex:
+            n_steps_per_timestep: int = 1) -> PopulationVertex:
         if n_neurons != len(self._devices):
             raise ConfigurationException(
                 "Number of neurons does not match number of "

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
@@ -16,7 +16,7 @@ from typing import Optional, List
 from spinn_utilities.overrides import overrides
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertex)
+    SplitterPopulationVertex)
 from spynnaker.pyNN.models.neuron import (
     PopulationVertex, AbstractPyNNNeuronModelStandard)
 from spynnaker.pyNN.models.defaults import (
@@ -113,7 +113,7 @@ class ExternalDeviceLifControl(AbstractPyNNNeuronModelStandard):
             max_expected_summed_weight: Optional[List[float]] = None,
             incoming_spike_buffer_size: Optional[int] = None,
             drop_late_spikes: Optional[bool] = None,
-            splitter: Optional[SplitterAbstractPopulationVertex] = None,
+            splitter: Optional[SplitterPopulationVertex] = None,
             seed: Optional[int] = None, n_colour_bits: Optional[int] = None,
             n_steps_per_timestep: int = 1) -> PopulationVertex:
         if n_neurons != len(self._devices):

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
@@ -21,7 +21,7 @@ from pacman.model.routing_info import BaseKeyAndMask
 from spinn_front_end_common.abstract_models import (
     AbstractVertexWithEdgeToDependentVertices, HasCustomAtomKeyMap)
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.neuron import PopulationVertex
 from .abstract_ethernet_controller import AbstractEthernetController
 from .abstract_multicast_controllable_device import (
     AbstractMulticastControllableDevice)
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 
 class ExternalDeviceLifControlVertex(
-        AbstractPopulationVertex,
+        PopulationVertex,
         AbstractEthernetController,
         AbstractVertexWithEdgeToDependentVertices,
         HasCustomAtomKeyMap):
@@ -164,7 +164,7 @@ class ExternalDeviceLifControlVertex(
         device = self.__devices[partition_id]
         return [(index, device.device_control_key)]
 
-    @overrides(AbstractPopulationVertex.get_fixed_key_and_mask)
+    @overrides(PopulationVertex.get_fixed_key_and_mask)
     def get_fixed_key_and_mask(
             self, partition_id: str) -> Optional[BaseKeyAndMask]:
         return BaseKeyAndMask(

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from spynnaker.pyNN.models.neuron import AbstractPyNNNeuronModel
     from .abstract_ethernet_translator import AbstractEthernetTranslator
     from spynnaker.pyNN.extra_algorithms.splitter_components import (
-        SplitterAbstractPopulationVertex)
+        SplitterPopulationVertex)
 
 
 class ExternalDeviceLifControlVertex(
@@ -65,7 +65,7 @@ class ExternalDeviceLifControlVertex(
             max_expected_summed_weight: Optional[List[float]] = None,
             incoming_spike_buffer_size: Optional[int] = None,
             drop_late_spikes: Optional[bool] = None,
-            splitter: Optional[SplitterAbstractPopulationVertex] = None,
+            splitter: Optional[SplitterPopulationVertex] = None,
             seed: Optional[int] = None, n_colour_bits: Optional[int] = None):
         """
         :param list(AbstractMulticastControllableDevice) devices:
@@ -86,7 +86,7 @@ class ExternalDeviceLifControlVertex(
         :param float ring_buffer_sigma:
         :param int incoming_spike_buffer_size:
         :param splitter: splitter from application vertices to machine vertices
-        :type splitter: SplitterAbstractPopulationVertex or None
+        :type splitter: SplitterPopulationVertex or None
         :param int n_colour_bits: The number of colour bits to use
         """
         # pylint: disable=too-many-arguments

--- a/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
+++ b/spynnaker/pyNN/extra_algorithms/delay_support_adder.py
@@ -24,7 +24,7 @@ from spynnaker.pyNN.models.neural_projections import (
     ProjectionApplicationEdge, DelayedApplicationEdge,
     DelayAfferentApplicationEdge)
 from spynnaker.pyNN.models.utility_models.delays import DelayExtensionVertex
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.neuron import PopulationVertex
 
 
 def delay_support_adder() -> Tuple[
@@ -55,7 +55,7 @@ class _DelaySupportAdder(object):
         self._app_to_delay_map: Dict[
             ApplicationEdgePartition, DelayExtensionVertex] = dict()
         self._delay_post_edge_map: Dict[
-            Tuple[DelayExtensionVertex, AbstractPopulationVertex, str],
+            Tuple[DelayExtensionVertex, PopulationVertex, str],
             DelayedApplicationEdge] = dict()
         self._new_edges: List[Tuple[ApplicationEdge, str]] = list()
         self._new_vertices: List[DelayExtensionVertex] = list()

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/__init__.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/__init__.py
@@ -14,19 +14,18 @@
 
 from .abstract_spynnaker_splitter_delay import AbstractSpynnakerSplitterDelay
 from .spynnaker_splitter_selector import spynnaker_splitter_selector
-from .splitter_abstract_pop_vertex import SplitterAbstractPopulationVertex
-from .splitter_abstract_pop_vertex_fixed import (
-    SplitterAbstractPopulationVertexFixed)
 from .splitter_delay_vertex_slice import SplitterDelayVertexSlice
-from .splitter_abstract_pop_vertex_neurons_synapses import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
 from .splitter_poisson_delegate import SplitterPoissonDelegate
+from .splitter_population_vertex import SplitterPopulationVertex
+from .splitter_population_vertex_fixed import SplitterPopulationVertexFixed
+from .splitter_population_vertex_neurons_synapses import (
+    SplitterPopulationVertexNeuronsSynapses)
 from .abstract_supports_one_to_one_sdram_input import (
     AbstractSupportsOneToOneSDRAMInput)
 
 __all__ = [
-    'AbstractSpynnakerSplitterDelay', 'SplitterAbstractPopulationVertex',
-    'SplitterDelayVertexSlice', 'spynnaker_splitter_selector',
-    'SplitterAbstractPopulationVertexNeuronsSynapses',
-    'SplitterPoissonDelegate', 'AbstractSupportsOneToOneSDRAMInput',
-    'SplitterAbstractPopulationVertexFixed']
+    'AbstractSpynnakerSplitterDelay', 'AbstractSupportsOneToOneSDRAMInput',
+    'SplitterDelayVertexSlice', 'SplitterPoissonDelegate',
+    'SplitterPopulationVertex', 'SplitterPopulationVertexFixed',
+    'SplitterPopulationVertexNeuronsSynapses',
+    'spynnaker_splitter_selector']

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex.py
@@ -20,7 +20,7 @@ from pacman.model.graphs.common import Slice
 from pacman.model.partitioner_splitters import AbstractSplitterCommon
 from pacman.utilities.algorithm_utilities\
     .partition_algorithm_utilities import get_multidimensional_slices
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.neuron import PopulationVertex
 from .abstract_spynnaker_splitter_delay import AbstractSpynnakerSplitterDelay
 
 
@@ -30,10 +30,10 @@ MAX_RING_BUFFER_BITS = 14
 
 
 class SplitterAbstractPopulationVertex(
-        AbstractSplitterCommon[AbstractPopulationVertex],
+        AbstractSplitterCommon[PopulationVertex],
         AbstractSpynnakerSplitterDelay):
     """
-    Abstract base class of splitters for :py:class:`AbstractPopulationVertex`.
+    Abstract base class of splitters for :py:class:`PopulationVertex`.
     """
     __slots__ = ("_max_delay", "__slices")
 
@@ -45,12 +45,12 @@ class SplitterAbstractPopulationVertex(
     @final
     @overrides(AbstractSplitterCommon.set_governed_app_vertex)
     def set_governed_app_vertex(
-            self, app_vertex: AbstractPopulationVertex) -> None:
-        if not isinstance(app_vertex, AbstractPopulationVertex):
+            self, app_vertex: PopulationVertex) -> None:
+        if not isinstance(app_vertex, PopulationVertex):
             raise PacmanConfigurationException(
                 f"The vertex {app_vertex} cannot be supported by the "
                 f"{self.__class__.__name__} as the only vertex "
-                "supported by this splitter is a AbstractPopulationVertex. "
+                "supported by this splitter is a PopulationVertex. "
                 "Please use the correct splitter for your vertex and try "
                 "again.")
         super().set_governed_app_vertex(app_vertex)

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_fixed.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_fixed.py
@@ -59,7 +59,7 @@ MAX_RING_BUFFER_BITS = 14
 
 class SplitterAbstractPopulationVertexFixed(SplitterAbstractPopulationVertex):
     """
-    Handles the splitting of the :py:class:`AbstractPopulationVertex`
+    Handles the splitting of the :py:class:`PopulationVertex`
     using fixed slices.
     """
 

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_abstract_pop_vertex_neurons_synapses.py
@@ -95,7 +95,7 @@ _MAX_CORES = 15
 class SplitterAbstractPopulationVertexNeuronsSynapses(
         SplitterAbstractPopulationVertex, AbstractSupportsOneToOneSDRAMInput):
     """
-    Splits an :py:class:`AbstractPopulationVertex` so that there are separate
+    Splits an :py:class:`PopulationVertex` so that there are separate
     neuron cores each being fed by one or more synapse cores.  Incoming
     one-to-one Poisson cores are also added here if they meet the criteria.
     """

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_population_vertex.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_population_vertex.py
@@ -29,7 +29,7 @@ from .abstract_spynnaker_splitter_delay import AbstractSpynnakerSplitterDelay
 MAX_RING_BUFFER_BITS = 14
 
 
-class SplitterAbstractPopulationVertex(
+class SplitterPopulationVertex(
         AbstractSplitterCommon[PopulationVertex],
         AbstractSpynnakerSplitterDelay):
     """

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_population_vertex_fixed.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_population_vertex_fixed.py
@@ -49,15 +49,16 @@ from spynnaker.pyNN.models.neuron.neuron_data import NeuronData
 from spynnaker.pyNN.models.neuron.population_machine_common import (
     PopulationMachineCommon)
 
-from .splitter_abstract_pop_vertex import SplitterAbstractPopulationVertex
+from .splitter_population_vertex import SplitterPopulationVertex
 from .abstract_spynnaker_splitter_delay import AbstractSpynnakerSplitterDelay
 
 # The maximum number of bits for the ring buffer index that are likely to
-# fit in DTCM (14-bits = 16,384 16-bit ring buffer entries = 32Kb DTCM
+# fit in DTCM (14-bits = 16,384 16-bit ring
+# buffer entries = 32Kb DTCM
 MAX_RING_BUFFER_BITS = 14
 
 
-class SplitterAbstractPopulationVertexFixed(SplitterAbstractPopulationVertex):
+class SplitterPopulationVertexFixed(SplitterPopulationVertex):
     """
     Handles the splitting of the :py:class:`PopulationVertex`
     using fixed slices.
@@ -308,13 +309,13 @@ class SplitterAbstractPopulationVertexFixed(SplitterAbstractPopulationVertex):
                            self.governed_app_vertex.incoming_projections))
         return sdram
 
-    @overrides(SplitterAbstractPopulationVertex.
+    @overrides(SplitterPopulationVertex.
                reset_called)  # type: ignore[has-type]
     def reset_called(self) -> None:
         super().reset_called()
         self.__expect_delay_extension = None
 
-    @overrides(SplitterAbstractPopulationVertex._update_max_delay)
+    @overrides(SplitterPopulationVertex._update_max_delay)
     def _update_max_delay(self) -> None:
         # Find the maximum delay from incoming synapses
         self._max_delay, self.__expect_delay_extension = \

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_population_vertex_neurons_synapses.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/splitter_population_vertex_neurons_synapses.py
@@ -78,7 +78,7 @@ from spynnaker.pyNN.models.spike_source.spike_source_poisson_machine_vertex \
 
 from .splitter_poisson_delegate import SplitterPoissonDelegate
 from .abstract_spynnaker_splitter_delay import AbstractSpynnakerSplitterDelay
-from .splitter_abstract_pop_vertex import SplitterAbstractPopulationVertex
+from .splitter_population_vertex import SplitterPopulationVertex
 from .abstract_supports_one_to_one_sdram_input import (
     AbstractSupportsOneToOneSDRAMInput)
 
@@ -92,8 +92,8 @@ MAX_RING_BUFFER_BITS = 14
 _MAX_CORES = 15
 
 
-class SplitterAbstractPopulationVertexNeuronsSynapses(
-        SplitterAbstractPopulationVertex, AbstractSupportsOneToOneSDRAMInput):
+class SplitterPopulationVertexNeuronsSynapses(
+        SplitterPopulationVertex, AbstractSupportsOneToOneSDRAMInput):
     """
     Splits an :py:class:`PopulationVertex` so that there are separate
     neuron cores each being fed by one or more synapse cores.  Incoming
@@ -818,7 +818,7 @@ class SplitterAbstractPopulationVertexNeuronsSynapses(
                 BYTES_PER_WORD))
         return sdram
 
-    @overrides(SplitterAbstractPopulationVertex._update_max_delay)
+    @overrides(SplitterPopulationVertex._update_max_delay)
     def _update_max_delay(self) -> None:
         # Find the maximum delay from incoming synapses
         self._max_delay, needs_delay_extension = \

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/spynnaker_splitter_selector.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/spynnaker_splitter_selector.py
@@ -25,11 +25,11 @@ from spynnaker.pyNN.data import SpynnakerDataView
 from spynnaker.pyNN.models.neuron import PopulationVertex
 from spynnaker.pyNN.models.spike_source import (
     SpikeSourceArrayVertex, SpikeSourcePoissonVertex)
-from .splitter_abstract_pop_vertex_fixed import (
-    SplitterAbstractPopulationVertexFixed)
+from .splitter_population_vertex_fixed import (
+    SplitterPopulationVertexFixed)
 from .splitter_poisson_delegate import SplitterPoissonDelegate
-from .splitter_abstract_pop_vertex_neurons_synapses import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+from .splitter_population_vertex_neurons_synapses import (
+    SplitterPopulationVertexNeuronsSynapses)
 from .abstract_spynnaker_splitter_delay import AbstractSpynnakerSplitterDelay
 
 PROGRESS_BAR_NAME = "Adding Splitter selectors where appropriate"
@@ -44,7 +44,7 @@ def spynnaker_splitter_selector() -> None:
     Add a splitter to every vertex that doesn't already have one.
 
     The default for :py:class:`PopulationVertex` is the
-    :py:class:`SplitterAbstractPopulationVertexFixed`.
+    :py:class:`SplitterPopulationVertexFixed`.
     The default for external device splitters are
     :py:class:`~pacman.model.partitioner_splitters.SplitterExternalDevice`.
     The default for the rest is the
@@ -73,10 +73,10 @@ def spynnaker_vertex_selector(app_vertex: ApplicationVertex) -> None:
     if not app_vertex.has_splitter:
         if isinstance(app_vertex, PopulationVertex):
             if app_vertex.combined_core_capable:
-                app_vertex.splitter = SplitterAbstractPopulationVertexFixed()
+                app_vertex.splitter = SplitterPopulationVertexFixed()
             else:
                 app_vertex.splitter = (
-                    SplitterAbstractPopulationVertexNeuronsSynapses(
+                    SplitterPopulationVertexNeuronsSynapses(
                         app_vertex.n_synapse_cores_required))
         elif isinstance(app_vertex, ApplicationSpiNNakerLinkVertex):
             app_vertex.splitter = SplitterExternalDevice()

--- a/spynnaker/pyNN/extra_algorithms/splitter_components/spynnaker_splitter_selector.py
+++ b/spynnaker/pyNN/extra_algorithms/splitter_components/spynnaker_splitter_selector.py
@@ -22,7 +22,7 @@ from spinn_front_end_common.interface.splitter_selectors import (
 from spynnaker.pyNN.models.abstract_models import (
     AbstractAcceptsIncomingSynapses)
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.neuron import PopulationVertex
 from spynnaker.pyNN.models.spike_source import (
     SpikeSourceArrayVertex, SpikeSourcePoissonVertex)
 from .splitter_abstract_pop_vertex_fixed import (
@@ -43,7 +43,7 @@ def spynnaker_splitter_selector() -> None:
     """
     Add a splitter to every vertex that doesn't already have one.
 
-    The default for :py:class:`AbstractPopulationVertex` is the
+    The default for :py:class:`PopulationVertex` is the
     :py:class:`SplitterAbstractPopulationVertexFixed`.
     The default for external device splitters are
     :py:class:`~pacman.model.partitioner_splitters.SplitterExternalDevice`.
@@ -71,7 +71,7 @@ def spynnaker_vertex_selector(app_vertex: ApplicationVertex) -> None:
         application vertex to give a splitter object to
     """
     if not app_vertex.has_splitter:
-        if isinstance(app_vertex, AbstractPopulationVertex):
+        if isinstance(app_vertex, PopulationVertex):
             if app_vertex.combined_core_capable:
                 app_vertex.splitter = SplitterAbstractPopulationVertexFixed()
             else:

--- a/spynnaker/pyNN/models/common/local_only_2d_common.py
+++ b/spynnaker/pyNN/models/common/local_only_2d_common.py
@@ -28,7 +28,6 @@ from spynnaker.pyNN.models.abstract_models import ColouredApplicationVertex
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 
 if TYPE_CHECKING:
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
     from spynnaker.pyNN.models.projection import Projection
 
 #: The number of bits in a short value
@@ -122,13 +121,13 @@ def get_rinfo_for_spike_source(
     return r_info, core_mask, mask_shift
 
 
-def get_sources_for_target(app_vertex: "AbstractPopulationVertex") -> Dict[
+def get_sources_for_target(app_vertex: "PopulationVertex") -> Dict[
         Tuple[ColouredApplicationVertex, str], List[Source]]:
     """
     Get all the application vertex sources that will hit the given application
     vertex.
 
-    :param AbstractPopulationVertex app_vertex: The vertex being targeted
+    :param PopulationVertex app_vertex: The vertex being targeted
     :return:
         A dict of source ApplicationVertex to list of source information
     :rtype: dict(tuple(ApplicationVertex, str), list(Source))

--- a/spynnaker/pyNN/models/common/local_only_2d_common.py
+++ b/spynnaker/pyNN/models/common/local_only_2d_common.py
@@ -28,6 +28,7 @@ from spynnaker.pyNN.models.abstract_models import ColouredApplicationVertex
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 
 if TYPE_CHECKING:
+    from spynnaker.pyNN.models.neuron import PopulationVertex
     from spynnaker.pyNN.models.projection import Projection
 
 #: The number of bits in a short value

--- a/spynnaker/pyNN/models/current_sources/abstract_current_source.py
+++ b/spynnaker/pyNN/models/current_sources/abstract_current_source.py
@@ -19,8 +19,8 @@ from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spinn_front_end_common.interface.ds import DataType
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.populations import Population, PopulationBase
-    from spynnaker.pyNN.models.neuron.abstract_population_vertex import (
-        AbstractPopulationVertex)
+    from spynnaker.pyNN.models.neuron.population_vertex import (
+        PopulationVertex)
 
 #: General type of parameters to current sources.
 #: Individual parameters will only be one of these!
@@ -50,7 +50,7 @@ class AbstractCurrentSource(object, metaclass=AbstractBase):
         "__population")
 
     def __init__(self) -> None:
-        self.__app_vertex: Optional[AbstractPopulationVertex] = None
+        self.__app_vertex: Optional[PopulationVertex] = None
         self.__population: Optional[Population] = None
 
     def inject_into(self, cells: PopulationBase) -> None:
@@ -62,20 +62,20 @@ class AbstractCurrentSource(object, metaclass=AbstractBase):
         # Call the population method to pass the source in
         cells.inject(self)
 
-    def set_app_vertex(self, vertex: AbstractPopulationVertex) -> None:
+    def set_app_vertex(self, vertex: PopulationVertex) -> None:
         """
         Set the application vertex associated with the current source.
 
-        :param AbstractPopulationVertex vertex: The population vertex
+        :param PopulationVertex vertex: The population vertex
         """
         self.__app_vertex = vertex
 
     @property
-    def app_vertex(self) -> Optional[AbstractPopulationVertex]:
+    def app_vertex(self) -> Optional[PopulationVertex]:
         """
         The application vertex associated with the current source.
 
-        :rtype: AbstractPopulationVertex
+        :rtype: PopulationVertex
         """
         return self.__app_vertex
 

--- a/spynnaker/pyNN/models/neural_projections/delayed_application_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/delayed_application_edge.py
@@ -19,7 +19,7 @@ from spinn_utilities.overrides import overrides
 from pacman.model.graphs.application import ApplicationEdge
 
 if TYPE_CHECKING:
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+    from spynnaker.pyNN.models.neuron import PopulationVertex
     from spynnaker.pyNN.models.utility_models.delays import (
         DelayExtensionVertex)
     from spynnaker.pyNN.models.neural_projections import (
@@ -36,7 +36,7 @@ class DelayedApplicationEdge(ApplicationEdge):
 
     def __init__(
             self, pre_vertex: DelayExtensionVertex,
-            post_vertex: AbstractPopulationVertex,
+            post_vertex: PopulationVertex,
             synapse_information: Union[
                 SynapseInformation, Iterable[SynapseInformation]],
             undelayed_edge: ProjectionApplicationEdge,
@@ -44,7 +44,7 @@ class DelayedApplicationEdge(ApplicationEdge):
         """
         :param DelayExtensionVertex pre_vertex:
             The delay extension at the start of the edge
-        :param AbstractPopulationVertex post_vertex:
+        :param PopulationVertex post_vertex:
             The target of the synapses
         :param synapse_information:
             The synapse information on this edge
@@ -69,8 +69,8 @@ class DelayedApplicationEdge(ApplicationEdge):
 
     @property
     @overrides(ApplicationEdge.post_vertex)
-    def post_vertex(self) -> AbstractPopulationVertex:
-        return cast('AbstractPopulationVertex', super().post_vertex)
+    def post_vertex(self) -> PopulationVertex:
+        return cast('PopulationVertex', super().post_vertex)
 
     @property
     def synapse_information(self) -> List[SynapseInformation]:

--- a/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
+++ b/spynnaker/pyNN/models/neural_projections/projection_application_edge.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         SynapseDynamicsSTDP, SynapseDynamicsNeuromodulation)
     from spynnaker.pyNN.models.neural_projections import (
         SynapseInformation, DelayedApplicationEdge)
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+    from spynnaker.pyNN.models.neuron import PopulationVertex
 
 
 class _Dynamics:
@@ -127,7 +127,7 @@ def are_dynamics_neuromodulation(
 class ProjectionApplicationEdge(
         ApplicationEdge, AbstractProvidesLocalProvenanceData):
     """
-    An edge which terminates on an :py:class:`AbstractPopulationVertex`.
+    An edge which terminates on an :py:class:`PopulationVertex`.
     """
     __slots__ = (
         "__delay_edge",
@@ -136,12 +136,12 @@ class ProjectionApplicationEdge(
 
     def __init__(
             self, pre_vertex: PopulationApplicationVertex,
-            post_vertex: AbstractPopulationVertex,
+            post_vertex: PopulationVertex,
             synapse_information: SynapseInformation,
             label: Optional[str] = None):
         """
         :param PopulationApplicationVertex pre_vertex:
-        :param AbstractPopulationVertex post_vertex:
+        :param PopulationVertex post_vertex:
         :param SynapseInformation synapse_information:
             The synapse information on this edge
         :param str label:
@@ -223,5 +223,5 @@ class ProjectionApplicationEdge(
 
     @property
     @overrides(ApplicationEdge.post_vertex)
-    def post_vertex(self) -> AbstractPopulationVertex:
-        return cast('AbstractPopulationVertex', super().post_vertex)
+    def post_vertex(self) -> PopulationVertex:
+        return cast('PopulationVertex', super().post_vertex)

--- a/spynnaker/pyNN/models/neuron/__init__.py
+++ b/spynnaker/pyNN/models/neuron/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .abstract_population_vertex import AbstractPopulationVertex
 from .connection_holder import ConnectionHolder
 from .population_machine_vertex import (
     PopulationMachineVertex, SpikeProcessingProvenance)
@@ -25,17 +24,19 @@ from .population_synapses_machine_vertex_shared import (
 from .population_synapses_machine_vertex_common import (
     PopulationSynapsesMachineVertexCommon, SpikeProcessingFastProvenance)
 from .population_machine_synapses_provenance import SynapseProvenance
+from .population_vertex import PopulationVertex
 from .abstract_pynn_neuron_model import AbstractPyNNNeuronModel
 from .abstract_pynn_neuron_model_standard import (
     AbstractPyNNNeuronModelStandard)
 from .population_machine_local_only_combined_vertex import (
     PopulationMachineLocalOnlyCombinedVertex, LocalOnlyProvenance)
 
-__all__ = ["AbstractPopulationVertex", "AbstractPyNNNeuronModel",
+__all__ = ["AbstractPyNNNeuronModel",
            "AbstractPyNNNeuronModelStandard", "ConnectionHolder",
            "PopulationMachineVertex", "PopulationNeuronsMachineVertex",
            "NeuronProvenance", "PopulationSynapsesMachineVertexCommon",
            "PopulationSynapsesMachineVertexLead", "NeuronRegions",
-           "PopulationSynapsesMachineVertexShared", "SynapseProvenance",
+           "PopulationSynapsesMachineVertexShared", "PopulationVertex",
+           "SynapseProvenance",
            "SpikeProcessingProvenance", "SpikeProcessingFastProvenance",
            "PopulationMachineLocalOnlyCombinedVertex", "LocalOnlyProvenance"]

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model.py
@@ -14,7 +14,7 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from spinn_utilities.overrides import overrides
-from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+from spynnaker.pyNN.models.neuron import PopulationVertex
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
 from spynnaker.pyNN.utilities.constants import POP_TABLE_MAX_ROW_LENGTH
 if TYPE_CHECKING:
@@ -64,7 +64,7 @@ class AbstractPyNNNeuronModel(AbstractPyNNModel):
             drop_late_spikes: Optional[bool] = None,
             splitter: Optional[SplitterAbstractPopulationVertex] = None,
             seed: Optional[int] = None,
-            n_colour_bits: Optional[int] = None) -> AbstractPopulationVertex:
+            n_colour_bits: Optional[int] = None) -> PopulationVertex:
         """
         :param float spikes_per_second:
         :param float ring_buffer_sigma:
@@ -77,7 +77,7 @@ class AbstractPyNNNeuronModel(AbstractPyNNModel):
         """
         # pylint: disable=arguments-differ
         max_atoms = self.get_model_max_atoms_per_dimension_per_core()
-        return AbstractPopulationVertex(
+        return PopulationVertex(
             n_neurons=n_neurons, label=label, max_atoms_per_core=max_atoms,
             spikes_per_second=spikes_per_second,
             ring_buffer_sigma=ring_buffer_sigma,

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model.py
@@ -20,7 +20,7 @@ from spynnaker.pyNN.utilities.constants import POP_TABLE_MAX_ROW_LENGTH
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.neuron.implementations import AbstractNeuronImpl
     from spynnaker.pyNN.extra_algorithms.splitter_components import (
-        SplitterAbstractPopulationVertex)
+        SplitterPopulationVertex)
 
 # The maximum atoms per core is the master population table row length to
 # make it easier when all-to-all-connector is used
@@ -62,7 +62,7 @@ class AbstractPyNNNeuronModel(AbstractPyNNModel):
             max_expected_summed_weight: Optional[List[float]] = None,
             incoming_spike_buffer_size: Optional[int] = None,
             drop_late_spikes: Optional[bool] = None,
-            splitter: Optional[SplitterAbstractPopulationVertex] = None,
+            splitter: Optional[SplitterPopulationVertex] = None,
             seed: Optional[int] = None,
             n_colour_bits: Optional[int] = None) -> PopulationVertex:
         """
@@ -71,7 +71,7 @@ class AbstractPyNNNeuronModel(AbstractPyNNModel):
         :param int incoming_spike_buffer_size:
         :param bool drop_late_spikes:
         :param splitter:
-        :type splitter: SplitterAbstractPopulationVertex or None
+        :type splitter: SplitterPopulationVertex or None
         :param int seed:
         :param int n_colour_bits:
         """

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
         AbstractThresholdType)
     from .population_vertex import PopulationVertex
     from spynnaker.pyNN.extra_algorithms.splitter_components import (
-        SplitterAbstractPopulationVertex)
+        SplitterPopulationVertex)
 
 _population_parameters: Dict[str, Any] = dict(APNM_default_params)
 _population_parameters["n_steps_per_timestep"] = 1
@@ -77,7 +77,7 @@ class AbstractPyNNNeuronModelStandard(AbstractPyNNNeuronModel):
             max_expected_summed_weight: Optional[List[float]] = None,
             incoming_spike_buffer_size: Optional[int] = None,
             drop_late_spikes: Optional[bool] = None,
-            splitter: Optional[SplitterAbstractPopulationVertex] = None,
+            splitter: Optional[SplitterPopulationVertex] = None,
             seed: Optional[int] = None, n_colour_bits: Optional[int] = None,
             n_steps_per_timestep: int = 1) -> PopulationVertex:
         """

--- a/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
+++ b/spynnaker/pyNN/models/neuron/abstract_pynn_neuron_model_standard.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from spynnaker.pyNN.models.neuron.synapse_types import AbstractSynapseType
     from spynnaker.pyNN.models.neuron.threshold_types import (
         AbstractThresholdType)
-    from .abstract_population_vertex import AbstractPopulationVertex
+    from .population_vertex import PopulationVertex
     from spynnaker.pyNN.extra_algorithms.splitter_components import (
         SplitterAbstractPopulationVertex)
 
@@ -79,7 +79,7 @@ class AbstractPyNNNeuronModelStandard(AbstractPyNNNeuronModel):
             drop_late_spikes: Optional[bool] = None,
             splitter: Optional[SplitterAbstractPopulationVertex] = None,
             seed: Optional[int] = None, n_colour_bits: Optional[int] = None,
-            n_steps_per_timestep: int = 1) -> AbstractPopulationVertex:
+            n_steps_per_timestep: int = 1) -> PopulationVertex:
         """
         :param int n_steps_per_timestep:
         """

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_convolution.py
@@ -43,8 +43,8 @@ from spynnaker.pyNN.models.common.local_only_2d_common import (
 from .abstract_local_only import AbstractLocalOnly
 
 if TYPE_CHECKING:
-    from spynnaker.pyNN.models.neuron.abstract_population_vertex import (
-        AbstractPopulationVertex)
+    from spynnaker.pyNN.models.neuron.population_vertex import (
+        PopulationVertex)
     from spynnaker.pyNN.models.projection import Projection
     from spynnaker.pyNN.models.neuron import (
         PopulationMachineLocalOnlyCombinedVertex)
@@ -249,13 +249,13 @@ class LocalOnlyConvolution(AbstractLocalOnly, AbstractSupportsSignedWeights):
             numpy.concatenate(weight_data, dtype="int16").view("uint32"))
 
     def __get_sources_for_target(
-            self, app_vertex: AbstractPopulationVertex) -> Dict[
+            self, app_vertex: PopulationVertex) -> Dict[
                 Tuple[ColouredApplicationVertex, str], List[Source]]:
         """
         Get all the application vertex sources that will hit the given
         application vertex.
 
-        :param AbstractPopulationVertex app_vertex: The vertex being targeted
+        :param PopulationVertex app_vertex: The vertex being targeted
         :return:
             A dict of source PopulationApplicationVertex to list of source
             information

--- a/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
+++ b/spynnaker/pyNN/models/neuron/local_only/local_only_pool_dense.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from spynnaker.pyNN.models.projection import Projection
     from spynnaker.pyNN.models.neuron import (
         PopulationMachineLocalOnlyCombinedVertex)
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+    from spynnaker.pyNN.models.neuron import PopulationVertex
     from spynnaker.pyNN.models.neuron.synapse_dynamics import (
         AbstractSynapseDynamics)
 
@@ -142,7 +142,7 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
             machine_vertex: PopulationMachineLocalOnlyCombinedVertex,
             weight_scales: NDArray[floating]) -> None:
         # Get incoming sources for this vertex
-        app_vertex = cast('AbstractPopulationVertex',
+        app_vertex = cast('PopulationVertex',
                           machine_vertex.app_vertex)
         sources = self.__get_sources_for_target(app_vertex)
 
@@ -227,13 +227,13 @@ class LocalOnlyPoolDense(AbstractLocalOnly, AbstractSupportsSignedWeights):
         spec.write_array(numpy.concatenate(connector_data))
 
     def __get_sources_for_target(
-            self, app_vertex: AbstractPopulationVertex) -> Dict[
+            self, app_vertex: PopulationVertex) -> Dict[
             Tuple[ColouredApplicationVertex, str], List[Source]]:
         """
         Get all the application vertex sources that will hit the given
         application vertex.
 
-        :param AbstractPopulationVertex app_vertex: The vertex being targeted
+        :param PopulationVertex app_vertex: The vertex being targeted
         :return:
             A dict of source ApplicationVertex and partition id to list of
             source information

--- a/spynnaker/pyNN/models/neuron/neuron_data.py
+++ b/spynnaker/pyNN/models/neuron/neuron_data.py
@@ -31,8 +31,8 @@ from spinn_front_end_common.utilities.helpful_functions import (
 
 from spynnaker.pyNN.utilities.struct import Struct, StructRepeat
 from spynnaker.pyNN.data import SpynnakerDataView
-from spynnaker.pyNN.models.neuron.abstract_population_vertex import (
-    AbstractPopulationVertex)
+from spynnaker.pyNN.models.neuron.population_vertex import (
+    PopulationVertex)
 from spynnaker.pyNN.models.neuron.population_machine_neurons import (
     NeuronRegions)
 
@@ -83,7 +83,7 @@ class NeuronData(object):
         # Whether to generate things on the machine
         "__gen_on_machine")
 
-    def __init__(self, app_vertex: AbstractPopulationVertex):
+    def __init__(self, app_vertex: PopulationVertex):
         self.__app_vertex = app_vertex
         self.__neuron_data: Optional[NDArray[uint32]] = None
         self.__neuron_recording_data: Optional[NDArray[uint32]] = None

--- a/spynnaker/pyNN/models/neuron/population_machine_common.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_common.py
@@ -39,7 +39,7 @@ from spinn_front_end_common.interface.profiling import (
     AbstractHasProfileData, ProfileData)
 from spinn_front_end_common.utilities.constants import SIMULATION_N_BYTES
 if TYPE_CHECKING:
-    from .abstract_population_vertex import AbstractPopulationVertex
+    from .population_vertex import PopulationVertex
 
 
 class CommonRegions(NamedTuple):
@@ -80,13 +80,13 @@ class PopulationMachineCommon(
         "__binary_file_name")
 
     def __init__(
-            self, label: str, app_vertex: AbstractPopulationVertex,
+            self, label: str, app_vertex: PopulationVertex,
             vertex_slice: Slice, sdram: AbstractSDRAM, regions: CommonRegions,
             n_provenance_items: int, profile_tags: Mapping[int, str],
             binary_file_name: str):
         """
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements
@@ -112,8 +112,8 @@ class PopulationMachineCommon(
         return self.__sdram
 
     @property
-    def _pop_vertex(self) -> AbstractPopulationVertex:
-        return cast('AbstractPopulationVertex', self._app_vertex)
+    def _pop_vertex(self) -> PopulationVertex:
+        return cast('PopulationVertex', self._app_vertex)
 
     @property
     @overrides(ProvidesProvenanceDataFromMachineImpl._provenance_region_id)

--- a/spynnaker/pyNN/models/neuron/population_machine_local_only_combined_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_local_only_combined_vertex.py
@@ -40,7 +40,7 @@ from spynnaker.pyNN.models.neuron.neuron_data import NeuronData
 from .population_machine_common import CommonRegions, PopulationMachineCommon
 from .population_machine_neurons import (
     NeuronRegions, PopulationMachineNeurons, NeuronProvenance)
-from .abstract_population_vertex import AbstractPopulationVertex
+from .population_vertex import PopulationVertex
 
 
 class LocalOnlyProvenance(ctypes.LittleEndianStructure):
@@ -145,7 +145,7 @@ class PopulationMachineLocalOnlyCombinedVertex(
 
     def __init__(
             self, sdram: AbstractSDRAM, label: str,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             slice_index: int, ring_buffer_shifts: Sequence[int],
             weight_scales: NDArray[floating], neuron_data: NeuronData,
             max_atoms_per_core: int):
@@ -153,7 +153,7 @@ class PopulationMachineLocalOnlyCombinedVertex(
         :param ~pacman.model.resources.AbstractSDRAM sdram:
             The SDRAM used by the vertex
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements
@@ -230,12 +230,12 @@ class PopulationMachineLocalOnlyCombinedVertex(
         return cast(AbstractLocalOnly, self._pop_vertex.synapse_dynamics)
 
     @staticmethod
-    def __get_binary_file_name(app_vertex: AbstractPopulationVertex) -> str:
+    def __get_binary_file_name(app_vertex: PopulationVertex) -> str:
         """
         Get the local binary filename for this vertex.  Static because at
         the time this is needed, the local app_vertex is not set.
 
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :rtype: str
         """

--- a/spynnaker/pyNN/models/neuron/population_machine_neurons.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_neurons.py
@@ -39,7 +39,7 @@ from spynnaker.pyNN.models.abstract_models import AbstractNeuronExpandable
 from spynnaker.pyNN.models.current_sources import CurrentSourceIDs
 from spynnaker.pyNN.utilities.utility_calls import convert_to
 if TYPE_CHECKING:
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+    from spynnaker.pyNN.models.neuron import PopulationVertex
     from spynnaker.pyNN.models.neuron.neuron_data import NeuronData
     from spynnaker.pyNN.models.current_sources import AbstractCurrentSource
 
@@ -85,14 +85,14 @@ class PopulationMachineNeurons(
 
     @property
     @abstractmethod
-    def _pop_vertex(self) -> AbstractPopulationVertex:
+    def _pop_vertex(self) -> PopulationVertex:
         """
         The application vertex of the machine vertex.
 
         .. note::
             This is likely to be available via the MachineVertex.
 
-        :rtype: AbstractPopulationVertex
+        :rtype: PopulationVertex
         """
         raise NotImplementedError
 

--- a/spynnaker/pyNN/models/neuron/population_machine_synapses.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_synapses.py
@@ -38,7 +38,7 @@ from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from spynnaker.pyNN.models.abstract_models import (
     AbstractSynapseExpandable, HasSynapses)
 
-from .abstract_population_vertex import AbstractPopulationVertex
+from .population_vertex import PopulationVertex
 from .population_machine_synapses_provenance import (
     PopulationMachineSynapsesProvenance)
 from .synaptic_matrices import SynapseRegions, SynapseRegionReferences
@@ -63,14 +63,14 @@ class PopulationMachineSynapses(
 
     @property
     @abstractmethod
-    def _pop_vertex(self) -> AbstractPopulationVertex:
+    def _pop_vertex(self) -> PopulationVertex:
         """
         The application vertex of the machine vertex.
 
         .. note::
             This is likely to be available via the MachineVertex.
 
-        :rtype: AbstractPopulationVertex
+        :rtype: PopulationVertex
         """
         raise NotImplementedError
 

--- a/spynnaker/pyNN/models/neuron/population_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_machine_vertex.py
@@ -35,7 +35,7 @@ from spinn_front_end_common.interface.provenance import ProvenanceWriter
 from spynnaker.pyNN.models.neuron.neuron_data import NeuronData
 from spynnaker.pyNN.models.neuron.synaptic_matrices import SynapticMatrices
 
-from .abstract_population_vertex import AbstractPopulationVertex
+from .population_vertex import PopulationVertex
 from .population_machine_common import CommonRegions, PopulationMachineCommon
 from .population_machine_neurons import (
     NeuronRegions, PopulationMachineNeurons, NeuronProvenance)
@@ -169,7 +169,7 @@ class PopulationMachineVertex(
 
     def __init__(
             self, sdram: AbstractSDRAM, label: str,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             slice_index: int, ring_buffer_shifts: Sequence[int],
             weight_scales: NDArray[floating], structural_sz: int,
             max_atoms_per_core: int, synaptic_matrices: SynapticMatrices,
@@ -178,7 +178,7 @@ class PopulationMachineVertex(
         :param ~pacman.model.resources.AbstractSDRAM sdram:
             The SDRAM used by the vertex
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements
@@ -260,12 +260,12 @@ class PopulationMachineVertex(
         return self.__max_atoms_per_core
 
     @staticmethod
-    def __get_binary_file_name(app_vertex: AbstractPopulationVertex) -> str:
+    def __get_binary_file_name(app_vertex: PopulationVertex) -> str:
         """
         Get the local binary filename for this vertex.  Static because at
         the time this is needed, the local `app_vertex` is not set.
 
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :rtype: str
         """

--- a/spynnaker/pyNN/models/neuron/population_neurons_machine_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_neurons_machine_vertex.py
@@ -43,7 +43,7 @@ from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from .population_machine_common import CommonRegions, PopulationMachineCommon
 from .population_machine_neurons import (
     NeuronRegions, PopulationMachineNeurons, NeuronProvenance)
-from .abstract_population_vertex import AbstractPopulationVertex
+from .population_vertex import PopulationVertex
 
 # Size of SDRAM params = 1 word for address + 1 word for size
 # + 1 word for n_neurons + 1 word for n_synapse_types
@@ -121,7 +121,7 @@ class PopulationNeuronsMachineVertex(
 
     def __init__(
             self, sdram: AbstractSDRAM, label: str,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             slice_index: int, ring_buffer_shifts: Sequence[int],
             weight_scales: NDArray[floating],
             neuron_data: NeuronData, max_atoms_per_core: int):
@@ -129,7 +129,7 @@ class PopulationNeuronsMachineVertex(
         :param ~pacman.model.resources.AbstractSDRAM sdram:
             The SDRAM used by the vertex
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements
@@ -215,12 +215,12 @@ class PopulationNeuronsMachineVertex(
         self.__sdram_partition = sdram_partition
 
     @staticmethod
-    def __get_binary_file_name(app_vertex: AbstractPopulationVertex) -> str:
+    def __get_binary_file_name(app_vertex: PopulationVertex) -> str:
         """
         Get the local binary filename for this vertex.  Static because at
         the time this is needed, the local app_vertex is not set.
 
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :rtype: str
         """

--- a/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_common.py
+++ b/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_common.py
@@ -34,7 +34,7 @@ from .population_machine_common import CommonRegions, PopulationMachineCommon
 from .synaptic_matrices import SynapseRegions
 from .population_machine_synapses_provenance import SynapseProvenance
 if TYPE_CHECKING:
-    from .abstract_population_vertex import AbstractPopulationVertex
+    from .population_vertex import PopulationVertex
     from .population_neurons_machine_vertex import (
         PopulationNeuronsMachineVertex)
 
@@ -158,12 +158,12 @@ class PopulationSynapsesMachineVertexCommon(
 
     def __init__(
             self, sdram: AbstractSDRAM, label: str,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice):
+            app_vertex: PopulationVertex, vertex_slice: Slice):
         """
         :param ~pacman.model.resources.AbstractSDRAM sdram:
             The SDRAM used by the vertex
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements
@@ -207,12 +207,12 @@ class PopulationSynapsesMachineVertexCommon(
         self.__partition_id = partition_id
 
     @staticmethod
-    def __get_binary_file_name(app_vertex: AbstractPopulationVertex) -> str:
+    def __get_binary_file_name(app_vertex: PopulationVertex) -> str:
         """
         Get the local binary filename for this vertex.  Static because at
         the time this is needed, the local `app_vertex` is not set.
 
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :rtype: str
         """

--- a/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_lead.py
+++ b/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_lead.py
@@ -34,7 +34,7 @@ from .population_synapses_machine_vertex_common import (
     PopulationSynapsesMachineVertexCommon)
 
 if TYPE_CHECKING:
-    from .abstract_population_vertex import AbstractPopulationVertex
+    from .population_vertex import PopulationVertex
     from spynnaker.pyNN.models.neuron.synaptic_matrices import (
         SynapseRegions, SynapseRegionReferences, SynapticMatrices)
 
@@ -60,7 +60,7 @@ class PopulationSynapsesMachineVertexLead(
 
     def __init__(
             self, sdram: AbstractSDRAM, label: str,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             ring_buffer_shifts: Sequence[int],
             weight_scales: NDArray[floating], structural_sz: int,
             synapse_references: SynapseRegionReferences,
@@ -69,7 +69,7 @@ class PopulationSynapsesMachineVertexLead(
         :param ~pacman.model.resources.AbstractSDRAM sdram:
             The SDRAM used by the vertex
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements

--- a/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_shared.py
+++ b/spynnaker/pyNN/models/neuron/population_synapses_machine_vertex_shared.py
@@ -25,7 +25,7 @@ from .population_synapses_machine_vertex_common import (
 from .population_machine_synapses_provenance import (
     PopulationMachineSynapsesProvenance)
 if TYPE_CHECKING:
-    from .abstract_population_vertex import AbstractPopulationVertex
+    from .population_vertex import PopulationVertex
     from spynnaker.pyNN.models.neuron.synaptic_matrices import (
         SynapseRegionReferences)
 
@@ -42,13 +42,13 @@ class PopulationSynapsesMachineVertexShared(
 
     def __init__(
             self, sdram: AbstractSDRAM, label: str,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             synapse_references: SynapseRegionReferences):
         """
         :param ~pacman.model.resources.AbstractSDRAM sdram:
             The SDRAM used by the vertex
         :param str label: The label of the vertex
-        :param AbstractPopulationVertex app_vertex:
+        :param PopulationVertex app_vertex:
             The associated application vertex
         :param ~pacman.model.graphs.common.Slice vertex_slice:
             The slice of the population that this implements

--- a/spynnaker/pyNN/models/neuron/population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_vertex.py
@@ -99,7 +99,7 @@ from .synapse_io import get_max_row_info
 
 if TYPE_CHECKING:
     from spynnaker.pyNN.extra_algorithms.splitter_components import (
-        SplitterAbstractPopulationVertex)
+        SplitterPopulationVertex)
     from spynnaker.pyNN.models.current_sources import AbstractCurrentSource
     from spynnaker.pyNN.models.neural_projections import (
         SynapseInformation, ProjectionApplicationEdge)
@@ -245,7 +245,7 @@ class PopulationVertex(
             incoming_spike_buffer_size: Optional[int],
             neuron_impl: AbstractNeuronImpl,
             pynn_model: AbstractPyNNNeuronModel, drop_late_spikes: bool,
-            splitter: Optional[SplitterAbstractPopulationVertex],
+            splitter: Optional[SplitterPopulationVertex],
             seed: Optional[int], n_colour_bits: Optional[int],
             extra_partitions: Optional[List[str]] = None):
         """
@@ -270,7 +270,7 @@ class PopulationVertex(
         :param AbstractPyNNNeuronModel pynn_model:
             The PyNN neuron model that this vertex is working on behalf of.
         :param splitter: splitter object
-        :type splitter: SplitterAbstractPopulationVertex or None
+        :type splitter: SplitterPopulationVertex or None
         :param seed:
             The Population seed, used to ensure the same random generation
             on each run.
@@ -394,15 +394,15 @@ class PopulationVertex(
 
     @property  # type: ignore[override]
     @overrides(PopulationApplicationVertex.splitter)
-    def splitter(self) -> SplitterAbstractPopulationVertex:
+    def splitter(self) -> SplitterPopulationVertex:
         s = self._splitter
         if s is None:
             raise PacmanConfigurationException(
                 f"The splitter object on {self._label} has not yet been set.")
-        return cast('SplitterAbstractPopulationVertex', s)
+        return cast('SplitterPopulationVertex', s)
 
     @splitter.setter
-    def splitter(self, splitter: SplitterAbstractPopulationVertex) -> None:
+    def splitter(self, splitter: SplitterPopulationVertex) -> None:
         if self._splitter == splitter:
             return
         if self.has_splitter:
@@ -412,7 +412,7 @@ class PopulationVertex(
         # Circularity
         # pylint: disable=import-outside-toplevel
         from spynnaker.pyNN.extra_algorithms.splitter_components import (
-            SplitterAbstractPopulationVertex as ValidSplitter)
+            SplitterPopulationVertex as ValidSplitter)
         if not isinstance(splitter, ValidSplitter):
             raise PacmanConfigurationException(
                 f"The splitter object on {self._label} must be set to one "

--- a/spynnaker/pyNN/models/neuron/population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_vertex.py
@@ -182,7 +182,6 @@ class PopulationVertex(
         AbstractCanReset, SupportsStructure):
     """
     Underlying vertex model for Neural Populations.
-    Not actually abstract.
     """
 
     __slots__ = (

--- a/spynnaker/pyNN/models/neuron/population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_vertex.py
@@ -177,7 +177,7 @@ def _is_structural(dynamics: AbstractSynapseDynamics
     return isinstance(dynamics, AbstractSynapseDynamicsStructural)
 
 
-class AbstractPopulationVertex(
+class PopulationVertex(
         PopulationApplicationVertex, AbstractAcceptsIncomingSynapses,
         AbstractCanReset, SupportsStructure):
     """
@@ -417,7 +417,7 @@ class AbstractPopulationVertex(
         if not isinstance(splitter, ValidSplitter):
             raise PacmanConfigurationException(
                 f"The splitter object on {self._label} must be set to one "
-                "capable of handling an AbstractPopulationVertex.")
+                "capable of handling an PopulationVertex.")
         self._splitter = cast(Any, splitter)
         splitter.set_governed_app_vertex(self)
 
@@ -1838,7 +1838,7 @@ class _Stats(object):
         stats = self.running_totals[s_type]
         rates = self.rate_stats[s_type]
         # pylint: disable=protected-access
-        w_max = AbstractPopulationVertex._ring_buffer_expected_upper_bound(
+        w_max = PopulationVertex._ring_buffer_expected_upper_bound(
             stats.mean, stats.standard_deviation, rates.mean,
             stats.n_items, self.ring_buffer_sigma)
         w_max = min(w_max, self.total_weights[s_type])

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_synapse_dynamics_structural.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
         .elimination import AbstractElimination
     from spynnaker.pyNN.models.projection import Projection
     from spynnaker.pyNN.models.neuron.synaptic_matrices import SynapticMatrices
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+    from spynnaker.pyNN.models.neuron import PopulationVertex
     from spynnaker.pyNN.models.neural_projections import (
         ProjectionApplicationEdge, SynapseInformation)
 
@@ -74,7 +74,7 @@ class AbstractSynapseDynamicsStructural(object, metaclass=AbstractBase):
     def write_structural_parameters(
             self, spec: DataSpecificationBase, region: int,
             weight_scales: NDArray[floating],
-            app_vertex: AbstractPopulationVertex,
+            app_vertex: PopulationVertex,
             vertex_slice: Slice, synaptic_matrices: SynapticMatrices) -> None:
         """
         Write structural plasticity parameters.

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from spynnaker.pyNN.models.projection import Projection
     from spynnaker.pyNN.models.neural_projections import (
         SynapseInformation)
-    from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
+    from spynnaker.pyNN.models.neuron import PopulationVertex
     from spynnaker.pyNN.models.neuron.synaptic_matrices import SynapticMatrices
     from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
         ConnectionsArray)
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
 
     #: :meta private:
     ConnectionsInfo: TypeAlias = Dict[
-        Tuple[AbstractPopulationVertex, int],
+        Tuple[PopulationVertex, int],
         List[Tuple[ConnectionsArray, ProjectionApplicationEdge,
                    SynapseInformation]]]
 
@@ -127,7 +127,7 @@ class SynapseDynamicsStructuralCommon(
     def write_structural_parameters(
             self, spec: DataSpecificationBase, region: int,
             weight_scales: NDArray[numpy.floating],
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             synaptic_matrices: SynapticMatrices) -> None:
         spec.comment("Writing structural plasticity parameters")
         spec.switch_write_focus(region)
@@ -191,7 +191,7 @@ class SynapseDynamicsStructuralCommon(
 
     def __write_common_rewiring_data(
             self, spec: DataSpecificationBase,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice,
+            app_vertex: PopulationVertex, vertex_slice: Slice,
             n_pre_pops: int) -> None:
         """
         Write the non-sub-population synapse parameters to the spec.
@@ -260,7 +260,7 @@ class SynapseDynamicsStructuralCommon(
             list(~pacman.model.graphs.machine.MachineEdge))
         :param dict(int,float) weight_scales:
         :param SynapticMatrices synaptic_matrices:
-        :rtype: dict(tuple(AbstractPopulationVertex,SynapseInformation),int)
+        :rtype: dict(tuple(PopulationVertex,SynapseInformation),int)
         """
         spec.comment("Writing pre-population info")
         pop_index: _PopIndexType = dict()
@@ -328,14 +328,14 @@ class SynapseDynamicsStructuralCommon(
     def __write_post_to_pre_table(
             self, spec: DataSpecificationBase, pop_index: _PopIndexType,
             subpop_index: _SubpopIndexType, lo_atom_index: _SubpopIndexType,
-            app_vertex: AbstractPopulationVertex, vertex_slice: Slice) -> None:
+            app_vertex: PopulationVertex, vertex_slice: Slice) -> None:
         """
         Post to pre table is basically the transpose of the synaptic matrix.
 
         :param ~data_specification.DataSpecificationGenerator spec:
         :param pop_index:
         :type pop_index:
-            dict(tuple(AbstractPopulationVertex,SynapseInformation), int)
+            dict(tuple(PopulationVertex,SynapseInformation), int)
         :param ~pacman.model.graphs.application.ApplicationVertex app_vertex:
             the vertex for which data specs are being prepared
         :param ~pacman.model.graphs.common.Slice vertex_slice:

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -72,8 +72,8 @@ class SynapseDynamicsWeightChanger(
         # dynamics can change over time
         # Import here required to avoid circular imports
         # pylint: disable=import-outside-toplevel
-        from spynnaker.pyNN.models.neuron import AbstractPopulationVertex
-        self.__post_vertex = cast(AbstractPopulationVertex,
+        from spynnaker.pyNN.models.neuron import PopulationVertex
+        self.__post_vertex = cast(PopulationVertex,
                                   self.__synapse_info.post_vertex)
 
     @overrides(AbstractPlasticSynapseDynamics.merge)

--- a/spynnaker/pyNN/models/neuron/synaptic_matrices.py
+++ b/spynnaker/pyNN/models/neuron/synaptic_matrices.py
@@ -45,8 +45,8 @@ from spynnaker.pyNN.models.spike_source import SpikeSourcePoissonVertex
 from .synaptic_matrix_app import SynapticMatrixApp
 
 if TYPE_CHECKING:
-    from spynnaker.pyNN.models.neuron.abstract_population_vertex import (
-        AbstractPopulationVertex)
+    from spynnaker.pyNN.models.neuron.population_vertex import (
+        PopulationVertex)
     from spynnaker.pyNN.models.neural_projections import (
         ProjectionApplicationEdge, SynapseInformation)
 
@@ -174,7 +174,7 @@ class SynapticMatrices(object):
         "__max_gen_data")
 
     def __init__(
-            self, app_vertex: AbstractPopulationVertex,
+            self, app_vertex: PopulationVertex,
             regions: SynapseRegions, max_atoms_per_core: int,
             weight_scales: NDArray[floating], all_syn_block_sz: int):
         """

--- a/spynnaker/pyNN/models/projection.py
+++ b/spynnaker/pyNN/models/projection.py
@@ -42,7 +42,7 @@ from spynnaker.pyNN.models.neural_projections import (
 from spynnaker.pyNN.models.neural_projections.connectors import (
     FromListConnector)
 from spynnaker.pyNN.models.neuron import (
-    AbstractPopulationVertex, ConnectionHolder)
+    PopulationVertex, ConnectionHolder)
 from spynnaker.pyNN.models.populations import Population, PopulationView
 from spynnaker.pyNN.models.neuron.synapse_dynamics import (
     SynapseDynamicsStatic, AbstractHasParameterNames)
@@ -136,8 +136,7 @@ class Projection(object):
         connector.set_space(space)
 
         pre_vertex = pre_synaptic_population._vertex
-        post_vertex = cast(AbstractPopulationVertex,
-                           post_synaptic_population._vertex)
+        post_vertex = cast(PopulationVertex, post_synaptic_population._vertex)
 
         if not isinstance(post_vertex, AbstractAcceptsIncomingSynapses):
             raise ConfigurationException(
@@ -211,7 +210,7 @@ class Projection(object):
 
         # If the target is a population, add to the list of incoming
         # projections
-        if isinstance(post_vertex, AbstractPopulationVertex):
+        if isinstance(post_vertex, PopulationVertex):
             post_vertex.add_incoming_projection(self)
 
         # If the source is a poisson, add to the list of outgoing projections

--- a/spynnaker_integration_tests/scripts/synfire_runner.py
+++ b/spynnaker_integration_tests/scripts/synfire_runner.py
@@ -83,7 +83,7 @@ class SynfireRunner(object):
         :type constraint: AbstractConstraint
         :param cell_class: class to be used for the main population.\
             Not used by any test at the moment
-        :type cell_class: AbstractPopulationVertex
+        :type cell_class: PopulationVertex
         :param cell_params: values for the main population.\
             Not used by any test at the moment.\
             Note: the values must match what is expected by the cellclass

--- a/spynnaker_integration_tests/test_multi_call_examples/poisson_reset.py
+++ b/spynnaker_integration_tests/test_multi_call_examples/poisson_reset.py
@@ -14,7 +14,7 @@
 import pyNN.spiNNaker as sim
 from spinn_front_end_common.data.fec_data_view import FecDataView
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 
 
 def test_possion_reset():
@@ -24,7 +24,7 @@ def test_possion_reset():
     noise = sim.Population(100, sim.SpikeSourcePoisson(
         rate=10.0), label="Noise")
     pop = sim.Population(100, sim.IF_curr_exp(), additional_parameters={
-        "splitter": SplitterAbstractPopulationVertexNeuronsSynapses()})
+        "splitter": SplitterPopulationVertexNeuronsSynapses()})
     sim.Projection(noise, pop, sim.OneToOneConnector(), sim.StaticSynapse(1.0))
 
     sim.run(1000)

--- a/spynnaker_integration_tests/test_onchip_compressor/many_routes.py
+++ b/spynnaker_integration_tests/test_onchip_compressor/many_routes.py
@@ -17,7 +17,7 @@ from spynnaker.pyNN.exceptions import ConfigurationException
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN import SpynnakerDataView
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexFixed)
+    SplitterPopulationVertexFixed)
 
 
 def find_good_chip(machine, n_target):
@@ -54,7 +54,7 @@ def do_run():
         pop = sim.Population(
             n_neurons, sim.IF_curr_exp(), label="target_{}".format(t),
             additional_parameters={
-                "splitter": SplitterAbstractPopulationVertexFixed()})
+                "splitter": SplitterPopulationVertexFixed()})
         pop.add_placement_constraint(x=target_x, y=target_y)
         targets.append(pop)
 
@@ -63,7 +63,7 @@ def do_run():
         sources.append(sim.Population(
             n_neurons, sim.IF_curr_exp(), label="source_{}".format(s),
             additional_parameters={
-                "splitter": SplitterAbstractPopulationVertexFixed()}))
+                "splitter": SplitterPopulationVertexFixed()}))
 
     for s in range(n_source):
         for t in range(n_target):

--- a/spynnaker_integration_tests/test_onchip_compressor/one_route.py
+++ b/spynnaker_integration_tests/test_onchip_compressor/one_route.py
@@ -17,7 +17,7 @@ from spinn_front_end_common.interface.provenance import GlobalProvenance
 from spynnaker.pyNN.exceptions import ConfigurationException
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexFixed)
+    SplitterPopulationVertexFixed)
 
 
 def find_good_chip(machine, n_target):
@@ -55,7 +55,7 @@ def do_one_run():
         pop = sim.Population(
             n_neurons, sim.IF_curr_exp(), label="target_{}".format(t),
             additional_parameters={
-                "splitter": SplitterAbstractPopulationVertexFixed()})
+                "splitter": SplitterPopulationVertexFixed()})
         pop.add_placement_constraint(x=target_x, y=target_y)
         targets.append(pop)
 
@@ -64,7 +64,7 @@ def do_one_run():
         sources.append(sim.Population(
             n_neurons, sim.IF_curr_exp(), label="source_{}".format(s),
             additional_parameters={
-                "splitter": SplitterAbstractPopulationVertexFixed()}))
+                "splitter": SplitterPopulationVertexFixed()}))
 
     for s in range(n_source):
         for t in range(n_target):

--- a/spynnaker_integration_tests/test_spike_source/test_poisson_spike_source_sdram.py
+++ b/spynnaker_integration_tests/test_spike_source/test_poisson_spike_source_sdram.py
@@ -15,7 +15,7 @@ from spinnaker_testbase import BaseTestCase
 import pyNN.spiNNaker as sim
 import numpy
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 
 # Parameters designed to make the delta neuron count spikes in voltage
 PARAMS = {
@@ -77,7 +77,7 @@ class TestPoissonSpikeSourceSDRAM(BaseTestCase):
     def make_delta_pop(self, n_neurons, ssp, weight, delay=1.0):
         pop_1 = sim.Population(
             n_neurons, sim.IF_curr_delta(**PARAMS), label='pop_1',
-            splitter=SplitterAbstractPopulationVertexNeuronsSynapses(1))
+            splitter=SplitterPopulationVertexNeuronsSynapses(1))
         pop_1.initialize(v=0)
         pop_1.record("v")
         proj = sim.Projection(

--- a/spynnaker_integration_tests/test_split_various/test_split_delays.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_delays.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 import numpy
 from spinnaker_testbase import BaseTestCase
 
@@ -23,19 +23,19 @@ def run_delayed_split():
     source = sim.Population(10, sim.SpikeSourceArray(spike_times=[0]))
     target_1 = sim.Population(
         10, sim.IF_curr_exp(), label="target_1", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     target_1.record("spikes")
     target_2 = sim.Population(
         10, sim.IF_curr_exp(), label="target_2", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(2)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(2)})
     target_2.record("spikes")
     target_3 = sim.Population(
         10, sim.IF_curr_exp(), label="target_3", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(3)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(3)})
     target_3.record("spikes")
     target_4 = sim.Population(
         10, sim.IF_curr_exp(), label="target_4", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(3)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(3)})
     target_4.record("spikes")
 
     # Try from list, which means host generated

--- a/spynnaker_integration_tests/test_split_various/test_split_impossible.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_impossible.py
@@ -14,7 +14,7 @@
 import pyNN.spiNNaker as sim
 import pytest
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spinnaker_testbase import BaseTestCase
 
@@ -24,7 +24,7 @@ def mission_impossible():
 
     # Can't do that many neurons and delays together
     sim.Population(128, sim.IF_curr_exp(), additional_parameters={
-        "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(
+        "splitter": SplitterPopulationVertexNeuronsSynapses(
             1, 128, False)})
 
     with pytest.raises(SynapticConfigurationException):
@@ -37,7 +37,7 @@ def mission_impossible_2():
     # Can't do structural on multiple synapse cores
     source = sim.Population(1, sim.SpikeSourcePoisson(rate=10))
     pop = sim.Population(128, sim.IF_curr_exp(), additional_parameters={
-        "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(
+        "splitter": SplitterPopulationVertexNeuronsSynapses(
             2)})
 
     sim.Projection(source, pop, sim.FromListConnector([]),

--- a/spynnaker_integration_tests/test_split_various/test_split_sdram.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_sdram.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 from spinnaker_testbase import BaseTestCase
 
 
@@ -26,7 +26,7 @@ def run_sdram_split():
     post_pop = sim.Population(
         600, sim.IF_cond_exp, label="post",
         additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(
+            "splitter": SplitterPopulationVertexNeuronsSynapses(
                 1, 64, False)})
 
     pre_pop.set_max_atoms_per_core(20000)

--- a/spynnaker_integration_tests/test_split_various/test_split_simple.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_simple.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterPoissonDelegate, SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPoissonDelegate, SplitterPopulationVertexNeuronsSynapses)
 from pacman.model.partitioner_splitters import SplitterFixedLegacy
 from spinnaker_testbase import BaseTestCase
 import numpy
@@ -36,7 +36,7 @@ def run_simple_split():
     rand_source.record("spikes")
     target = sim.Population(
         50, sim.IF_curr_exp(), additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(3)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(3)})
     target.record(["spikes", "packets-per-timestep"])
     sim.Projection(
         one_to_one_source, target, sim.OneToOneConnector(),

--- a/spynnaker_integration_tests/test_split_various/test_split_stdp.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_stdp.py
@@ -19,7 +19,7 @@ from spinnaker_testbase import BaseTestCase
 
 import numpy
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 
 
 def split_potentiation_and_depression():
@@ -58,7 +58,7 @@ def split_potentiation_and_depression():
     # Post-plastic-synapse population
     post_pop = p.Population(
         1, p.IF_curr_exp(),  label="post", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
 
     # Create projections
     p.Projection(

--- a/spynnaker_integration_tests/test_split_various/test_split_struct.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_struct.py
@@ -14,7 +14,7 @@
 from spinnaker_testbase import BaseTestCase
 import pyNN.spiNNaker as p
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 
 
 def split_structural_without_stdp():
@@ -24,18 +24,18 @@ def split_structural_without_stdp():
     # These populations should experience formation
     pop = p.Population(
         1, p.IF_curr_exp(), label="pop", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     pop_2 = p.Population(
         1, p.IF_curr_exp(), label="pop_2", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
 
     # These populations should experience elimination
     pop_3 = p.Population(
         1, p.IF_curr_exp(), label="pop_3", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     pop_4 = p.Population(
         1, p.IF_curr_exp(), label="pop_4", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
 
     # Formation with last-neuron selection (0 probability elimination)
     proj = p.Projection(

--- a/spynnaker_integration_tests/test_split_various/test_split_struct_stdp.py
+++ b/spynnaker_integration_tests/test_split_various/test_split_struct_stdp.py
@@ -17,7 +17,7 @@ from spinnaker_testbase import BaseTestCase
 import pyNN.spiNNaker as p
 import numpy
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 
 
 def split_structural_with_stdp():
@@ -37,16 +37,16 @@ def split_structural_with_stdp():
     stim = p.Population(1, p.SpikeSourceArray(pre_spikes), label="stim")
     pop = p.Population(
         1, p.IF_curr_exp(), label="pop", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     pop_2 = p.Population(
         1, p.IF_curr_exp(), label="pop_2", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     pop_3 = p.Population(
         1, p.IF_curr_exp(), label="pop_3", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     pop_4 = p.Population(
         1, p.IF_curr_exp(), label="pop_4", additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            "splitter": SplitterPopulationVertexNeuronsSynapses(1)})
     pop.record("spikes")
     pop_2.record("spikes")
     proj = p.Projection(

--- a/spynnaker_integration_tests/test_stdp/test_STDP_with_self_connection.py
+++ b/spynnaker_integration_tests/test_stdp/test_STDP_with_self_connection.py
@@ -15,7 +15,7 @@
 import pyNN.spiNNaker as sim
 from spinnaker_testbase import BaseTestCase
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexNeuronsSynapses)
+    SplitterPopulationVertexNeuronsSynapses)
 
 
 def stdp_with_self_connection():
@@ -27,7 +27,7 @@ def stdp_with_self_connection():
     main_pop = sim.Population(
         64, sim.IF_curr_exp, label='main',
         additional_parameters={
-            'splitter': SplitterAbstractPopulationVertexNeuronsSynapses(1)})
+            'splitter': SplitterPopulationVertexNeuronsSynapses(1)})
 
     delay1 = sim.RandomDistribution('uniform', (2, 3))
     delayself = sim.RandomDistribution('uniform', (5, 6))

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -52,7 +52,7 @@ from spynnaker.pyNN.models.neuron.structural_plasticity.synaptogenesis\
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.neuron.builds.if_curr_exp_base import IFCurrExpBase
 from spynnaker.pyNN.extra_algorithms.splitter_components import (
-    SplitterAbstractPopulationVertexFixed)
+    SplitterPopulationVertexFixed)
 from spynnaker.pyNN.extra_algorithms import delay_support_adder
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractGenerateConnectorOnMachine)
@@ -117,11 +117,11 @@ def test_write_data_spec():
     pre_pop = p.Population(
         10, p.IF_curr_exp(), label="Pre",
         additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexFixed()})
+            "splitter": SplitterPopulationVertexFixed()})
     post_pop = p.Population(
         10, p.IF_curr_exp(), label="Post",
         additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexFixed()})
+            "splitter": SplitterPopulationVertexFixed()})
     proj_one_to_one_1 = p.Projection(
         pre_pop, post_pop, p.OneToOneConnector(),
         p.StaticSynapse(weight=1.5, delay=1.0))
@@ -452,12 +452,12 @@ def test_pop_based_master_pop_table_standard(
     post_pop = p.Population(
         256, p.IF_curr_exp(), label="Post",
         additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexFixed()})
+            "splitter": SplitterPopulationVertexFixed()})
     p.IF_curr_exp.set_model_max_atoms_per_dimension_per_core(neurons_per_core)
     pre_pop = p.Population(
         n_pre_neurons, p.IF_curr_exp(), label="Pre",
         additional_parameters={
-            "splitter": SplitterAbstractPopulationVertexFixed()})
+            "splitter": SplitterPopulationVertexFixed()})
     p.Projection(
         pre_pop, post_pop, p.FromListConnector(connections), p.StaticSynapse())
 

--- a/unittests/test_populations/test_vertex.py
+++ b/unittests/test_populations/test_vertex.py
@@ -17,7 +17,7 @@ import numpy
 import pyNN.spiNNaker as sim
 from spynnaker.pyNN.config_setup import unittest_setup
 from spynnaker.pyNN.models.neuron import (
-    AbstractPopulationVertex, AbstractPyNNNeuronModelStandard)
+    PopulationVertex, AbstractPyNNNeuronModelStandard)
 from spynnaker.pyNN.models.neuron.synapse_types import AbstractSynapseType
 from spynnaker.pyNN.models.defaults import default_initial_values
 from spynnaker.pyNN.models.neuron.implementations import (
@@ -96,7 +96,7 @@ class FooBar(AbstractPyNNNeuronModelStandard):
         return self._model
 
 
-class MockNeuron(AbstractPopulationVertex):
+class MockNeuron(PopulationVertex):
     def __init__(self):
         foo_bar = FooBar()
         super().__init__(


### PR DESCRIPTION
remove the "Abstract" from a Class which is not Abstract

Renamed 
AbstractPopulationVertex -> PopulationVertex
SplitterAbstractPopulationVertex -> SplitterPopulationVertex
SplitterAbstractPopulationVertexFixed -> SplitterPopulationVertexFixed
SplitterAbstractPopulationVertexNeuronsSynapse -> SplitterPopulationVertexNeuronsSynapse

Currently there are no deprecated stubs but these could easily be added if needed.

Must be done at the same time as:
https://github.com/SpiNNakerManchester/PyNNExamples/pull/125
https://github.com/SpiNNakerManchester/TSPonSpiNNaker/pull/59
https://github.com/SpiNNakerManchester/microcircuit_model/pull/42

Tested by:
https://github.com/SpiNNakerManchester/IntegrationTests/pull/314

this also found:
https://github.com/SpiNNakerManchester/sPyNNakerNewModelTemplate/pull/118
