### PR TITLE
Pylint

### DIFF
--- a/spynnaker/pyNN/__init__.py
+++ b/spynnaker/pyNN/__init__.py
@@ -18,7 +18,6 @@ and implementation for the PyNN High-level API
 
 This package contains the profile of that code for PyNN 0.9.
 """
-# pylint: disable=invalid-name
 
 # common imports
 import filecmp

--- a/spynnaker/pyNN/__init__.py
+++ b/spynnaker/pyNN/__init__.py
@@ -304,7 +304,7 @@ def setup(timestep: Optional[Union[float, Literal["auto"]]] = None,
         ~spinn_front_end_common.utilities.exceptions.ConfigurationException:
         if both ``n_chips_required`` and ``n_boards_required`` are used.
     """
-    # pylint: disable=global-statement,too-many-arguments
+    # pylint: disable=global-statement
     # Check for "auto" values and None
     global __simulator
     if timestep is None:
@@ -395,7 +395,6 @@ def Projection(
     :return: a projection object for SpiNNaker
     :rtype: ~spynnaker.pyNN.models.projection.Projection
     """
-    # pylint: disable=too-many-arguments
     return SpiNNakerProjection(
         pre_synaptic_population=presynaptic_population,
         post_synaptic_population=postsynaptic_population, connector=connector,
@@ -555,7 +554,6 @@ def connect(pre: Population, post: Population, weight: float = 0.0,
     :param float p: probability
     :param ~pyNN.random.NumpyRNG rng: random number generator
     """
-    # pylint: disable=too-many-arguments
     SpynnakerDataView.check_user_can_act()
     __pynn["connect"](pre, post, weight, delay, receptor_type, p, rng)
 

--- a/spynnaker/pyNN/__init__.py
+++ b/spynnaker/pyNN/__init__.py
@@ -18,6 +18,7 @@ and implementation for the PyNN High-level API
 
 This package contains the profile of that code for PyNN 0.9.
 """
+# pylint: disable=invalid-name
 
 # common imports
 import filecmp

--- a/spynnaker/pyNN/connections/spif_live_spikes_connection.py
+++ b/spynnaker/pyNN/connections/spif_live_spikes_connection.py
@@ -104,7 +104,6 @@ class SPIFLiveSpikesConnection(DatabaseConnection):
             the port that the toolchain will send the notification on (19999
             by default)
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             self.__do_start_resume, self.__do_stop_pause,
             local_host=local_host, local_port=local_port)

--- a/spynnaker/pyNN/connections/spynnaker_live_spikes_connection.py
+++ b/spynnaker/pyNN/connections/spynnaker_live_spikes_connection.py
@@ -47,7 +47,6 @@ class SpynnakerLiveSpikesConnection(LiveEventConnection):
             the port that the toolchain will send the notification on (19999
             by default)
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             live_packet_gather_label, receive_labels, send_labels,
             local_host, local_port)

--- a/spynnaker/pyNN/external_devices/__init__.py
+++ b/spynnaker/pyNN/external_devices/__init__.py
@@ -239,7 +239,7 @@ def EthernetControlPopulation(
     :rtype: ~spynnaker.pyNN.models.populations.Population
     :raises TypeError: If an invalid model class is used.
     """
-    # pylint: disable=too-many-arguments, global-statement
+    # pylint: disable=global-statement
     population = Population(n_neurons, model, label=label)
     vertex, aec, vertex_label = __vtx(population)
     translator = aec.get_message_translator()

--- a/spynnaker/pyNN/external_devices_models/arbitrary_fpga_device.py
+++ b/spynnaker/pyNN/external_devices_models/arbitrary_fpga_device.py
@@ -41,7 +41,6 @@ class ArbitraryFPGADevice(ApplicationFPGAVertex, PopulationApplicationVertex):
         :param label:
         :type label: str or None
         """
-        # pylint: disable=too-many-arguments
         conn = FPGAConnection(
             fpga_id, fpga_link_id, board_address, chip_coords)
         super().__init__(n_neurons, [conn], conn, label)

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control.py
@@ -83,8 +83,6 @@ class ExternalDeviceLifControl(AbstractPyNNNeuronModelStandard):
         :param float isyn_inh:
             (defaulted LIF neuron state variable initial value)
         """
-        # pylint: disable=too-many-arguments
-
         if not devices:
             raise ConfigurationException("No devices specified")
 

--- a/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
+++ b/spynnaker/pyNN/external_devices_models/external_device_lif_control_vertex.py
@@ -93,7 +93,6 @@ class ExternalDeviceLifControlVertex(
         :type splitter: SplitterPopulationVertex or None
         :param int n_colour_bits: The number of colour bits to use
         """
-        # pylint: disable=too-many-arguments
         if drop_late_spikes is None:
             drop_late_spikes = False
         extra_partition_ids = [

--- a/spynnaker/pyNN/external_devices_models/external_spinnaker_link_fpga_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/external_spinnaker_link_fpga_retina_device.py
@@ -104,7 +104,6 @@ class ExternalFPGARetinaDevice(
         :param str label:
         :param str board_address:
         """
-        # pylint: disable=too-many-arguments
         fixed_n_neurons = self.get_n_neurons(mode, polarity)
         super().__init__(
             n_atoms=fixed_n_neurons, spinnaker_link_id=spinnaker_link_id,

--- a/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_motor_device.py
@@ -68,7 +68,6 @@ class MunichMotorDevice(
         :param str label:
         :type label: str or None
         """
-        # pylint: disable=too-many-arguments
         m_vertex = MachineMunichMotorDevice(
             speed, sample_time, update_time, delay_time, delta_threshold,
             continue_if_not_different, label, app_vertex=self)

--- a/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/munich_spinnaker_link_retina_device.py
@@ -103,7 +103,6 @@ class MunichRetinaDevice(
         :param board_address:
         :type board_address: str or None
         """
-        # pylint: disable=too-many-arguments
         if polarity is None:
             polarity = MunichRetinaDevice.MERGED_POLARITY
 

--- a/spynnaker/pyNN/external_devices_models/push_bot/abstract_push_bot_output_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/abstract_push_bot_output_device.py
@@ -28,7 +28,7 @@ class AbstractPushBotOutputDevice(Enum):
             self, value: int, protocol_property: property, min_value: int,
             max_value: Decimal, time_between_send: int,
             send_type: SendType = SendType.SEND_TYPE_INT):
-        # pylint: disable=too-many-arguments, protected-access
+        # pylint: disable=protected-access
         self._value_ = value
         self._protocol_property = protocol_property
         self._min_value = min_value

--- a/spynnaker/pyNN/external_devices_models/push_bot/control/push_bot_lif_ethernet.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/control/push_bot_lif_ethernet.py
@@ -61,8 +61,6 @@ class PushBotLifEthernet(ExternalDeviceLifControl):
             tau_syn_I: float = 5.0, tau_refrac: float = 0.1,
             i_offset: float = 0.0, v: float = 0.0, isyn_exc: float = 0.0,
             isyn_inh: float = 0.0):
-        # pylint: disable=too-many-arguments
-
         translator = PushBotTranslator(
             protocol,
             get_pushbot_wifi_connection(pushbot_ip_address, pushbot_port))

--- a/spynnaker/pyNN/external_devices_models/push_bot/control/push_bot_lif_spinnaker_link.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/control/push_bot_lif_spinnaker_link.py
@@ -54,8 +54,6 @@ class PushBotLifSpinnakerLink(ExternalDeviceLifControl):
             tau_syn_I: float = 5.0, tau_refrac: float = 0.1,
             i_offset: float = 0.0, v: float = 0.0, isyn_exc: float = 0.0,
             isyn_inh: float = 0.0):
-        # pylint: disable=too-many-arguments
-
         command_protocol = MunichIoSpiNNakerLinkProtocol(
             protocol.mode, uart_id=protocol.uart_id)
         for device in devices:

--- a/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_laser_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_laser_device.py
@@ -53,7 +53,6 @@ class PushBotEthernetLaserDevice(
             The number of timesteps between sending commands to the device,
             or `None` to use the default
         """
-        # pylint: disable=too-many-arguments
         if not isinstance(laser, PushBotLaser):
             raise ConfigurationException(
                 "laser parameter must be a PushBotLaser value")

--- a/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_led_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_led_device.py
@@ -55,7 +55,6 @@ class PushBotEthernetLEDDevice(
             The number of timesteps between sending commands to the device,
             or `None` to use the default
         """
-        # pylint: disable=too-many-arguments
         if not isinstance(led, PushBotLED):
             raise ConfigurationException(
                 "led parameter must be a PushBotLED value")

--- a/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_retina_connection.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_retina_connection.py
@@ -77,7 +77,6 @@ class PushBotRetinaConnection(SpynnakerLiveSpikesConnection):
         :param local_port:
         :type local_port: int or None
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             send_labels=[retina_injector_label], local_host=local_host,
             local_port=local_port)

--- a/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_retina_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_retina_device.py
@@ -50,7 +50,6 @@ class PushBotEthernetRetinaDevice(
         :param local_port:
         :param str retina_injector_label:
         """
-        # pylint: disable=too-many-arguments
         super().__init__(protocol, None)
         pushbot_wifi_connection = get_pushbot_wifi_connection(
             pushbot_ip_address, pushbot_port)

--- a/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_speaker_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/ethernet/push_bot_speaker_device.py
@@ -53,7 +53,6 @@ class PushBotEthernetSpeakerDevice(
             The number of timesteps between sending commands to the device,
             or `None` to use the default
         """
-        # pylint: disable=too-many-arguments
         if not isinstance(speaker, PushBotSpeaker):
             raise ConfigurationException(
                 "speaker parameter must be a PushBotSpeaker value")

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_laser_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_laser_device.py
@@ -57,7 +57,6 @@ class PushBotSpiNNakerLinkLaserDevice(
             The "total period" value to send at the start
         :param int start_frequency: The "frequency" to send at the start
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             laser, protocol, start_active_time,
             start_total_period, start_frequency)

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_led_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_led_device.py
@@ -61,7 +61,6 @@ class PushBotSpiNNakerLinkLEDDevice(
         :param start_frequency: The "frequency" to set at the start
         :type start_frequency: int or None
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             led, protocol, start_active_time_front, start_active_time_back,
             start_total_period, start_frequency)

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_motor_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_motor_device.py
@@ -46,7 +46,6 @@ class PushBotSpiNNakerLinkMotorDevice(
             The IP address of the board that the device is connected to
         :type board_address: str or None
         """
-        # pylint: disable=too-many-arguments
         super().__init__(motor, protocol)
         ApplicationSpiNNakerLinkVertex.__init__(
             self, spinnaker_link_id=spinnaker_link_id, n_atoms=n_neurons,

--- a/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_speaker_device.py
+++ b/spynnaker/pyNN/external_devices_models/push_bot/spinnaker_link/push_bot_speaker_device.py
@@ -57,7 +57,6 @@ class PushBotSpiNNakerLinkSpeakerDevice(
         :param start_frequency: The "frequency" to set at the start
         :param start_melody: The "melody" to set at the start
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             speaker, protocol, start_active_time, start_total_period,
             start_frequency, start_melody)

--- a/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/distance_dependent_probability_connector.py
@@ -98,7 +98,6 @@ class DistanceDependentProbabilityConnector(
         #    a Space object, needed if you wish to specify distance-dependent
         #    weights or delays.
 
-        # pylint: disable=too-many-arguments
         super().__init__(safe, callback, verbose)
         self.__d_expression = d_expression
         self.__allow_self_connections = allow_self_connections

--- a/spynnaker/pyNN/models/neural_projections/connectors/from_file_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/from_file_connector.py
@@ -84,7 +84,6 @@ class FromFileConnector(FromListConnector):
             column_names = [column for column in column_names
                             if column not in ("i", "j")]
 
-        # pylint: disable=too-many-arguments
         super().__init__(
             conn_list, safe=safe, verbose=verbose,
             column_names=column_names, callback=callback)

--- a/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
+++ b/spynnaker/pyNN/models/neural_projections/connectors/small_world_connector.py
@@ -84,7 +84,7 @@ class SmallWorldConnector(AbstractConnector, AbstractGenerateConnectorOnHost):
             Whether to output extra information about the connectivity to a
             CSV file
         """
-        # pylint: disable=too-many-arguments, unused-private-member
+        # pylint: disable=unused-private-member
         super().__init__(safe, callback, verbose)
         self.__rewiring = rewiring
         self.__degree = degree

--- a/spynnaker/pyNN/models/neuron/builds/eif_cond_alpha_isfa_ista.py
+++ b/spynnaker/pyNN/models/neuron/builds/eif_cond_alpha_isfa_ista.py
@@ -41,6 +41,6 @@ class EIFConductanceAlphaPopulation(AbstractProvidesDefaults):
             e_rev_I: ModelParameter = -80.0, delta_T: ModelParameter = 2.0,
             v: ModelParameter = -70.6, w: ModelParameter = 0.0,
             gsyn_exc: ModelParameter = 0.0, gsyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments, unused-argument, invalid-name
+        # pylint: disable=unused-argument, invalid-name
         raise SpynnakerException(
             "This neuron model is currently not supported by the tool chain")

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_exp_base.py
@@ -81,7 +81,6 @@ class IFCondExpBase(AbstractPyNNNeuronModelStandard):
             i_offset: ModelParameter = 0.0, e_rev_E: ModelParameter = 0.0,
             e_rev_I: ModelParameter = -70.0, v: ModelParameter = -65.0,
             isyn_exc: ModelParameter = 0.0, isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeExponential(

--- a/spynnaker/pyNN/models/neuron/builds/if_cond_exp_stoc.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_cond_exp_stoc.py
@@ -92,7 +92,6 @@ class IFCondExpStoc(AbstractPyNNNeuronModelStandard):
             e_rev_I: ModelParameter = -70.0, du_th: ModelParameter = 0.5,
             tau_th: ModelParameter = 20.0, v: ModelParameter = -65.0,
             isyn_exc: ModelParameter = 0.0, isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeExponential(

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_alpha.py
@@ -85,7 +85,6 @@ class IFCurrAlpha(AbstractPyNNNeuronModelStandard):
             exc_exp_response: ModelParameter = 0.0,
             inh_response: ModelParameter = 0.0,
             inh_exp_response: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
 

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_delta.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_delta.py
@@ -66,7 +66,6 @@ class IFCurrDelta(AbstractPyNNNeuronModelStandard):
             v_thresh: ModelParameter = -50.0, tau_refrac: ModelParameter = 0.1,
             i_offset: ModelParameter = 0.0, v: ModelParameter = -65.0,
             isyn_exc: ModelParameter = 0.0, isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeDelta(isyn_exc, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_delta_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_delta_ca2_adaptive.py
@@ -79,7 +79,6 @@ class IFCurrDeltaCa2Adaptive(AbstractPyNNNeuronModelStandard):
             i_alpha: ModelParameter = 0.1, i_offset: ModelParameter = 0.0,
             v: ModelParameter = -65.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeDelta(isyn_exc, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_delta_fixed_prob.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_delta_fixed_prob.py
@@ -72,7 +72,6 @@ class IFCurrDeltaFixedProb(AbstractPyNNNeuronModelStandard):
             tau_refrac: ModelParameter = 0.0, i_offset: ModelParameter = 0.0,
             v: ModelParameter = 0.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0, seed: Optional[int] = None):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeDelta(isyn_exc, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_dual_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_dual_exp_base.py
@@ -82,7 +82,6 @@ class IFCurrDualExpBase(AbstractPyNNNeuronModelStandard):
             tau_refrac: ModelParameter = 0.1, i_offset: ModelParameter = 0.0,
             v: ModelParameter = -65.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0, isyn_exc2: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeDualExponential(

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_base.py
@@ -73,7 +73,6 @@ class IFCurrExpBase(AbstractPyNNNeuronModelStandard):
             tau_syn_I: ModelParameter = 5.0, tau_refrac: ModelParameter = 0.1,
             i_offset: ModelParameter = 0.0, v:  ModelParameter = -65.0,
             isyn_exc: ModelParameter = 0.0, isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeExponential(

--- a/spynnaker/pyNN/models/neuron/builds/if_curr_exp_ca2_adaptive.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_curr_exp_ca2_adaptive.py
@@ -90,7 +90,6 @@ class IFCurrExpCa2Adaptive(AbstractPyNNNeuronModelStandard):
             i_ca2: ModelParameter = 0.0, i_alpha: ModelParameter = 0.1,
             v: ModelParameter = -65.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelLeakyIntegrateAndFire(
             v, v_rest, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeExponential(

--- a/spynnaker/pyNN/models/neuron/builds/if_facets_hardware1.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_facets_hardware1.py
@@ -35,6 +35,6 @@ class IFFacetsConductancePopulation(AbstractProvidesDefaults):
             tau_syn_I: ModelParameter = 30.0, v_thresh: ModelParameter = -55.0,
             v_rest: ModelParameter = -65.0, e_rev_I: ModelParameter = -80,
             v_reset: ModelParameter = -80.0, v: ModelParameter = -65.0):
-        # pylint: disable=too-many-arguments, unused-argument, invalid-name
+        # pylint: disable=unused-argument, invalid-name
         raise SpynnakerException(
             "This neuron model is currently not supported by the tool chain")

--- a/spynnaker/pyNN/models/neuron/builds/if_trunc_delta.py
+++ b/spynnaker/pyNN/models/neuron/builds/if_trunc_delta.py
@@ -63,7 +63,6 @@ class IFTruncDelta(AbstractPyNNNeuronModelStandard):
             tau_refrac: ModelParameter = 1.0, i_offset: ModelParameter = 0.0,
             v: ModelParameter = 0.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelIFTrunc(
             v, tau_m, cm, i_offset, v_reset, tau_refrac)
         synapse_type = SynapseTypeDelta(isyn_exc, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/builds/izk_cond_dual_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/izk_cond_dual_exp_base.py
@@ -86,7 +86,6 @@ class IzkCondDualExpBase(AbstractPyNNNeuronModelStandard):
             e_rev_E: ModelParameter = 0.0, e_rev_I: ModelParameter = -70.0,
             isyn_exc: ModelParameter = 0.0, isyn_exc2: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelIzh(a, b, c, d, v, u, i_offset)
         synapse_type = SynapseTypeDualExponential(
             tau_syn_E, tau_syn_E2, tau_syn_I, isyn_exc, isyn_exc2, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/builds/izk_cond_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/izk_cond_exp_base.py
@@ -78,7 +78,6 @@ class IzkCondExpBase(AbstractPyNNNeuronModelStandard):
             tau_syn_I: ModelParameter = 5.0, e_rev_E: ModelParameter = 0.0,
             e_rev_I: ModelParameter = -70.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelIzh(a, b, c, d, v, u, i_offset)
         synapse_type = SynapseTypeExponential(
             tau_syn_E, tau_syn_I, isyn_exc, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/builds/izk_curr_exp_base.py
+++ b/spynnaker/pyNN/models/neuron/builds/izk_curr_exp_base.py
@@ -71,7 +71,6 @@ class IzkCurrExpBase(AbstractPyNNNeuronModelStandard):
             v: ModelParameter = -70.0, tau_syn_E: ModelParameter = 5.0,
             tau_syn_I: ModelParameter = 5.0, isyn_exc: ModelParameter = 0.0,
             isyn_inh: ModelParameter = 0.0):
-        # pylint: disable=too-many-arguments
         neuron_model = NeuronModelIzh(a, b, c, d, v, u, i_offset)
         synapse_type = SynapseTypeExponential(
             tau_syn_E, tau_syn_I, isyn_exc, isyn_inh)

--- a/spynnaker/pyNN/models/neuron/connection_holder.py
+++ b/spynnaker/pyNN/models/neuron/connection_holder.py
@@ -100,7 +100,6 @@ class ConnectionHolder(object):
             data requested
         :type notify: callable(ConnectionHolder, None) or None
         """
-        # pylint: disable=too-many-arguments
         self.__data_items_to_return = data_items_to_return
         self.__as_list = as_list
         self.__n_pre_atoms = n_pre_atoms

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_recurrent.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/timing_dependence/timing_dependence_recurrent.py
@@ -66,7 +66,6 @@ class TimingDependenceRecurrent(AbstractTimingDependence):
         :param float A_plus: :math:`A^+`
         :param float A_minus: :math:`A^-`
         """
-        # pylint: disable=too-many-arguments
         super().__init__(SynapseStructureWeightAccumulator())
         self.__accumulator_depression_plus_one = accumulator_depression + 1
         self.__accumulator_potentiation_minus_one = \

--- a/spynnaker/pyNN/models/neuron/population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_vertex.py
@@ -286,7 +286,6 @@ class PopulationVertex(
         :param extra_partitions:
             Extra partitions that are to be sent by the vertex
         """
-        # pylint: disable=too-many-arguments
         super().__init__(label, max_atoms_per_core, splitter)
 
         self.__n_atoms = self.round_n_atoms(n_neurons, "n_neurons")

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_plastic_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_plastic_synapse_dynamics.py
@@ -29,7 +29,6 @@ class AbstractPlasticSynapseDynamics(
     """
     Synapses which change over time.
     """
-    # pylint: disable=too-many-arguments
 
     __slots__ = ()
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_static_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_static_synapse_dynamics.py
@@ -27,7 +27,6 @@ class AbstractStaticSynapseDynamics(
     """
     Dynamics which don't change over time.
     """
-    # pylint: disable=too-many-arguments
 
     __slots__ = ()
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
@@ -219,7 +219,6 @@ class SynapseDynamicsNeuromodulation(
             max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
                 NDArray[uint32], NDArray[uint32], NDArray[uint32],
                 NDArray[uint32]]:
-        # pylint: disable=too-many-arguments
         weights = numpy.rint(
             numpy.abs(connections["weight"]) * STDP_FIXED_POINT_ONE)
         fixed_plastic = (

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -123,7 +123,6 @@ class SynapseDynamicsStatic(
             n_synapse_types: int,
             max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
                 List[NDArray], NDArray]:
-        # pylint: disable=too-many-arguments
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
         n_synapse_type_bits = get_n_bits(n_synapse_types)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -494,7 +494,6 @@ class SynapseDynamicsSTDP(
             pp_data: List[NDArray[uint32]], fp_size: NDArray[uint32],
             fp_data: List[NDArray[uint32]],
             max_atoms_per_core: int) -> ConnectionsArray:
-        # pylint: disable=too-many-arguments
         n_rows = len(fp_size)
 
         n_synapse_type_bits = get_n_bits(n_synapse_types)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -248,7 +248,6 @@ class SynapseDynamicsWeightChangable(
             " change-spike has been received, and so the weights might"
             " not be as expected")
 
-        # pylint: disable=too-many-arguments
         n_rows = len(fp_size)
 
         n_synapse_type_bits = get_n_bits(n_synapse_types)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -141,7 +141,6 @@ class SynapseDynamicsWeightChanger(
             max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
                 NDArray[uint32], NDArray[uint32], NDArray[uint32],
                 NDArray[uint32]]:
-        # pylint: disable=too-many-arguments
         weights = numpy.rint(numpy.abs(connections["weight"]))
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -255,7 +255,6 @@ def get_synapses(
     :rtype:
         tuple(~numpy.ndarray, ~numpy.ndarray)
     """
-    # pylint: disable=too-many-arguments
     # Get delays in timesteps
     max_delay = app_edge.post_vertex.splitter.max_support_delay()
 
@@ -343,7 +342,6 @@ def _get_row_data(
     :param int max_atoms_per_core: The maximum number of atoms per core
     :rtype: ~numpy.ndarray
     """
-    # pylint: disable=too-many-arguments
     fp_data: Union[NDArray[uint32], List[NDArray[uint32]]]
     pp_data: Union[NDArray[uint32], List[NDArray[uint32]]]
     if isinstance(synapse_dynamics, AbstractStaticSynapseDynamics):

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_alpha.py
@@ -89,7 +89,6 @@ class SynapseTypeAlpha(AbstractSynapseType):
             {EXC_RESPONSE: "", EXC_EXP_RESPONSE: "", TAU_SYN_E: "ms",
              INH_RESPONSE: "", INH_EXP_RESPONSE: "", TAU_SYN_I: "ms"})
 
-        # pylint: disable=too-many-arguments
         self.__exc_response = exc_response
         self.__exc_exp_response = exc_exp_response
         # pylint: disable=invalid-name

--- a/spynnaker/pyNN/models/populations/population.py
+++ b/spynnaker/pyNN/models/populations/population.py
@@ -112,8 +112,6 @@ class Population(PopulationBase):
             A nicer way of allowing additional things
         :type additional_kwargs: dict(str, ...)
         """
-        # pylint: disable=too-many-arguments
-
         # Deal with the kwargs!
         additional: _ParamDict = dict()
         if additional_parameters is not None:

--- a/spynnaker/pyNN/models/populations/population_base.py
+++ b/spynnaker/pyNN/models/populations/population_base.py
@@ -266,7 +266,6 @@ class PopulationBase(object, metaclass=AbstractBase):
         :param annotations: annotations to put on the Neo block
         :type annotations: None or dict(str, ...)
         """
-        # pylint: disable=too-many-arguments
         raise NotImplementedError
 
     @final

--- a/spynnaker/pyNN/models/projection.py
+++ b/spynnaker/pyNN/models/projection.py
@@ -102,7 +102,6 @@ class Projection(object):
         :param str label:
         :param bool download_synapses:
         """
-        # pylint: disable=too-many-arguments
         if source is not None:
             raise NotImplementedError(
                 f"sPyNNaker {__version__} does not yet support "
@@ -261,7 +260,6 @@ class Projection(object):
             "last" is supported
         :return: values selected
         """
-        # pylint: disable=too-many-arguments
         if not gather:
             logger.warning("sPyNNaker always gathers from every core.")
         if multiple_synapses != 'last':
@@ -295,7 +293,6 @@ class Projection(object):
         :param bool gather: Ignored
         :param bool with_address:
         """
-        # pylint: disable=too-many-arguments
         if not gather:
             warn_once(
                 logger, "sPyNNaker only supports gather=True. We will run "

--- a/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_array_vertex.py
@@ -116,7 +116,6 @@ class SpikeSourceArrayVertex(
             model: SpikeSourceArray,
             splitter: Optional[AbstractSplitterCommon],
             n_colour_bits: Optional[int]):
-        # pylint: disable=too-many-arguments
         self.__model_name = "SpikeSourceArray"
         self.__model = model
         self.__structure: Optional[BaseStructure] = None

--- a/spynnaker/pyNN/models/spike_source/spike_source_from_file.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_from_file.py
@@ -35,7 +35,6 @@ class SpikeSourceFromFile(SpikeSourceArray):
             min_atom: float = 0.0, max_atom: float = _inf,
             min_time: float = 0.0, max_time: float = _inf,
             split_value: str = "\t"):
-        # pylint: disable=too-many-arguments
         spike_times = utility_calls.read_spikes_from_file(
             spike_time_file, min_atom, max_atom, min_time, max_time,
             split_value)

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_machine_vertex.py
@@ -241,7 +241,6 @@ class SpikeSourcePoissonMachineVertex(
             self, sdram: AbstractSDRAM, is_recording: bool,
             label: Optional[str], app_vertex: SpikeSourcePoissonVertex,
             vertex_slice: Slice):
-        # pylint: disable=too-many-arguments
         super().__init__(
             label, app_vertex=app_vertex, vertex_slice=vertex_slice)
         self.__is_recording = is_recording

--- a/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
+++ b/spynnaker/pyNN/models/spike_source/spike_source_poisson_vertex.py
@@ -196,7 +196,6 @@ class SpikeSourcePoissonVertex(
             ~pacman.model.partitioner_splitters.AbstractSplitterCommon or None
         :param int n_colour_bits:
         """
-        # pylint: disable=too-many-arguments
         super().__init__(label, max_atoms_per_core, splitter)
 
         # atoms params

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_machine_vertex.py
@@ -338,8 +338,6 @@ class DelayExtensionMachineVertex(
         :param int incoming_key:
         :param int incoming_mask:
         """
-        # pylint: disable=too-many-arguments
-
         # Write spec with commands to construct required delay region:
         spec.comment(
             f"Writing Delay Parameters for {vertex_slice.n_atoms} Neurons:\n")

--- a/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/delays/delay_extension_vertex.py
@@ -63,7 +63,6 @@ class DelayExtensionVertex(ColouredApplicationVertex, AbstractHasDelayStages):
         :param int n_colour_bits: the number of bits for event colouring
         :param str label: the vertex label
         """
-        # pylint: disable=too-many-arguments
         super().__init__(
             label, POP_TABLE_MAX_ROW_LENGTH, splitter=None)
 

--- a/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
+++ b/spynnaker/pyNN/models/utility_models/spike_injector/spike_injector_vertex.py
@@ -56,7 +56,6 @@ class SpikeInjectorVertex(
             splitter: Optional[AbstractSplitterCommon],
             max_atoms_per_core: Optional[
                 Union[int, Tuple[int, ...]]] = sys.maxsize):
-        # pylint: disable=too-many-arguments
         super().__init__(
             n_keys=n_neurons, label=label, receive_port=port,
             virtual_key=virtual_key,

--- a/spynnaker/pyNN/spinnaker.py
+++ b/spynnaker/pyNN/spinnaker.py
@@ -94,7 +94,7 @@ class SpiNNaker(AbstractSpinnakerBase, pynn_control.BaseState):
             if `None` the cfg value is used
         :type timestep: float or None
         """
-        # pylint: disable=too-many-arguments, too-many-locals
+        # pylint: disable=too-many-locals
 
         # change min delay auto to be the min delay supported by simulator
         if min_delay == "auto":

--- a/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
+++ b/spynnaker/pyNN/spynnaker_external_device_plugin_manager.py
@@ -141,7 +141,7 @@ class SpynnakerExternalDevicePluginManager(object):
             Whether the incoming keys from the cores should be translated
             to global keys rather than core-based keys
         """
-        # pylint: disable=too-many-arguments, too-many-locals, protected-access
+        # pylint: disable=too-many-locals, protected-access
         # get default params if none set
         if port is None:
             port = get_config_int("Recording", "live_spike_port")
@@ -264,7 +264,7 @@ class SpynnakerExternalDevicePluginManager(object):
         :param bool reserve_reverse_ip_tag: True if a reverse IP tag is to be
             used, False if SDP is to be used (default)
         """
-        # pylint: disable=too-many-arguments, protected-access
+        # pylint: disable=protected-access
         vertex = poisson_population._vertex
         if not isinstance(vertex, SpikeSourcePoissonVertex):
             raise TypeError("population must contain a SpikeSourcePoisson")

--- a/spynnaker/pyNN/utilities/neo_csv.py
+++ b/spynnaker/pyNN/utilities/neo_csv.py
@@ -274,7 +274,6 @@ class NeoCsv(object):
         :param units: the units of the recorded value
         :type units: quantities.quantity.Quantity or str
         """
-        # pylint: disable=too-many-arguments
         block = segment.block
 
         first_id: int = block.annotations[self._FIRST_ID]

--- a/spynnaker/pyNN/utilities/utility_calls.py
+++ b/spynnaker/pyNN/utilities/utility_calls.py
@@ -206,8 +206,6 @@ def read_spikes_from_file(
         spike times.
     :rtype: numpy.ndarray(int, int)
     """
-    # pylint: disable=too-many-arguments
-
     # For backward compatibility as previous version tested for None rather
     # than having default values
     if min_atom is None:

--- a/spynnaker/spynnaker_plotting.py
+++ b/spynnaker/spynnaker_plotting.py
@@ -103,7 +103,6 @@ def plot_spiketrains(
     :param str label: Label for the graph
     :param options: plotting options
     """
-    # pylint: disable=c-extension-no-member
     axes.set_xlim(0, spiketrains[0].t_stop / quantities.ms)
     _handle_options(axes, options)
     neurons = np.concatenate(

--- a/spynnaker_integration_tests/scripts/synfire_runner.py
+++ b/spynnaker_integration_tests/scripts/synfire_runner.py
@@ -32,7 +32,7 @@ CELL_PARAMS_LIF = {'cm': 0.25, 'i_offset': 0.0, 'tau_m': 20.0,
 
 
 class SynfireRunner(object):
-    # pylint: disable=too-many-arguments, attribute-defined-outside-init
+    # pylint: disable=attribute-defined-outside-init
 
     def __init__(self) -> None:
         self.__init_object_state()


### PR DESCRIPTION
similar to https://github.com/SpiNNakerManchester/SpiNNUtils/pull/302

Still used disables

Many classes
- invalid-name
  - Param names defined by PyNN
  -  Module name "pyNN" doesn't conform to snake_case naming style

pyNN/__init__.py
- import-self
  - used when copied into pyNN.spiNNaker
- global-statement
  - The simulator.  
- broad-except
  -  logger.exception("Error forcing previous simulation to clear")
- protected-access
  - external_devices._set_simulator(__simulator)

