### PR TITLE
a warning if calling sim.set_number_of_neurons_per_dimension_per_core

### DIFF
--- a/spynnaker/pyNN/data/spynnaker_data_view.py
+++ b/spynnaker/pyNN/data/spynnaker_data_view.py
@@ -262,7 +262,6 @@ class SpynnakerDataView(FecDataView):
                       "or consider using Population.set_max_atoms_per_core")
         neuron_type.set_model_max_atoms_per_dimension_per_core(max_permitted)
         cls.__spy_data._neurons_per_core_set.add(neuron_type)
-        cls.set_requires_mapping()
 
     @classmethod
     def get_sim_name(cls) -> str:

--- a/spynnaker/pyNN/data/spynnaker_data_view.py
+++ b/spynnaker/pyNN/data/spynnaker_data_view.py
@@ -251,6 +251,7 @@ class SpynnakerDataView(FecDataView):
 
         neuron_type.set_model_max_atoms_per_dimension_per_core(max_permitted)
         cls.__spy_data._neurons_per_core_set.add(neuron_type)
+        cls.set_requires_mapping()
 
     @classmethod
     def get_sim_name(cls) -> str:

--- a/spynnaker/pyNN/data/spynnaker_data_view.py
+++ b/spynnaker/pyNN/data/spynnaker_data_view.py
@@ -15,10 +15,15 @@ from __future__ import annotations
 import logging
 from typing import (
     Iterator, Optional, Set, Tuple, Type, Union, TYPE_CHECKING)
+
 from spinn_utilities.log import FormatAdapter
+from spinn_utilities.logger_utils import warn_once
+
 from spinn_front_end_common.data import FecDataView
+
 from spynnaker import _version
 from spynnaker.pyNN.models.abstract_pynn_model import AbstractPyNNModel
+
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.projection import Projection
     from spynnaker.pyNN.models.populations import Population
@@ -249,6 +254,12 @@ class SpynnakerDataView(FecDataView):
         if not issubclass(neuron_type, AbstractPyNNModel):
             raise TypeError(f"{neuron_type} is not an AbstractPyNNModel")
 
+        if SpynnakerDataView.get_n_populations() > 0:
+            warn_once(logger,
+                      "set_number_of_neurons_per_dimension_per_core "
+                      "only affects Populations not yet made. "
+                      "Either move the set to the beginning of the script "
+                      "or consider using Population.set_max_atoms_per_core")
         neuron_type.set_model_max_atoms_per_dimension_per_core(max_permitted)
         cls.__spy_data._neurons_per_core_set.add(neuron_type)
         cls.set_requires_mapping()

--- a/spynnaker/pyNN/models/populations/population.py
+++ b/spynnaker/pyNN/models/populations/population.py
@@ -738,8 +738,6 @@ class Population(PopulationBase):
                     f"Set the max_atoms_per_core to {max_atoms_per_core} "
                     f"blocked as the current limit for the model is {cap}")
         self.__vertex.set_max_atoms_per_dimension_per_core(max_atoms_per_core)
-        # state that something has changed in the population
-        SpynnakerDataView.set_requires_mapping()
 
     @property
     def size(self) -> int:

--- a/spynnaker_integration_tests/test_external_devices/test_live_sync.py
+++ b/spynnaker_integration_tests/test_external_devices/test_live_sync.py
@@ -28,7 +28,6 @@ n_spikes.append(0)
 def recv(label, time, neuron_ids):
     """ Receive spikes and add the number received to the current segment count
     """
-    global n_spikes
     print("Time: {}; Received spikes from {}:{}".format(
         time, label, neuron_ids))
     n_spikes[len(n_spikes) - 1] += len(neuron_ids)
@@ -64,6 +63,7 @@ def test_live_sync():
         and checking that the right spikes only arrive after synchronisation
     """
     global sim_finished
+    global n_spikes
     conn = SpynnakerLiveSpikesConnection(
         receive_labels=["ssa"], local_port=None)
     conn.add_receive_callback("ssa", recv)

--- a/spynnaker_integration_tests/test_external_devices/test_live_sync.py
+++ b/spynnaker_integration_tests/test_external_devices/test_live_sync.py
@@ -38,7 +38,6 @@ def send_sync(label, conn):
     """ Send "continue" signal after a delay and update the current segment
     """
     global sim_finished
-    global n_spikes
     while not sim_finished:
         sleep(0.1)
         if not sim_finished:
@@ -65,7 +64,6 @@ def test_live_sync():
         and checking that the right spikes only arrive after synchronisation
     """
     global sim_finished
-    global n_spikes
     conn = SpynnakerLiveSpikesConnection(
         receive_labels=["ssa"], local_port=None)
     conn.add_receive_callback("ssa", recv)


### PR DESCRIPTION
sim.set_number_of_neurons_per_dimension_per_core only affects Populations not yet made.

So add a warning if used after Populations have been made.

Also moves the requires Mapping on a set_max_atoms_per_dimension_per_core to the Pacman Level

See https://github.com/SpiNNakerManchester/PACMAN/pull/594

