### PR TITLE
clear connections if set called again

### DIFF
--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_static.py
@@ -212,6 +212,7 @@ class SynapseDynamicsStructuralStatic(SynapseDynamicsStatic, _Common):
         if not isinstance(synapse_info.synapse_dynamics,
                           AbstractSynapseDynamicsStructural):
             return
+        self.__connections = dict()
         collector = self.__connections.setdefault(
             (app_edge.post_vertex, post_vertex_slice.lo_atom), [])
         collector.append((connections, app_edge, synapse_info))

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_stdp.py
@@ -223,6 +223,7 @@ class SynapseDynamicsStructuralSTDP(
         if not isinstance(synapse_info.synapse_dynamics,
                           AbstractSynapseDynamicsStructural):
             return
+        self.__connections = dict()
         collector = self.__connections.setdefault(
             (app_edge.post_vertex, post_vertex_slice.lo_atom), [])
         collector.append((connections, app_edge, synapse_info))


### PR DESCRIPTION
fixes: https://github.com/SpiNNakerManchester/sPyNNaker/issues/1279

It may be slightly faster to just detect connections already set.
But this is safer in case they are changed in any way.


