### PR TITLE
check_executable_path without logging use

### DIFF
--- a/spynnaker/pyNN/models/neuron/population_vertex.py
+++ b/spynnaker/pyNN/models/neuron/population_vertex.py
@@ -513,12 +513,8 @@ class PopulationVertex(
         # so easier to assume they exist
         if get_config_bool("Machine", "virtual_board"):
             return True
-        try:
-            SpynnakerDataView().get_executable_path(
-                self.combined_binary_file_name)
-            return True
-        except KeyError:
-            return False
+        return SpynnakerDataView().check_executable_path(
+            self.combined_binary_file_name)
 
     @property
     def split_binaries_exist(self) -> bool:
@@ -529,14 +525,11 @@ class PopulationVertex(
         # so easier to assume they exist
         if get_config_bool("Machine", "virtual_board"):
             return True
-        try:
-            SpynnakerDataView().get_executable_path(
-                self.neuron_core_binary_file_name)
-            SpynnakerDataView().get_executable_path(
-                self.synapse_core_binary_file_name)
-            return True
-        except KeyError:
+        if not SpynnakerDataView().check_executable_path(
+                self.neuron_core_binary_file_name):
             return False
+        return SpynnakerDataView().check_executable_path(
+            self.synapse_core_binary_file_name)
 
     @property
     def use_combined_core(self) -> bool:


### PR DESCRIPTION
part of https://github.com/SpiNNakerManchester/SpiNNUtils/pull/345

Avoid any false positives on binaries used just because they where tested