### PR TITLE
remove broken links

### DIFF
--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_additive.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_additive.py
@@ -104,10 +104,6 @@ class WeightDependenceAdditive(
                 data=self.__w_max * global_weight_scale,
                 data_type=DataType.S1615)
 
-            # pylint: disable=wrong-spelling-in-comment
-            # Based on http://data.andrewdavison.info/docs/PyNN/_modules/pyNN
-            #                /standardmodels/synapses.html
-            # Pre-multiply A+ and A- by Wmax
             spec.write_value(
                 data=self.A_plus * global_weight_scale,
                 data_type=DataType.S1615)

--- a/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_additive_triplet.py
+++ b/spynnaker/pyNN/models/neuron/plasticity/stdp/weight_dependence/weight_dependence_additive_triplet.py
@@ -127,10 +127,6 @@ class WeightDependenceAdditiveTriplet(
             spec.write_value(data=self.__w_max * global_weight_scale,
                              data_type=DataType.S1615)
 
-            # pylint: disable=wrong-spelling-in-comment
-            # Based on http://data.andrewdavison.info/docs/PyNN/_modules/pyNN
-            #                /standardmodels/synapses.html
-            # Pre-multiply A+ and A- by Wmax
             spec.write_value(
                 data=self.A_plus * self.__w_max * global_weight_scale,
                 data_type=DataType.S1615)


### PR DESCRIPTION
fixes: https://github.com/SpiNNakerManchester/sPyNNaker/issues/1298

Doc now at
https://neuralensemble.org/docs/PyNN/reference/plasticitymodels.html

But that does not appear to say why global_weight_scale is applied.

So just removing the comments.