### PR TITLE
Parameterized

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [[tool.mypy.overrides]]
-module = ["csa", "docstring_parser", "matplotlib", "matplotlib.*", "pyNN.*", "quantities", "neo", "neo.*", "scipy", "scipy.*", "lazyarray", "testfixtures"]
+module = ["csa", "docstring_parser", "matplotlib", "matplotlib.*", "parameterized", "pyNN.*", "quantities", "neo", "neo.*", "scipy", "scipy.*", "lazyarray", "testfixtures"]
 ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,6 +71,7 @@ spynnaker.pyNN.model_binaries =
 [options.extras_require]
 test =
         SpiNNakerTestBase == 1!7.4.2
+        parameterized
         # pytest will be brought in by pytest-cov
         pytest-cov
         testfixtures

--- a/spynnaker/pyNN/data/spynnaker_data_writer.py
+++ b/spynnaker/pyNN/data/spynnaker_data_writer.py
@@ -42,6 +42,7 @@ class SpynnakerDataWriter(FecDataWriter, SpynnakerDataView):
 
     @overrides(FecDataWriter._mock)
     def _mock(self) -> None:
+        self.__spy_data._clear()
         FecDataWriter._mock(self)
         self.set_min_delay(1)
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_structural_common.py
@@ -429,9 +429,9 @@ class SynapseDynamicsStructuralCommon(
             # pylint: disable=unidiomatic-typecheck
             (type(self.partner_selection) ==  # noqa: E721
              type(synapse_dynamics.partner_selection)) and
-            (type(self.formation) ==
+            (type(self.formation) is
              type(synapse_dynamics.formation)) and
-            (type(self.elimination) ==
+            (type(self.elimination) is
              type(synapse_dynamics.elimination)))
 
     @property

--- a/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_delta.py
+++ b/spynnaker/pyNN/models/neuron/synapse_types/synapse_type_delta.py
@@ -44,7 +44,7 @@ class SynapseTypeDelta(AbstractSynapseType):
             [Struct([
                 (DataType.S1615, ISYN_EXC),  # isyn_exc
                 (DataType.S1615, ISYN_INH)])],  # isyn_inh
-            {ISYN_EXC: "", ISYN_EXC: ""})
+            {ISYN_EXC: "", ISYN_INH: ""})
         self.__isyn_exc = isyn_exc
         self.__isyn_inh = isyn_inh
 

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -411,7 +411,7 @@ def test_set_synapse_dynamics() -> None:
 
 @pytest.mark.parametrize(
     "undelayed_indices_connected,delayed_indices_connected,n_pre_neurons,"
-    "neurons_per_core,max_delay,version_number",[
+    "neurons_per_core,max_delay,version_number", [
         # Only undelayed, all edges exist
         (range(10), [], 1000, 100, None, FIVE),
         # Only delayed, all edges exist

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -23,7 +23,7 @@ import pytest
 
 from spinn_utilities.overrides import overrides
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import ALL_BOARD_TYPES, FIVE, SPIN2_48CHIP
+from spinn_machine.version import MANY_BOARD_TYPES, FIVE, SPIN2_48CHIP
 from spinnman.transceiver.mockable_transceiver import MockableTransceiver
 from spinnman.transceiver import Transceiver
 from pacman.model.placements import Placement
@@ -105,7 +105,7 @@ def say_false(*args: Any, **kwargs: Any) -> bool:
     return False
 
 
-@parameterized.expand(ALL_BOARD_TYPES)
+@parameterized.expand(MANY_BOARD_TYPES)
 def test_write_data_spec(_: str, ver_num: str) -> None:
     unittest_setup()
     set_config("Machine", "version", ver_num)

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -23,7 +23,7 @@ import pytest
 
 from spinn_utilities.overrides import overrides
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version.version_strings import VersionStrings
+from spinn_machine.version import ALL_BOARD_TYPES, FIVE, SPIN2_48CHIP
 from spinnman.transceiver.mockable_transceiver import MockableTransceiver
 from spinnman.transceiver import Transceiver
 from pacman.model.placements import Placement
@@ -105,9 +105,10 @@ def say_false(*args: Any, **kwargs: Any) -> bool:
     return False
 
 
-def test_write_data_spec() -> None:
+@parameterized.expand(ALL_BOARD_TYPES)
+def test_write_data_spec(_: str, ver_num: str) -> None:
     unittest_setup()
-    set_config("Machine", "versions", VersionStrings.ANY.text)
+    set_config("Machine", "version", ver_num)
     writer = SpynnakerDataWriter.mock()
     # UGLY but the mock transceiver NEED generate_on_machine to be False
     AbstractGenerateConnectorOnMachine.\
@@ -410,33 +411,51 @@ def test_set_synapse_dynamics() -> None:
 
 @pytest.mark.parametrize(
     "undelayed_indices_connected,delayed_indices_connected,n_pre_neurons,"
-    "neurons_per_core,max_delay", [
+    "neurons_per_core,max_delay,version_number",[
         # Only undelayed, all edges exist
-        (range(10), [], 1000, 100, None),
+        (range(10), [], 1000, 100, None, FIVE),
         # Only delayed, all edges exist
-        ([], range(10), 1000, 100, 200),
+        ([], range(10), 1000, 100, 200, FIVE),
         # All undelayed and delayed edges exist
-        (range(10), range(10), 1000, 100, 200),
+        (range(10), range(10), 1000, 100, 200, FIVE),
         # Only undelayed, some connections missing but app keys can still work
-        ([0, 1, 2, 3, 4], [], 1000, 100, None),
+        ([0, 1, 2, 3, 4], [], 1000, 100, None, FIVE),
         # Only delayed, some connections missing but app keys can still work
-        ([], [5, 6, 7, 8, 9], 1000, 100, 200),
+        ([], [5, 6, 7, 8, 9], 1000, 100, 200, FIVE),
         # Both delayed and undelayed, some undelayed edges don't exist
         # (app keys work because undelayed aren't filtered)
-        ([3, 4, 5, 6, 7], range(10), 1000, 100, 200),
+        ([3, 4, 5, 6, 7], range(10), 1000, 100, 200, FIVE),
         # Both delayed and undelayed, some delayed edges don't exist
         # (app keys work because all undelayed exist)
-        (range(10), [4, 5, 6, 7], 1000, 100, 200),
+        (range(10), [4, 5, 6, 7], 1000, 100, 200, FIVE),
         # Should work but number of cores doesn't work out
-        (range(100), [], 10000, 5, None)
+        (range(100), [], 10000, 5, None, FIVE),
+        # Only undelayed, all edges exist
+        (range(10), [], 1000, 100, None, SPIN2_48CHIP),
+        # Only delayed, all edges exist
+        ([], range(10), 1000, 100, 200, SPIN2_48CHIP),
+        # All undelayed and delayed edges exist
+        (range(10), range(10), 1000, 100, 200, SPIN2_48CHIP),
+        # Only undelayed, some connections missing but app keys can still work
+        ([0, 1, 2, 3, 4], [], 1000, 100, None, SPIN2_48CHIP),
+        # Only delayed, some connections missing but app keys can still work
+        ([], [5, 6, 7, 8, 9], 1000, 100, 200, SPIN2_48CHIP),
+        # Both delayed and undelayed, some undelayed edges don't exist
+        # (app keys work because undelayed aren't filtered)
+        ([3, 4, 5, 6, 7], range(10), 1000, 100, 200, SPIN2_48CHIP),
+        # Both delayed and undelayed, some delayed edges don't exist
+        # (app keys work because all undelayed exist)
+        (range(10), [4, 5, 6, 7], 1000, 100, 200, SPIN2_48CHIP),
+        # Should work but number of cores doesn't work out
+        (range(100), [], 10000, 5, None, SPIN2_48CHIP)
     ])
 def test_pop_based_master_pop_table_standard(
         undelayed_indices_connected: Sequence[int],
         delayed_indices_connected: Sequence[int],
         n_pre_neurons: int, neurons_per_core: int,
-        max_delay: Optional[int]) -> None:
+        max_delay: Optional[int], version_number: int) -> None:
     unittest_setup()
-    set_config("Machine", "versions", VersionStrings.FOUR_PLUS.text)
+    set_config("Machine", "version", str(version_number))
     writer = SpynnakerDataWriter.mock()
 
     # Build a from list connector with the delays we want

--- a/unittests/model_tests/neuron/test_synaptic_manager.py
+++ b/unittests/model_tests/neuron/test_synaptic_manager.py
@@ -15,6 +15,8 @@ import shutil
 import struct
 from typing import Any, BinaryIO, List, Optional, Sequence, Tuple
 import unittest
+
+from parameterized import parameterized
 from tempfile import mkdtemp
 import numpy
 import pytest

--- a/unittests/test_integration_using_virtual_board/spynnaker.cfg
+++ b/unittests/test_integration_using_virtual_board/spynnaker.cfg
@@ -1,7 +1,5 @@
 [Machine]
 machine_spec_file = None
-version = None
-versions = Any
 virtual_board = True
 machine_name = None
 spalloc_server  = None

--- a/unittests/test_integration_using_virtual_board/test_SA_neuron_class_no_edge.py
+++ b/unittests/test_integration_using_virtual_board/test_SA_neuron_class_no_edge.py
@@ -17,7 +17,7 @@ import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -26,7 +26,7 @@ class SSANeuronClassNoEdgeTest(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         sim.setup()
         set_config("Machine", "version", ver_num)

--- a/unittests/test_integration_using_virtual_board/test_SA_neuron_class_no_edge.py
+++ b/unittests/test_integration_using_virtual_board/test_SA_neuron_class_no_edge.py
@@ -27,7 +27,7 @@ class SSANeuronClassNoEdgeTest(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_run(self, _:str, ver_num:str) -> None:
+    def test_run(self, _: str, ver_num: str) -> None:
         sim.setup()
         set_config("Machine", "version", ver_num)
 

--- a/unittests/test_integration_using_virtual_board/test_SA_neuron_class_no_edge.py
+++ b/unittests/test_integration_using_virtual_board/test_SA_neuron_class_no_edge.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
@@ -20,8 +26,10 @@ class SSANeuronClassNoEdgeTest(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _:str, ver_num:str) -> None:
         sim.setup()
+        set_config("Machine", "version", ver_num)
 
         sim.Population(3, sim.SpikeSourceArray,
                        {"spike_times": [1.0, 2.0, 3.0]})

--- a/unittests/test_integration_using_virtual_board/test_SSP_neuron_class_no_edge.py
+++ b/unittests/test_integration_using_virtual_board/test_SSP_neuron_class_no_edge.py
@@ -17,7 +17,7 @@ import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -26,7 +26,7 @@ class SSPNeuronClassNoEdgeTest(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         sim.setup()
         set_config("Machine", "version", ver_num)

--- a/unittests/test_integration_using_virtual_board/test_SSP_neuron_class_no_edge.py
+++ b/unittests/test_integration_using_virtual_board/test_SSP_neuron_class_no_edge.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
@@ -20,8 +26,10 @@ class SSPNeuronClassNoEdgeTest(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _: str, ver_num: str) -> None:
         sim.setup()
+        set_config("Machine", "version", ver_num)
 
         sim.Population(3, sim.SpikeSourcePoisson, {"rate": 100})
         p2 = sim.Population(3, sim.SpikeSourceArray,
@@ -34,11 +42,3 @@ class SSPNeuronClassNoEdgeTest(BaseTestCase):
         sim.run(100.0)
 
         sim.end()
-
-
-if __name__ == "__main__":
-    """
-    main entrance method
-    """
-    blah = SSPNeuronClassNoEdgeTest()
-    blah.test_run()

--- a/unittests/test_integration_using_virtual_board/test_create_poissons.py
+++ b/unittests/test_integration_using_virtual_board/test_create_poissons.py
@@ -17,7 +17,7 @@ import pyNN.spiNNaker as p
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -117,6 +117,6 @@ class TestCreatePoissons(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         do_run(ver_num)

--- a/unittests/test_integration_using_virtual_board/test_create_poissons.py
+++ b/unittests/test_integration_using_virtual_board/test_create_poissons.py
@@ -11,12 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from parameterized import parameterized
 import pyNN.spiNNaker as p
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
-def do_run() -> None:
+def do_run(ver_num: str) -> None:
     p.setup(1.0)
+    set_config("Machine", "version", ver_num)
     n_neurons = 2
 
     pop_a = p.Population(n_neurons, p.extra_models.SpikeSourcePoissonVariable(
@@ -109,9 +117,6 @@ class TestCreatePoissons(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
-        do_run()
-
-
-if __name__ == '__main__':
-    do_run()
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _: str, ver_num: str) -> None:
+        do_run(ver_num)

--- a/unittests/test_integration_using_virtual_board/test_if_curr_alpha.py
+++ b/unittests/test_integration_using_virtual_board/test_if_curr_alpha.py
@@ -17,7 +17,7 @@ import pyNN.spiNNaker as p
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -53,6 +53,6 @@ class TestAlpha(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         do_run(ver_num)

--- a/unittests/test_integration_using_virtual_board/test_if_curr_alpha.py
+++ b/unittests/test_integration_using_virtual_board/test_if_curr_alpha.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as p
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
-def do_run() -> None:
+def do_run(ver_num: str) -> None:
     p.setup(0.1)
+    set_config("Machine", "version", ver_num)
     runtime = 50
     populations = []
 
@@ -46,9 +53,6 @@ class TestAlpha(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
-        do_run()
-
-
-if __name__ == '__main__':
-    do_run()
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _: str, ver_num: str) -> None:
+        do_run(ver_num)

--- a/unittests/test_integration_using_virtual_board/test_one_pop_lif_example.py
+++ b/unittests/test_integration_using_virtual_board/test_one_pop_lif_example.py
@@ -14,13 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+from parameterized import parameterized
 import pyNN.spiNNaker as p
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
-def do_run(nNeurons: int) -> None:
+def do_run(nNeurons: int, ver_num: str) -> None:
 
     p.setup(timestep=1.0, min_delay=1.0)
+    set_config("Machine", "version", ver_num)
 
     cell_params_lif_in = {'tau_m': 333.33, 'cm': 208.33, 'v': 0.0,
                           'v_rest': 0.1, 'v_reset': 0.0, 'v_thresh': 1.0,
@@ -46,11 +54,7 @@ class OnePopLifExample(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _: str, ver_num: str) -> None:
         nNeurons = 255  # number of neurons in each population
-        do_run(nNeurons)
-
-
-if __name__ == '__main__':
-    nNeurons = 255  # number of neurons in each population
-    do_run(nNeurons)
+        do_run(nNeurons, ver_num)

--- a/unittests/test_integration_using_virtual_board/test_one_pop_lif_example.py
+++ b/unittests/test_integration_using_virtual_board/test_one_pop_lif_example.py
@@ -20,7 +20,7 @@ import pyNN.spiNNaker as p
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -54,7 +54,7 @@ class OnePopLifExample(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         nNeurons = 255  # number of neurons in each population
         do_run(nNeurons, ver_num)

--- a/unittests/test_integration_using_virtual_board/test_params_set_as_list.py
+++ b/unittests/test_integration_using_virtual_board/test_params_set_as_list.py
@@ -18,7 +18,7 @@ import pyNN.spiNNaker as p
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -104,6 +104,6 @@ class ParamsSetAsList(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         do_run(255, ver_num)

--- a/unittests/test_integration_using_virtual_board/test_params_set_as_list.py
+++ b/unittests/test_integration_using_virtual_board/test_params_set_as_list.py
@@ -12,14 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 from pyNN.random import RandomDistribution
 import pyNN.spiNNaker as p
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
-def do_run(nNeurons: int) -> None:
+def do_run(nNeurons: int, ver_num: str) -> None:
 
     p.setup(timestep=1.0, min_delay=1.0)
+    set_config("Machine", "version", ver_num)
 
     p.set_number_of_neurons_per_core(p.IF_curr_exp, 100)
 
@@ -97,9 +104,6 @@ class ParamsSetAsList(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
-        do_run(225)  # number of neurons in each population
-
-
-if __name__ == '__main__':
-    do_run(225)  # number of neurons in each population
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _: str, ver_num: str) -> None:
+        do_run(255, ver_num)

--- a/unittests/test_integration_using_virtual_board/test_synfire_Izhikevich.py
+++ b/unittests/test_integration_using_virtual_board/test_synfire_Izhikevich.py
@@ -17,12 +17,20 @@
 """
 Synfirechain-like example
 """
+from parameterized import parameterized
 import pyNN.spiNNaker as p
+
+from spinn_utilities.config_holder import set_config
+
+from spinn_machine.version import BIG_BOARD_TYPES
+
 from spinnaker_testbase import BaseTestCase
 
 
-def do_run(nNeurons: int) -> None:
+def do_run(nNeurons: int, ver_num: str) -> None:
     p.setup(timestep=1.0, min_delay=1.0)
+    set_config("Machine", "version", ver_num)
+
     p.set_number_of_neurons_per_core(p.Izhikevich, 100)
 
     cell_params_izk = {
@@ -77,11 +85,7 @@ class SynfireIzhikevich(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_run(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_run(self, _: str, ver_num: str) -> None:
         nNeurons = 200  # number of neurons in each population
-        do_run(nNeurons)
-
-
-if __name__ == '__main__':
-    x = SynfireIzhikevich()
-    x.test_run()
+        do_run(nNeurons, ver_num)

--- a/unittests/test_integration_using_virtual_board/test_synfire_Izhikevich.py
+++ b/unittests/test_integration_using_virtual_board/test_synfire_Izhikevich.py
@@ -22,7 +22,7 @@ import pyNN.spiNNaker as p
 
 from spinn_utilities.config_holder import set_config
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -85,7 +85,7 @@ class SynfireIzhikevich(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_run(self, _: str, ver_num: str) -> None:
         nNeurons = 200  # number of neurons in each population
         do_run(nNeurons, ver_num)

--- a/unittests/test_sata_connectors/spynnaker.cfg
+++ b/unittests/test_sata_connectors/spynnaker.cfg
@@ -2,9 +2,6 @@
 machine_spec_file = None
 
 machine_name = None
-version = None
-versions = With FPGAs
-
 remote_spinnaker_url = None
 
 spalloc_server = None

--- a/unittests/test_sata_connectors/test_sata_2_different_boards_no_board_address.py
+++ b/unittests/test_sata_connectors/test_sata_2_different_boards_no_board_address.py
@@ -16,13 +16,18 @@
 retina example that just feeds data from a retina to live output via an
 intermediate population
 """
+from parameterized import parameterized
 import pyNN.spiNNaker as p
-from spinnaker_testbase import BaseTestCase
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import FPGA_BOARD_TYPES
 
 
-def do_run() -> None:
+@parameterized.expand(FPGA_BOARD_TYPES)
+def test_sata_2_different_boards_no_board_address(
+        _: str, ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0)
+    set_config("Machine", "version", ver_num)
 
     src_1 = p.Population(
         None,
@@ -39,15 +44,3 @@ def do_run() -> None:
 
     p.run(1000)
     p.end()
-
-
-class Sata2DifferentBoardsNoBoardAddressTest(BaseTestCase):
-
-    # NO unittest_setup() as sim.setup is called
-
-    def test_sata_2_different_boards_no_board_address(self) -> None:
-        do_run()
-
-
-if __name__ == '__main__':
-    do_run()

--- a/unittests/test_sata_connectors/test_sata_2_different_boards_no_board_address.py
+++ b/unittests/test_sata_connectors/test_sata_2_different_boards_no_board_address.py
@@ -20,11 +20,10 @@ from parameterized import parameterized
 import pyNN.spiNNaker as p
 from spinn_utilities.config_holder import set_config
 from spinn_machine.version import FPGA_BOARD_TYPES
+from spinnaker_testbase import BaseTestCase
 
 
-@parameterized.expand(FPGA_BOARD_TYPES)
-def test_sata_2_different_boards_no_board_address(
-        _: str, ver_num: str) -> None:
+def do_run(ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0)
     set_config("Machine", "version", ver_num)
@@ -44,3 +43,16 @@ def test_sata_2_different_boards_no_board_address(
 
     p.run(1000)
     p.end()
+
+
+class Sata2DifferentBoardsNoBoardAddressTest(BaseTestCase):
+
+    # NO unittest_setup() as sim.setup is called
+    # BaseTestCase to change dir and pickup cfg
+
+    @parameterized.expand(FPGA_BOARD_TYPES)
+    def test_sata_2_different_boards_no_board_address(
+            self, _: str, ver_num: str) -> None:
+        do_run(ver_num)
+
+

--- a/unittests/test_sata_connectors/test_sata_2_different_boards_no_board_address.py
+++ b/unittests/test_sata_connectors/test_sata_2_different_boards_no_board_address.py
@@ -54,5 +54,3 @@ class Sata2DifferentBoardsNoBoardAddressTest(BaseTestCase):
     def test_sata_2_different_boards_no_board_address(
             self, _: str, ver_num: str) -> None:
         do_run(ver_num)
-
-

--- a/unittests/test_sata_connectors/test_sata_2_different_boards_valid_board_address.py
+++ b/unittests/test_sata_connectors/test_sata_2_different_boards_valid_board_address.py
@@ -20,11 +20,10 @@ from parameterized import parameterized
 import pyNN.spiNNaker as p
 from spinn_utilities.config_holder import set_config
 from spinn_machine.version import FPGA_BOARD_TYPES
+from spinnaker_testbase import BaseTestCase
 
 
-@parameterized.expand(FPGA_BOARD_TYPES)
-def test_sata_2_different_boards_valid_board_address(
-        _: str, ver_num: str) -> None:
+def do_run(ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0, n_boards_required=3)
     set_config("Machine", "version", ver_num)
@@ -51,3 +50,14 @@ def test_sata_2_different_boards_valid_board_address(
 
     p.run(1000)
     p.end()
+
+
+class Sata2DifferentBoardsValidBoardAddress(BaseTestCase):
+
+    # NO unittest_setup() as sim.setup is called
+    # BaseTestCase to change dir and pickup cfg
+
+    @parameterized.expand(FPGA_BOARD_TYPES)
+    def test_sata_2_different_boards_valid_board_address(
+            self, _: str, ver_num: str) -> None:
+        do_run(ver_num)

--- a/unittests/test_sata_connectors/test_sata_2_different_boards_valid_board_address.py
+++ b/unittests/test_sata_connectors/test_sata_2_different_boards_valid_board_address.py
@@ -16,13 +16,18 @@
 retina example that just feeds data from a retina to live output via an
 intermediate population
 """
+from parameterized import parameterized
 import pyNN.spiNNaker as p
-from spinnaker_testbase import BaseTestCase
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import FPGA_BOARD_TYPES
 
 
-def do_run() -> None:
+@parameterized.expand(FPGA_BOARD_TYPES)
+def test_sata_2_different_boards_valid_board_address(
+        _: str, ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0, n_boards_required=3)
+    set_config("Machine", "version", ver_num)
 
     src_1 = p.Population(
         None,
@@ -46,15 +51,3 @@ def do_run() -> None:
 
     p.run(1000)
     p.end()
-
-
-class Sata2DifferentBoardsValidBoardAddress(BaseTestCase):
-
-    # NO unittest_setup() as sim.setup is called
-
-    def test_sata_2_different_boards_valid_board_address(self) -> None:
-        do_run()
-
-
-if __name__ == '__main__':
-    do_run()

--- a/unittests/test_spinnaker_link_connectors/spynnaker.cfg
+++ b/unittests/test_spinnaker_link_connectors/spynnaker.cfg
@@ -1,8 +1,6 @@
 [Machine]
 spalloc_server = None
 machine_name = None
-version = None
-versions = With FPGAs
 virtual_board = True
 down_cores = None
 down_chips = None

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
@@ -52,6 +52,7 @@ def do_run(ver_num: str) -> None:
     p.run(1000)
     p.end()
 
+
 class SpinnakerLink2DifferentBoardsNoBoardAddressTest(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
@@ -61,5 +62,6 @@ class SpinnakerLink2DifferentBoardsNoBoardAddressTest(BaseTestCase):
     def test_spinnaker_link_2_different_boards_no_board_address(
             self, _: str, ver_num: str) -> None:
         do_run(ver_num)
+
 
 

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
@@ -62,6 +62,3 @@ class SpinnakerLink2DifferentBoardsNoBoardAddressTest(BaseTestCase):
     def test_spinnaker_link_2_different_boards_no_board_address(
             self, _: str, ver_num: str) -> None:
         do_run(ver_num)
-
-
-

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
@@ -20,11 +20,10 @@ from parameterized import parameterized
 import pyNN.spiNNaker as p
 from spinn_utilities.config_holder import set_config
 from spinn_machine.version import FPGA_BOARD_TYPES
+from spinnaker_testbase import BaseTestCase
 
 
-@parameterized.expand(FPGA_BOARD_TYPES)
-def test_spinnaker_link_2_different_boards_no_board_address(
-        _: str, ver_num: str) -> None:
+def do_run(ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0)
     set_config("Machine", "version", ver_num)
@@ -52,3 +51,15 @@ def test_spinnaker_link_2_different_boards_no_board_address(
 
     p.run(1000)
     p.end()
+
+class SpinnakerLink2DifferentBoardsNoBoardAddressTest(BaseTestCase):
+
+    # NO unittest_setup() as sim.setup is called
+    # BaseTestCase to change dir and pickup cfg
+
+    @parameterized.expand(FPGA_BOARD_TYPES)
+    def test_spinnaker_link_2_different_boards_no_board_address(
+            self, _: str, ver_num: str) -> None:
+        do_run(ver_num)
+
+

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_no_board_address.py
@@ -16,13 +16,18 @@
 retina example that just feeds data from a retina to live output via an
 intermediate population
 """
+from parameterized import parameterized
 import pyNN.spiNNaker as p
-from spinnaker_testbase import BaseTestCase
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import FPGA_BOARD_TYPES
 
 
-def do_run() -> None:
+@parameterized.expand(FPGA_BOARD_TYPES)
+def test_spinnaker_link_2_different_boards_no_board_address(
+        _: str, ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0)
+    set_config("Machine", "version", ver_num)
 
     # FPGA Retina
     retina_device = p.external_devices.ExternalFPGARetinaDevice
@@ -47,15 +52,3 @@ def do_run() -> None:
 
     p.run(1000)
     p.end()
-
-
-class SpinnakerLink2DifferentBoardsNoBoardAddressTest(BaseTestCase):
-
-    # NO unittest_setup() as sim.setup is called
-
-    def test_spinnaker_link_2_different_boards_no_board_address(self) -> None:
-        do_run()
-
-
-if __name__ == "__main__":
-    do_run()

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_valid_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_valid_board_address.py
@@ -64,5 +64,3 @@ class SpinnakerLink2DifferentBoardsValidBoardAddressTest(BaseTestCase):
     def test_valid_board_address(
             self, _: str, ver_num: str) -> None:
         do_run(ver_num)
-
-

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_valid_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_valid_board_address.py
@@ -20,11 +20,10 @@ from parameterized import parameterized
 import pyNN.spiNNaker as p
 from spinn_utilities.config_holder import set_config
 from spinn_machine.version import FPGA_BOARD_TYPES
+from spinnaker_testbase import BaseTestCase
 
 
-@parameterized.expand(FPGA_BOARD_TYPES)
-def test_spinnaker_link_2_different_boards_valid_board_address(
-        _: str, ver_num: str) -> None:
+def do_run(ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0, n_boards_required=3)
     set_config("Machine", "version", ver_num)
@@ -54,3 +53,16 @@ def test_spinnaker_link_2_different_boards_valid_board_address(
 
     p.run(1000)
     p.end()
+
+
+class SpinnakerLink2DifferentBoardsValidBoardAddressTest(BaseTestCase):
+
+    # NO unittest_setup() as sim.setup is called
+    # BaseTestCase to change dir and pickup cfg
+
+    @parameterized.expand(FPGA_BOARD_TYPES)
+    def test_valid_board_address(
+            self, _: str, ver_num: str) -> None:
+        do_run(ver_num)
+
+

--- a/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_valid_board_address.py
+++ b/unittests/test_spinnaker_link_connectors/test_spinnaker_link_2_different_boards_valid_board_address.py
@@ -16,13 +16,18 @@
 retina example that just feeds data from a retina to live output via an
 intermediate population
 """
+from parameterized import parameterized
 import pyNN.spiNNaker as p
-from spinnaker_testbase import BaseTestCase
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import FPGA_BOARD_TYPES
 
 
-def do_run() -> None:
+@parameterized.expand(FPGA_BOARD_TYPES)
+def test_spinnaker_link_2_different_boards_valid_board_address(
+        _: str, ver_num: str) -> None:
     # Setup
     p.setup(timestep=1.0, n_boards_required=3)
+    set_config("Machine", "version", ver_num)
 
     # FPGA Retina
     retina_device = p.external_devices.ExternalFPGARetinaDevice
@@ -49,15 +54,3 @@ def do_run() -> None:
 
     p.run(1000)
     p.end()
-
-
-class SpinnakerLink2DifferentBoardsValidBoardAddressTest(BaseTestCase):
-
-    # NO unittest_setup() as sim.setup is called
-
-    def test_valid_board_address(self) -> None:
-        do_run()
-
-
-if __name__ == "__main__":
-    do_run()

--- a/unittests/test_using_virtual_board/spynnaker.cfg
+++ b/unittests/test_using_virtual_board/spynnaker.cfg
@@ -1,6 +1,5 @@
 [Machine]
 version = None
-versions = ANY
 virtual_board = True
 machine_name = None
 spalloc_server  = None

--- a/unittests/test_using_virtual_board/test_constraint.py
+++ b/unittests/test_using_virtual_board/test_constraint.py
@@ -15,7 +15,7 @@
 from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 from spynnaker.pyNN.data.spynnaker_data_view import SpynnakerDataView
 
@@ -24,7 +24,7 @@ class TestConstraint(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_placement_constraint(self, _: str, ver_num: str) -> None:
         """
         test the get_placements call.

--- a/unittests/test_using_virtual_board/test_constraint.py
+++ b/unittests/test_using_virtual_board/test_constraint.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 from spynnaker.pyNN.data.spynnaker_data_view import SpynnakerDataView
 
@@ -22,12 +24,14 @@ class TestConstraint(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_placement_constraint(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_placement_constraint(self, _:str, ver_num:str) -> None:
         """
         test the get_placements call.
 
         """
         sim.setup(timestep=1.0)
+        set_config("Machine", "version", ver_num)
         width, height = SpynnakerDataView.get_machine_version().board_shape
         # pick and XY in the middle of the board
         x = (width + 1) // 3

--- a/unittests/test_using_virtual_board/test_constraint.py
+++ b/unittests/test_using_virtual_board/test_constraint.py
@@ -25,7 +25,7 @@ class TestConstraint(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_placement_constraint(self, _:str, ver_num:str) -> None:
+    def test_placement_constraint(self, _: str, ver_num: str) -> None:
         """
         test the get_placements call.
 

--- a/unittests/test_using_virtual_board/test_debug_mode/spynnaker.cfg
+++ b/unittests/test_using_virtual_board/test_debug_mode/spynnaker.cfg
@@ -1,6 +1,4 @@
 [Machine]
-version = None
-versions = Any
 virtual_board = True
 machine_name = None
 spalloc_server  = None

--- a/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
+++ b/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
@@ -54,7 +54,7 @@ class TestDebug(BaseTestCase):
                         f"Unable to find report for {option} {path}")
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_debug(self, _:str, ver_num:str) -> None:
+    def test_debug(self, _: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)
         pop = sim.Population(100, sim.IF_curr_exp, {}, label="pop")

--- a/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
+++ b/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
@@ -20,7 +20,7 @@ from spinn_utilities.config_holder import (
     config_options, config_sections, get_report_path, get_timestamp_path,
     set_config)
 
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -53,7 +53,7 @@ class TestDebug(BaseTestCase):
                     raise AssertionError(
                         f"Unable to find report for {option} {path}")
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_debug(self, _: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
+++ b/unittests/test_using_virtual_board/test_debug_mode/test_debug.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 import os
-import unittest
+
+from parameterized import parameterized
 
 from spinn_utilities.config_holder import (
-    config_options, config_sections, get_report_path, get_timestamp_path)
+    config_options, config_sections, get_report_path, get_timestamp_path,
+    set_config)
+
+from spinn_machine.version import BIG_BOARD_TYPES
 
 from spinnaker_testbase import BaseTestCase
 
@@ -49,8 +53,10 @@ class TestDebug(BaseTestCase):
                     raise AssertionError(
                         f"Unable to find report for {option} {path}")
 
-    def debug(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_debug(self, _:str, ver_num:str) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         pop = sim.Population(100, sim.IF_curr_exp, {}, label="pop")
         pop.record("v")
         inp = sim.Population(1, sim.SpikeSourceArray(
@@ -62,10 +68,3 @@ class TestDebug(BaseTestCase):
         sim.end()
 
         self.assert_reports()
-
-    def test_debug(self) -> None:
-        self.runsafe(self.debug)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/unittests/test_using_virtual_board/test_extracting_spikes_when_v_only_set_to_record.py
+++ b/unittests/test_using_virtual_board/test_extracting_spikes_when_v_only_set_to_record.py
@@ -18,7 +18,7 @@ from parameterized import parameterized
 import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinnaker_testbase import BaseTestCase
 
@@ -27,7 +27,7 @@ class ExtractingSpikesWhenVOnlySetToRecord(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)

--- a/unittests/test_using_virtual_board/test_extracting_spikes_when_v_only_set_to_record.py
+++ b/unittests/test_using_virtual_board/test_extracting_spikes_when_v_only_set_to_record.py
@@ -28,7 +28,7 @@ class ExtractingSpikesWhenVOnlySetToRecord(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_cause_error(self, _:str, ver_num:str) -> None:
+    def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
             set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_extracting_spikes_when_v_only_set_to_record.py
+++ b/unittests/test_using_virtual_board/test_extracting_spikes_when_v_only_set_to_record.py
@@ -14,7 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinnaker_testbase import BaseTestCase
 
@@ -23,9 +27,11 @@ class ExtractingSpikesWhenVOnlySetToRecord(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_cause_error(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_cause_error(self, _:str, ver_num:str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
+            set_config("Machine", "version", ver_num)
             sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
 
             pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")

--- a/unittests/test_using_virtual_board/test_extracting_v_when_spikes_only_set_to_record.py
+++ b/unittests/test_using_virtual_board/test_extracting_v_when_spikes_only_set_to_record.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinnaker_testbase import BaseTestCase
 
@@ -25,7 +25,7 @@ class ExtractingSpikesWhenVOnlySetToRecord(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)

--- a/unittests/test_using_virtual_board/test_extracting_v_when_spikes_only_set_to_record.py
+++ b/unittests/test_using_virtual_board/test_extracting_v_when_spikes_only_set_to_record.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 from spinnaker_testbase import BaseTestCase
 
@@ -21,9 +25,11 @@ class ExtractingSpikesWhenVOnlySetToRecord(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_cause_error(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_cause_error(self, _:str, ver_num:str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
+            set_config("Machine", "version", ver_num)
             sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
 
             pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")

--- a/unittests/test_using_virtual_board/test_extracting_v_when_spikes_only_set_to_record.py
+++ b/unittests/test_using_virtual_board/test_extracting_v_when_spikes_only_set_to_record.py
@@ -26,7 +26,7 @@ class ExtractingSpikesWhenVOnlySetToRecord(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_cause_error(self, _:str, ver_num:str) -> None:
+    def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
             set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_from_file_connector.py
+++ b/unittests/test_using_virtual_board/test_from_file_connector.py
@@ -73,7 +73,7 @@ class TestFromFileConnector(BaseTestCase):
             as_index += 1
 
     def check_other_connect(
-            self, aslist: AsList, ver_num:str,
+            self, aslist: AsList, ver_num: str,
             header: Optional[str] = None, w_index: Optional[int] = 2,
             d_index: Optional[int] = 3, sources: int = 6,
             destinations: int = 8) -> None:

--- a/unittests/test_using_virtual_board/test_from_file_connector.py
+++ b/unittests/test_using_virtual_board/test_from_file_connector.py
@@ -12,14 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import tempfile
 import os
 from typing import List, Optional, Tuple, Union
+
+from parameterized import parameterized
 from typing_extensions import TypeAlias
 
 import numpy
 import pyNN.spiNNaker as sim
 
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -68,7 +73,7 @@ class TestFromFileConnector(BaseTestCase):
             as_index += 1
 
     def check_other_connect(
-            self, aslist: AsList,
+            self, aslist: AsList, ver_num:str,
             header: Optional[str] = None, w_index: Optional[int] = 2,
             d_index: Optional[int] = 3, sources: int = 6,
             destinations: int = 8) -> None:
@@ -79,6 +84,7 @@ class TestFromFileConnector(BaseTestCase):
             numpy.savetxt(name, aslist)
 
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         pop1 = sim.Population(sources, sim.IF_curr_exp(), label="pop1")
         pop2 = sim.Population(destinations, sim.IF_curr_exp(), label="pop2")
         synapse_type = sim.StaticSynapse(weight=WEIGHT, delay=DELAY)
@@ -94,7 +100,8 @@ class TestFromFileConnector(BaseTestCase):
         except OSError:
             pass
 
-    def test_simple(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_simple(self, _:str, ver_num:str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (3, 0, 0.2, 11),
@@ -102,9 +109,10 @@ class TestFromFileConnector(BaseTestCase):
             (5, 1, 0.4, 13),
             (0, 1, 0.5, 14),
         ]
-        self.check_other_connect(as_list)
+        self.check_other_connect(as_list, ver_num)
 
-    def test_list_too_big(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_list_too_big(self, _:str, ver_num:str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (13, 0, 0.2, 11),
@@ -112,9 +120,10 @@ class TestFromFileConnector(BaseTestCase):
             (5, 1, 0.4, 13),
             (0, 1, 0.5, 14),
         ]
-        self.check_other_connect(as_list)
+        self.check_other_connect(as_list, ver_num)
 
-    def test_no_delays(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_no_delays(self, _:str, ver_num:str) -> None:
         as_list = [
             (0, 0, 0.1),
             (3, 0, 0.2),
@@ -123,9 +132,11 @@ class TestFromFileConnector(BaseTestCase):
             (0, 1, 0.5),
         ]
         self.check_other_connect(
-            as_list, header='columns = ["i", "j", "weight"]', d_index=None)
+            as_list, ver_num, header='columns = ["i", "j", "weight"]',
+            d_index=None)
 
-    def test_no_weight(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_no_weight(self, _:str, ver_num:str) -> None:
         as_list: List[Tuple[int, int, float]] = [
             (0, 0, 10),
             (3, 0, 11),
@@ -134,10 +145,11 @@ class TestFromFileConnector(BaseTestCase):
             (0, 1, 14),
         ]
         self.check_other_connect(
-            as_list, header='columns = ["i", "j", "delay"]', d_index=2,
-            w_index=None)
+            as_list, ver_num, header='columns = ["i", "j", "delay"]',
+            d_index=2, w_index=None)
 
-    def test_invert(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_invert(self, _:str, ver_num:str) -> None:
         as_list: List[Tuple[int, int, float, float]] = [
             (0, 0, 10, 0.1),
             (3, 0, 11, 0.2),
@@ -146,10 +158,12 @@ class TestFromFileConnector(BaseTestCase):
             (0, 1, 14, 0.5),
         ]
         self.check_other_connect(
-            as_list, header='columns = ["i", "j", "delay", "weight"]',
+            as_list, ver_num,
+            header='columns = ["i", "j", "delay", "weight"]',
             w_index=3, d_index=2)
 
-    def test_big(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_big(self, _:str, ver_num:str) -> None:
         sources = 200
         destinations = 300
         aslist: AsList4 = []
@@ -158,5 +172,5 @@ class TestFromFileConnector(BaseTestCase):
                 aslist.append((s, d, 5, 2))
 
         self.check_other_connect(
-            aslist, header=None, w_index=2, d_index=3, sources=sources,
-            destinations=destinations)
+            aslist, ver_num, header=None, w_index=2, d_index=3,
+            sources=sources, destinations=destinations)

--- a/unittests/test_using_virtual_board/test_from_file_connector.py
+++ b/unittests/test_using_virtual_board/test_from_file_connector.py
@@ -101,7 +101,7 @@ class TestFromFileConnector(BaseTestCase):
             pass
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_simple(self, _:str, ver_num:str) -> None:
+    def test_simple(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (3, 0, 0.2, 11),
@@ -112,7 +112,7 @@ class TestFromFileConnector(BaseTestCase):
         self.check_other_connect(as_list, ver_num)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_list_too_big(self, _:str, ver_num:str) -> None:
+    def test_list_too_big(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (13, 0, 0.2, 11),
@@ -123,7 +123,7 @@ class TestFromFileConnector(BaseTestCase):
         self.check_other_connect(as_list, ver_num)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_no_delays(self, _:str, ver_num:str) -> None:
+    def test_no_delays(self, _: str, ver_num: str) -> None:
         as_list = [
             (0, 0, 0.1),
             (3, 0, 0.2),
@@ -136,7 +136,7 @@ class TestFromFileConnector(BaseTestCase):
             d_index=None)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_no_weight(self, _:str, ver_num:str) -> None:
+    def test_no_weight(self, _: str, ver_num: str) -> None:
         as_list: List[Tuple[int, int, float]] = [
             (0, 0, 10),
             (3, 0, 11),
@@ -149,7 +149,7 @@ class TestFromFileConnector(BaseTestCase):
             d_index=2, w_index=None)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_invert(self, _:str, ver_num:str) -> None:
+    def test_invert(self, _: str, ver_num: str) -> None:
         as_list: List[Tuple[int, int, float, float]] = [
             (0, 0, 10, 0.1),
             (3, 0, 11, 0.2),
@@ -163,7 +163,7 @@ class TestFromFileConnector(BaseTestCase):
             w_index=3, d_index=2)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_big(self, _:str, ver_num:str) -> None:
+    def test_big(self, _: str, ver_num: str) -> None:
         sources = 200
         destinations = 300
         aslist: AsList4 = []

--- a/unittests/test_using_virtual_board/test_from_file_connector.py
+++ b/unittests/test_using_virtual_board/test_from_file_connector.py
@@ -24,7 +24,7 @@ import numpy
 import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -100,7 +100,7 @@ class TestFromFileConnector(BaseTestCase):
         except OSError:
             pass
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_simple(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
@@ -111,7 +111,7 @@ class TestFromFileConnector(BaseTestCase):
         ]
         self.check_other_connect(as_list, ver_num)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_list_too_big(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
@@ -122,7 +122,7 @@ class TestFromFileConnector(BaseTestCase):
         ]
         self.check_other_connect(as_list, ver_num)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_no_delays(self, _: str, ver_num: str) -> None:
         as_list = [
             (0, 0, 0.1),
@@ -135,7 +135,7 @@ class TestFromFileConnector(BaseTestCase):
             as_list, ver_num, header='columns = ["i", "j", "weight"]',
             d_index=None)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_no_weight(self, _: str, ver_num: str) -> None:
         as_list: List[Tuple[int, int, float]] = [
             (0, 0, 10),
@@ -148,7 +148,7 @@ class TestFromFileConnector(BaseTestCase):
             as_list, ver_num, header='columns = ["i", "j", "delay"]',
             d_index=2, w_index=None)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_invert(self, _: str, ver_num: str) -> None:
         as_list: List[Tuple[int, int, float, float]] = [
             (0, 0, 10, 0.1),
@@ -162,7 +162,7 @@ class TestFromFileConnector(BaseTestCase):
             header='columns = ["i", "j", "delay", "weight"]',
             w_index=3, d_index=2)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_big(self, _: str, ver_num: str) -> None:
         sources = 200
         destinations = 300

--- a/unittests/test_using_virtual_board/test_from_list_connector.py
+++ b/unittests/test_using_virtual_board/test_from_list_connector.py
@@ -87,7 +87,7 @@ class TestFromListConnector(BaseTestCase):
         sim.end()
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_simple(self, _:str, ver_num:str) -> None:
+    def test_simple(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (3, 0, 0.2, 11),
@@ -98,7 +98,7 @@ class TestFromListConnector(BaseTestCase):
         self.check_other_connect(as_list, ver_num)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_list_too_big(self, _:str, ver_num:str) -> None:
+    def test_list_too_big(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (13, 0, 0.2, 11),
@@ -109,7 +109,7 @@ class TestFromListConnector(BaseTestCase):
         self.check_other_connect(as_list, ver_num)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_no_delays(self, _:str, ver_num:str) -> None:
+    def test_no_delays(self, _: str, ver_num: str) -> None:
         as_list: AsList3 = [
             (0, 0, 0.1),
             (3, 0, 0.2),
@@ -121,7 +121,7 @@ class TestFromListConnector(BaseTestCase):
             as_list, ver_num, column_names=["weight"], d_index=None)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_no_weight(self, _:str, ver_num:str) -> None:
+    def test_no_weight(self, _: str, ver_num: str) -> None:
         as_list: AsList3 = [
             (0, 0, 10),
             (3, 0, 11),
@@ -133,7 +133,7 @@ class TestFromListConnector(BaseTestCase):
             as_list, ver_num, column_names=["delay"], d_index=2, w_index=None)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_invert(self, _:str, ver_num:str) -> None:
+    def test_invert(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 10, 0.1),
             (3, 0, 11, 0.2),
@@ -146,7 +146,7 @@ class TestFromListConnector(BaseTestCase):
             d_index=2)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_big(self, _:str, ver_num:str) -> None:
+    def test_big(self, _: str, ver_num: str) -> None:
         sources = 200
         destinations = 300
         aslist: AsList4 = []
@@ -159,7 +159,7 @@ class TestFromListConnector(BaseTestCase):
             sources=sources, destinations=destinations)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_get_before_run(self, _:str, ver_num:str) -> None:
+    def test_get_before_run(self, _: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)
         pop1 = sim.Population(3, sim.IF_curr_exp(), label="pop1")
@@ -174,7 +174,7 @@ class TestFromListConnector(BaseTestCase):
         sim.end()
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_using_static_synapse_singles(self, _:str, ver_num:str) -> None:
+    def test_using_static_synapse_singles(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")
@@ -191,7 +191,7 @@ class TestFromListConnector(BaseTestCase):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_using_half_static_synapse_singles(self, _:str, ver_num:str) -> None:
+    def test_using_half_static_synapse_singles(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")
@@ -209,7 +209,7 @@ class TestFromListConnector(BaseTestCase):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_using_static_synapse_doubles(self, _:str, ver_num:str) -> None:
+    def test_using_static_synapse_doubles(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")

--- a/unittests/test_using_virtual_board/test_from_list_connector.py
+++ b/unittests/test_using_virtual_board/test_from_list_connector.py
@@ -19,7 +19,7 @@ from typing_extensions import TypeAlias
 import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -86,7 +86,7 @@ class TestFromListConnector(BaseTestCase):
             projection, aslist, w_index, d_index, sources, destinations)
         sim.end()
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_simple(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
@@ -97,7 +97,7 @@ class TestFromListConnector(BaseTestCase):
         ]
         self.check_other_connect(as_list, ver_num)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_list_too_big(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
@@ -108,7 +108,7 @@ class TestFromListConnector(BaseTestCase):
         ]
         self.check_other_connect(as_list, ver_num)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_no_delays(self, _: str, ver_num: str) -> None:
         as_list: AsList3 = [
             (0, 0, 0.1),
@@ -120,7 +120,7 @@ class TestFromListConnector(BaseTestCase):
         self.check_other_connect(
             as_list, ver_num, column_names=["weight"], d_index=None)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_no_weight(self, _: str, ver_num: str) -> None:
         as_list: AsList3 = [
             (0, 0, 10),
@@ -132,7 +132,7 @@ class TestFromListConnector(BaseTestCase):
         self.check_other_connect(
             as_list, ver_num, column_names=["delay"], d_index=2, w_index=None)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_invert(self, _: str, ver_num: str) -> None:
         as_list: AsList4 = [
             (0, 0, 10, 0.1),
@@ -145,7 +145,7 @@ class TestFromListConnector(BaseTestCase):
             as_list, ver_num, column_names=["delay", "weight"], w_index=3,
             d_index=2)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_big(self, _: str, ver_num: str) -> None:
         sources = 200
         destinations = 300
@@ -158,7 +158,7 @@ class TestFromListConnector(BaseTestCase):
             aslist, ver_num, column_names=None, w_index=2, d_index=3,
             sources=sources, destinations=destinations)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_get_before_run(self, _: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)
@@ -173,7 +173,7 @@ class TestFromListConnector(BaseTestCase):
         self.assertEqual(1, len(weights))
         sim.end()
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_using_static_synapse_singles(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)
@@ -190,7 +190,7 @@ class TestFromListConnector(BaseTestCase):
             for j in range(2):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_using_half_static_synapse_singles(
             self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
@@ -209,7 +209,7 @@ class TestFromListConnector(BaseTestCase):
             for j in range(2):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_using_static_synapse_doubles(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_from_list_connector.py
+++ b/unittests/test_using_virtual_board/test_from_list_connector.py
@@ -191,7 +191,8 @@ class TestFromListConnector(BaseTestCase):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_using_half_static_synapse_singles(self, _: str, ver_num: str) -> None:
+    def test_using_half_static_synapse_singles(
+            self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")

--- a/unittests/test_using_virtual_board/test_from_list_connector.py
+++ b/unittests/test_using_virtual_board/test_from_list_connector.py
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 from typing import List, Optional, Tuple, Union
+
+from parameterized import parameterized
 from typing_extensions import TypeAlias
 import pyNN.spiNNaker as sim
+
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -63,10 +68,12 @@ class TestFromListConnector(BaseTestCase):
             as_index += 1
 
     def check_other_connect(
-            self, aslist: AsList, column_names: Optional[List[str]] = None,
+            self, aslist: AsList, ver_num: str,
+            column_names: Optional[List[str]] = None,
             w_index: Optional[int] = 2, d_index: Optional[int] = 3,
             sources: int = 6, destinations: int = 8) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         pop1 = sim.Population(sources, sim.IF_curr_exp(), label="pop1")
         pop2 = sim.Population(destinations, sim.IF_curr_exp(), label="pop2")
         synapse_type = sim.StaticSynapse(weight=WEIGHT, delay=DELAY)
@@ -79,7 +86,8 @@ class TestFromListConnector(BaseTestCase):
             projection, aslist, w_index, d_index, sources, destinations)
         sim.end()
 
-    def test_simple(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_simple(self, _:str, ver_num:str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (3, 0, 0.2, 11),
@@ -87,9 +95,10 @@ class TestFromListConnector(BaseTestCase):
             (5, 1, 0.4, 13),
             (0, 1, 0.5, 14),
         ]
-        self.check_other_connect(as_list)
+        self.check_other_connect(as_list, ver_num)
 
-    def test_list_too_big(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_list_too_big(self, _:str, ver_num:str) -> None:
         as_list: AsList4 = [
             (0, 0, 0.1, 10),
             (13, 0, 0.2, 11),
@@ -97,9 +106,10 @@ class TestFromListConnector(BaseTestCase):
             (5, 1, 0.4, 13),
             (0, 1, 0.5, 14),
         ]
-        self.check_other_connect(as_list)
+        self.check_other_connect(as_list, ver_num)
 
-    def test_no_delays(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_no_delays(self, _:str, ver_num:str) -> None:
         as_list: AsList3 = [
             (0, 0, 0.1),
             (3, 0, 0.2),
@@ -108,9 +118,10 @@ class TestFromListConnector(BaseTestCase):
             (0, 1, 0.5),
         ]
         self.check_other_connect(
-            as_list, column_names=["weight"], d_index=None)
+            as_list, ver_num, column_names=["weight"], d_index=None)
 
-    def test_no_weight(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_no_weight(self, _:str, ver_num:str) -> None:
         as_list: AsList3 = [
             (0, 0, 10),
             (3, 0, 11),
@@ -119,9 +130,10 @@ class TestFromListConnector(BaseTestCase):
             (0, 1, 14),
         ]
         self.check_other_connect(
-            as_list, column_names=["delay"], d_index=2, w_index=None)
+            as_list, ver_num, column_names=["delay"], d_index=2, w_index=None)
 
-    def test_invert(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_invert(self, _:str, ver_num:str) -> None:
         as_list: AsList4 = [
             (0, 0, 10, 0.1),
             (3, 0, 11, 0.2),
@@ -130,9 +142,11 @@ class TestFromListConnector(BaseTestCase):
             (0, 1, 14, 0.5),
         ]
         self.check_other_connect(
-            as_list, column_names=["delay", "weight"], w_index=3, d_index=2)
+            as_list, ver_num, column_names=["delay", "weight"], w_index=3,
+            d_index=2)
 
-    def test_big(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_big(self, _:str, ver_num:str) -> None:
         sources = 200
         destinations = 300
         aslist: AsList4 = []
@@ -141,11 +155,13 @@ class TestFromListConnector(BaseTestCase):
                 aslist.append((s, d, 5, 2))
 
         self.check_other_connect(
-            aslist, column_names=None, w_index=2, d_index=3, sources=sources,
-            destinations=destinations)
+            aslist, ver_num, column_names=None, w_index=2, d_index=3,
+            sources=sources, destinations=destinations)
 
-    def test_get_before_run(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_get_before_run(self, _:str, ver_num:str) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         pop1 = sim.Population(3, sim.IF_curr_exp(), label="pop1")
         pop2 = sim.Population(3, sim.IF_curr_exp(), label="pop2")
         synapse_type = sim.StaticSynapse(weight=5, delay=1)
@@ -157,8 +173,10 @@ class TestFromListConnector(BaseTestCase):
         self.assertEqual(1, len(weights))
         sim.end()
 
-    def test_using_static_synapse_singles(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_using_static_synapse_singles(self, _:str, ver_num:str) -> None:
         sim.setup(timestep=1.0)
+        set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")
         pop = sim.Population(2, sim.IF_curr_exp(), label="pop")
         as_list = [(0, 0), (1, 1)]
@@ -172,8 +190,10 @@ class TestFromListConnector(BaseTestCase):
             for j in range(2):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
-    def test_using_half_static_synapse_singles(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_using_half_static_synapse_singles(self, _:str, ver_num:str) -> None:
         sim.setup(timestep=1.0)
+        set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")
         pop = sim.Population(2, sim.IF_curr_exp(), label="pop")
         as_list = [(0, 0, 0.7), (1, 1, 0.3)]
@@ -188,8 +208,10 @@ class TestFromListConnector(BaseTestCase):
             for j in range(2):
                 self.assertAlmostEqual(weights[i][j], target[i][j], places=3)
 
-    def test_using_static_synapse_doubles(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_using_static_synapse_doubles(self, _:str, ver_num:str) -> None:
         sim.setup(timestep=1.0)
+        set_config("Machine", "version", ver_num)
         input = sim.Population(2, sim.SpikeSourceArray([0]), label="input")
         pop = sim.Population(2, sim.IF_curr_exp(), label="pop")
         as_list = [(0, 0), (1, 1)]

--- a/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
+++ b/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
@@ -83,11 +83,11 @@ class TestIndexBasedProbabilityConnector(BaseTestCase):
         sim.end()
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_self(self, _:str, ver_num:str) -> None:
+    def test_self(self, _: str, ver_num: str) -> None:
         self.check_connect(
             n=6, expression="(i+j)%3*0.5", ver_num=ver_num)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_other(self, _:str, ver_num:str) -> None:
+    def test_other(self, _: str, ver_num: str) -> None:
         self.check_connect_no_self(
             n=6, expression="(i+j)%3*0.5", ver_num=ver_num)

--- a/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
+++ b/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
@@ -67,7 +67,8 @@ class TestIndexBasedProbabilityConnector(BaseTestCase):
         self.check_weights(projection, n, expression, True)
         sim.end()
 
-    def check_connect_no_self(self, n: int, expression: str, ver_num:str) -> None:
+    def check_connect_no_self(
+            self, n: int, expression: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 10)

--- a/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
+++ b/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
@@ -15,7 +15,7 @@
 from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -83,12 +83,12 @@ class TestIndexBasedProbabilityConnector(BaseTestCase):
         self.check_weights(projection, n, expression, False)
         sim.end()
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_self(self, _: str, ver_num: str) -> None:
         self.check_connect(
             n=6, expression="(i+j)%3*0.5", ver_num=ver_num)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_other(self, _: str, ver_num: str) -> None:
         self.check_connect_no_self(
             n=6, expression="(i+j)%3*0.5", ver_num=ver_num)

--- a/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
+++ b/unittests/test_using_virtual_board/test_index_based_probabliity_connector.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -48,8 +51,9 @@ class TestIndexBasedProbabilityConnector(BaseTestCase):
         # Check not all the maybes connected
         self.assertGreaterEqual(len(weights), must_count)
 
-    def check_connect(self, n: int, expression: str) -> None:
+    def check_connect(self, n: int, expression: str, ver_num: str) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 10)
         pop1 = sim.Population(
             n, sim.SpikeSourceArray(spike_times=[0]), label="input")
@@ -63,8 +67,9 @@ class TestIndexBasedProbabilityConnector(BaseTestCase):
         self.check_weights(projection, n, expression, True)
         sim.end()
 
-    def check_connect_no_self(self, n: int, expression: str) -> None:
+    def check_connect_no_self(self, n: int, expression: str, ver_num:str) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 10)
         pop = sim.Population(n, sim.IF_curr_exp(), label="pop")
         synapse_type = sim.StaticSynapse(weight=5, delay=2)
@@ -77,10 +82,12 @@ class TestIndexBasedProbabilityConnector(BaseTestCase):
         self.check_weights(projection, n, expression, False)
         sim.end()
 
-    def test_self(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_self(self, _:str, ver_num:str) -> None:
         self.check_connect(
-            n=6, expression="(i+j)%3*0.5")
+            n=6, expression="(i+j)%3*0.5", ver_num=ver_num)
 
-    def test_other(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_other(self, _:str, ver_num:str) -> None:
         self.check_connect_no_self(
-            n=6, expression="(i+j)%3*0.5")
+            n=6, expression="(i+j)%3*0.5", ver_num=ver_num)

--- a/unittests/test_using_virtual_board/test_none_defaults/spynnaker.cfg
+++ b/unittests/test_using_virtual_board/test_none_defaults/spynnaker.cfg
@@ -1,6 +1,5 @@
 [Machine]
 version = None
-versions = ANY
 virtual_board = True
 machine_name = None
 spalloc_server  = None

--- a/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
+++ b/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 
@@ -20,8 +24,10 @@ class TestSimple(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_simple(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_simple(self_: str, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0, n_boards_required=1)
+        set_config("Machine", "version", ver_num)
         sim.get_machine()
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
 

--- a/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
+++ b/unittests/test_using_virtual_board/test_none_defaults/test_simple.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 import pyNN.spiNNaker as sim
 
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 
@@ -24,7 +24,7 @@ class TestSimple(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_simple(self_: str, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0, n_boards_required=1)
         set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_one_to_one_connector.py
+++ b/unittests/test_using_virtual_board/test_one_to_one_connector.py
@@ -51,7 +51,7 @@ class TestOneToOneConnector(BaseTestCase):
         sim.end()
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_same(self, _:str, ver_num:str) -> None:
+    def test_same(self, _: str, ver_num: str) -> None:
         self.check_other_connect(5, 5, ver_num)
 
     # Does not work on VM
@@ -63,11 +63,11 @@ class TestOneToOneConnector(BaseTestCase):
     #    self.check_other_connect(10, 5)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_many(self, _:str, ver_num:str) -> None:
+    def test_many(self, _: str, ver_num: str) -> None:
         self.check_other_connect(500, 500, ver_num)
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_get_before_run(self, _:str, ver_num:str) -> None:
+    def test_get_before_run(self, _: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)
         pop1 = sim.Population(3, sim.IF_curr_exp(), label="pop1")

--- a/unittests/test_using_virtual_board/test_one_to_one_connector.py
+++ b/unittests/test_using_virtual_board/test_one_to_one_connector.py
@@ -15,7 +15,7 @@
 from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -50,7 +50,7 @@ class TestOneToOneConnector(BaseTestCase):
         self.check_weights(projection, sources, destinations)
         sim.end()
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_same(self, _: str, ver_num: str) -> None:
         self.check_other_connect(5, 5, ver_num)
 
@@ -62,11 +62,11 @@ class TestOneToOneConnector(BaseTestCase):
     # def test_less_destinations(self) -> None:
     #    self.check_other_connect(10, 5)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_many(self, _: str, ver_num: str) -> None:
         self.check_other_connect(500, 500, ver_num)
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_get_before_run(self, _: str, ver_num: str) -> None:
         sim.setup(1.0)
         set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_one_to_one_connector.py
+++ b/unittests/test_using_virtual_board/test_one_to_one_connector.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 from spynnaker.pyNN.models.projection import Projection
@@ -34,8 +37,10 @@ class TestOneToOneConnector(BaseTestCase):
             self.assertLess(destination, sources)
         self.assertEqual(len(weights), min(sources, destinations))
 
-    def check_other_connect(self, sources: int, destinations: int) -> None:
+    def check_other_connect(
+            self, sources: int, destinations: int, ver_num: str) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         pop1 = sim.Population(sources, sim.IF_curr_exp(), label="pop1")
         pop2 = sim.Population(destinations, sim.IF_curr_exp(), label="pop2")
         synapse_type = sim.StaticSynapse(weight=5, delay=1)
@@ -45,8 +50,9 @@ class TestOneToOneConnector(BaseTestCase):
         self.check_weights(projection, sources, destinations)
         sim.end()
 
-    def test_same(self) -> None:
-        self.check_other_connect(5, 5)
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_same(self, _:str, ver_num:str) -> None:
+        self.check_other_connect(5, 5, ver_num)
 
     # Does not work on VM
     # def test_less_sources(self) -> None:
@@ -56,11 +62,14 @@ class TestOneToOneConnector(BaseTestCase):
     # def test_less_destinations(self) -> None:
     #    self.check_other_connect(10, 5)
 
-    def test_many(self) -> None:
-        self.check_other_connect(500, 500)
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_many(self, _:str, ver_num:str) -> None:
+        self.check_other_connect(500, 500, ver_num)
 
-    def test_get_before_run(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_get_before_run(self, _:str, ver_num:str) -> None:
         sim.setup(1.0)
+        set_config("Machine", "version", ver_num)
         pop1 = sim.Population(3, sim.IF_curr_exp(), label="pop1")
         pop2 = sim.Population(3, sim.IF_curr_exp(), label="pop2")
         synapse_type = sim.StaticSynapse(weight=5, delay=1)

--- a/unittests/test_using_virtual_board/test_reset_add_pop.py
+++ b/unittests/test_using_virtual_board/test_reset_add_pop.py
@@ -15,7 +15,7 @@
 from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 
@@ -23,7 +23,7 @@ class TestResetAdd(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def testReset_add(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_reset_add_pop.py
+++ b/unittests/test_using_virtual_board/test_reset_add_pop.py
@@ -24,7 +24,7 @@ class TestResetAdd(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def testReset_add(self, _:str, ver_num:str) -> None:
+    def testReset_add(self, _: str, ver_num: str) -> None:
         sim.setup(timestep=1.0)
         set_config("Machine", "version", ver_num)
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 1)

--- a/unittests/test_using_virtual_board/test_reset_add_pop.py
+++ b/unittests/test_using_virtual_board/test_reset_add_pop.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 
 
@@ -20,8 +23,10 @@ class TestResetAdd(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def testReset_add(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def testReset_add(self, _:str, ver_num:str) -> None:
         sim.setup(timestep=1.0)
+        set_config("Machine", "version", ver_num)
         sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 1)
 
         input = sim.Population(

--- a/unittests/test_using_virtual_board/test_synfire_extracting_spikes_when_nothing_set_to_recorded.py
+++ b/unittests/test_using_virtual_board/test_synfire_extracting_spikes_when_nothing_set_to_recorded.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -21,9 +24,11 @@ class SynfireExtractingSpikesWhenNothingSetToRecorded(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_cause_error(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_cause_error(self, _:str, ver_num:str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
+            set_config("Machine", "version", ver_num)
             sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
 
             pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")

--- a/unittests/test_using_virtual_board/test_synfire_extracting_spikes_when_nothing_set_to_recorded.py
+++ b/unittests/test_using_virtual_board/test_synfire_extracting_spikes_when_nothing_set_to_recorded.py
@@ -15,7 +15,7 @@
 from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -24,7 +24,7 @@ class SynfireExtractingSpikesWhenNothingSetToRecorded(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)

--- a/unittests/test_using_virtual_board/test_synfire_extracting_spikes_when_nothing_set_to_recorded.py
+++ b/unittests/test_using_virtual_board/test_synfire_extracting_spikes_when_nothing_set_to_recorded.py
@@ -25,7 +25,7 @@ class SynfireExtractingSpikesWhenNothingSetToRecorded(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_cause_error(self, _:str, ver_num:str) -> None:
+    def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
             set_config("Machine", "version", ver_num)

--- a/unittests/test_using_virtual_board/test_synfire_extracting_v_when_nothing_set_to_recorded.py
+++ b/unittests/test_using_virtual_board/test_synfire_extracting_v_when_nothing_set_to_recorded.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from parameterized import parameterized
 import pyNN.spiNNaker as sim
+from spinn_utilities.config_holder import set_config
+from spinn_machine.version import BIG_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -21,9 +24,11 @@ class SynfireExtractingSpikesWhenNothingSetToRecorded(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    def test_cause_error(self) -> None:
+    @parameterized.expand(BIG_BOARD_TYPES)
+    def test_cause_error(self, _:str, ver_num:str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
+            set_config("Machine", "version", ver_num)
             sim.set_number_of_neurons_per_core(sim.IF_curr_exp, 100)
 
             pop_1 = sim.Population(1, sim.IF_curr_exp(), label="pop_1")

--- a/unittests/test_using_virtual_board/test_synfire_extracting_v_when_nothing_set_to_recorded.py
+++ b/unittests/test_using_virtual_board/test_synfire_extracting_v_when_nothing_set_to_recorded.py
@@ -15,7 +15,7 @@
 from parameterized import parameterized
 import pyNN.spiNNaker as sim
 from spinn_utilities.config_holder import set_config
-from spinn_machine.version import BIG_BOARD_TYPES
+from spinn_machine.version import MANY_BOARD_TYPES
 from spinnaker_testbase import BaseTestCase
 from spinn_front_end_common.utilities.exceptions import ConfigurationException
 
@@ -24,7 +24,7 @@ class SynfireExtractingSpikesWhenNothingSetToRecorded(BaseTestCase):
 
     # NO unittest_setup() as sim.setup is called
 
-    @parameterized.expand(BIG_BOARD_TYPES)
+    @parameterized.expand(MANY_BOARD_TYPES)
     def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)

--- a/unittests/test_using_virtual_board/test_synfire_extracting_v_when_nothing_set_to_recorded.py
+++ b/unittests/test_using_virtual_board/test_synfire_extracting_v_when_nothing_set_to_recorded.py
@@ -25,7 +25,7 @@ class SynfireExtractingSpikesWhenNothingSetToRecorded(BaseTestCase):
     # NO unittest_setup() as sim.setup is called
 
     @parameterized.expand(BIG_BOARD_TYPES)
-    def test_cause_error(self, _:str, ver_num:str) -> None:
+    def test_cause_error(self, _: str, ver_num: str) -> None:
         with self.assertRaises(ConfigurationException):
             sim.setup(timestep=1.0)
             set_config("Machine", "version", ver_num)

--- a/unittests/test_virtual_board_no_vertices_supported/spynnaker.cfg
+++ b/unittests/test_virtual_board_no_vertices_supported/spynnaker.cfg
@@ -1,7 +1,6 @@
 [Machine]
 virtual_board = True
 version = None
-versions = Any
 machine_name = None
 remote_spinnaker_url = None
 spalloc_server = None


### PR DESCRIPTION
Part of https://github.com/SpiNNakerManchester/SpiNNMachine/pull/313

Most changes are just using parameterized
Others are:
- spynnaker_data_writer.py clear all data on mock
- test_synaptic_manager.py also uses @pytest.mark.parametrize(
- spynnaker.cfg remioved version and versions
- ver_num sometimes pass through
     - These test need this style to run BaseTestCase cd dir to pickup the cfg
- removed if __name__ == '__main__':  from some tests
    - as these where for Alan are not paramererized 
- setup.cfg to test install parameterized
- pyproject.toml to mypy skip parameterized