### PR TITLE
run WholeBoardTest

### DIFF
--- a/test_whole_board/test_whole_board.py
+++ b/test_whole_board/test_whole_board.py
@@ -208,6 +208,8 @@ def test_run(x, y, b):
         f.write("[Machine]\n")
         f.write(f"spalloc_server = {SPALLOC_URL}\n")
         f.write(f"spalloc_triad = {x},{y},{b}\n")
+        f.write("machine_name = None\n")
+        f.write("virtual_board = False\n")
         f.write("version = 5\n")
     test = WholeBoardTest()
     try:


### PR DESCRIPTION
disable other cfg settings

remove the reports error file if test skipped,
-prevents later checks from finding them and thinking there was an error
