### PR TITLE
Weight Scale Responsibility

### DIFF
--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_plastic_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_plastic_synapse_dynamics.py
@@ -20,6 +20,7 @@ from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 
 from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
     ConnectionsArray)
+from spynnaker.pyNN.types import WeightScales
 
 from .abstract_sdram_synapse_dynamics import AbstractSDRAMSynapseDynamics
 
@@ -46,7 +47,8 @@ class AbstractPlasticSynapseDynamics(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Union[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Union[
                 Tuple[NDArray[uint32], NDArray[uint32],
                       NDArray[uint32], NDArray[uint32]],
                 Tuple[List[NDArray[uint32]], List[NDArray[uint32]],
@@ -71,6 +73,11 @@ class AbstractPlasticSynapseDynamics(
         :param n_synapse_types: The number of synapse types
         :param max_n_synapses: The maximum number of synapses to generate
         :param max_atoms_per_core: The maximum number of atoms on a core
+        :param ring_buffer_weight_scales:
+            The ring buffer scaling of the weights for each synapse type.  This
+            does not have to be used in the storage of synapses, but could
+            instead be used when converting stored weights to ring buffer
+            weights.
         :return: (fp_data (2D), pp_data (2D), fp_size (1D), pp_size (1D))
         """
         raise NotImplementedError
@@ -110,7 +117,8 @@ class AbstractPlasticSynapseDynamics(
             self, n_synapse_types: int,
             pp_size: NDArray[uint32], pp_data: List[NDArray[uint32]],
             fp_size: NDArray[uint32], fp_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         """
         Read the connections indicated in the connection indices from the
         data in `pp_data` and `fp_data`.
@@ -121,6 +129,7 @@ class AbstractPlasticSynapseDynamics(
         :param fp_size: 1D
         :param fp_data: 2D
         :param max_atoms_per_core:
+        :param ring_buffer_weight_scales:
         :return:
             array with columns ``source``, ``target``, ``weight``, ``delay``
         """

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_static_synapse_dynamics.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/abstract_static_synapse_dynamics.py
@@ -19,6 +19,7 @@ from numpy.typing import NDArray
 from spinn_utilities.abstract_base import AbstractBase, abstractmethod
 from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
     ConnectionsArray)
+from spynnaker.pyNN.types import WeightScales
 from .abstract_sdram_synapse_dynamics import AbstractSDRAMSynapseDynamics
 
 
@@ -44,7 +45,8 @@ class AbstractStaticSynapseDynamics(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Tuple[
                 List[NDArray[uint32]], NDArray[integer]]:
         """
         Get the fixed-fixed data for each row, and lengths for the
@@ -65,6 +67,11 @@ class AbstractStaticSynapseDynamics(
         :param n_synapse_types: The number of synapse types
         :param max_n_synapses: The maximum number of synapses to generate
         :param max_atoms_per_core: The maximum number of atoms on a core
+        :param ring_buffer_weight_scales:
+            The ring buffer scaling of the weights for each synapse type.  This
+            does not have to be used in the storage of synapses, but could
+            instead be used when converting stored weights to ring buffer
+            weights.
         :return: (ff_data, ff_size)
         """
         raise NotImplementedError
@@ -92,7 +99,8 @@ class AbstractStaticSynapseDynamics(
     def read_static_synaptic_data(
             self, n_synapse_types: int,
             ff_size: NDArray[integer], ff_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         """
         Read the connections from the words of data in `ff_data`.
 
@@ -100,6 +108,7 @@ class AbstractStaticSynapseDynamics(
         :param ff_size:
         :param ff_data:
         :param max_atoms_per_core:
+        :param ring_buffer_weight_scales:
         :return: the connections read with dtype
             :py:const:`~.NUMPY_CONNECTORS_DTYPE`
         """

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_neuromodulation.py
@@ -32,7 +32,7 @@ from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
     NUMPY_CONNECTORS_DTYPE)
 from spynnaker.pyNN.models.neuron.plasticity.stdp.common import (
     STDP_FIXED_POINT_ONE, get_exp_lut_array)
-from spynnaker.pyNN.types import WeightsDelysIn as _Weight
+from spynnaker.pyNN.types import WeightsDelysIn as _Weight, WeightScales
 
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .abstract_generate_on_machine import (
@@ -215,7 +215,8 @@ class SynapseDynamicsNeuromodulation(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Tuple[
                 NDArray[uint32], NDArray[uint32], NDArray[uint32],
                 NDArray[uint32]]:
         weights = numpy.rint(
@@ -271,13 +272,14 @@ class SynapseDynamicsNeuromodulation(
             self, n_synapse_types: int,
             pp_size: NDArray[uint32], pp_data: List[NDArray[uint32]],
             fp_size: NDArray[uint32], fp_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         data = numpy.concatenate(fp_data)
         connections = numpy.zeros(data.size, dtype=NUMPY_CONNECTORS_DTYPE)
         connections["source"] = numpy.concatenate(
             [numpy.repeat(i, fp_size[i]) for i in range(len(fp_size))])
         connections["target"] = data & 0xFFFF
-        connections["weight"] = (data >> 16) & 0xFFFF
+        connections["weight"] = ((data >> 16) & 0xFFFF) / STDP_FIXED_POINT_ONE
         connections["delay"] = 1
         return connections
 

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -189,10 +189,10 @@ class SynapseDynamicsStatic(
         connections["weight"] = (data >> 16) & 0xFFFF
         connections["delay"] = (data & 0xFFFF) >> (
             n_neuron_id_bits + n_synapse_type_bits)
-        connections["synapse_type"] = (data >> n_neuron_id_bits) & (
+        synapse_type = (data >> n_neuron_id_bits) & (
             (1 << n_synapse_type_bits) - 1)
         connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
-            connections["synapse_type"]]
+            synapse_type]
         return connections
 
     @overrides(AbstractStaticSynapseDynamics.get_parameter_names)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_static.py
@@ -28,7 +28,7 @@ from spinn_front_end_common.utilities.constants import BYTES_PER_WORD
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
     NUMPY_CONNECTORS_DTYPE)
-from spynnaker.pyNN.types import WeightsDelysIn as _InTypes
+from spynnaker.pyNN.types import WeightsDelysIn as _InTypes, WeightScales
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 
 from .abstract_static_synapse_dynamics import AbstractStaticSynapseDynamics
@@ -120,15 +120,22 @@ class SynapseDynamicsStatic(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Tuple[
                 List[NDArray], NDArray]:
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
         n_synapse_type_bits = get_n_bits(n_synapse_types)
 
+        # Pre-scale the weights here to match the ring buffer format to make
+        # addition to the ring buffer easy
+        scaled_weights = (
+            numpy.abs(connections["weight"]) *
+            numpy.array(ring_buffer_weight_scales)[
+                connections["synapse_type"]])
+
         fixed_fixed = (
-            ((numpy.rint(numpy.abs(connections["weight"])).astype(uint32) &
-              0xFFFF) << 16) |
+            ((numpy.rint(scaled_weights).astype(uint32) & 0xFFFF) << 16) |
             (connections["delay"].astype(uint32) <<
              (n_neuron_id_bits + n_synapse_type_bits)) |
             (connections["synapse_type"].astype(uint32) << n_neuron_id_bits) |
@@ -168,8 +175,8 @@ class SynapseDynamicsStatic(
     @overrides(AbstractStaticSynapseDynamics.read_static_synaptic_data)
     def read_static_synaptic_data(
             self, n_synapse_types: int, ff_size: NDArray[integer],
-            ff_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            ff_data: List[NDArray[uint32]], max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         n_synapse_type_bits = get_n_bits(n_synapse_types)
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
@@ -182,7 +189,10 @@ class SynapseDynamicsStatic(
         connections["weight"] = (data >> 16) & 0xFFFF
         connections["delay"] = (data & 0xFFFF) >> (
             n_neuron_id_bits + n_synapse_type_bits)
-
+        connections["synapse_type"] = (data >> n_neuron_id_bits) & (
+            (1 << n_synapse_type_bits) - 1)
+        connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
+            connections["synapse_type"]]
         return connections
 
     @overrides(AbstractStaticSynapseDynamics.get_parameter_names)
@@ -203,8 +213,8 @@ class SynapseDynamicsStatic(
             self, synaptic_matrix_offset: int, delayed_matrix_offset: int,
             app_edge: ProjectionApplicationEdge,
             synapse_info: SynapseInformation, max_row_info: MaxRowInfo,
-            max_pre_atoms_per_core: int,
-            max_post_atoms_per_core: int) -> NDArray[uint32]:
+            max_pre_atoms_per_core: int, max_post_atoms_per_core: int
+            ) -> NDArray[uint32]:
         vertex = app_edge.post_vertex
         n_synapse_type_bits = get_n_bits(
             vertex.neuron_impl.get_n_synapse_types())

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -34,7 +34,7 @@ from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractConnector)
 from spynnaker.pyNN.models.neuron.plasticity.stdp.weight_dependence.\
     abstract_has_a_plus_a_minus import AbstractHasAPlusAMinus
-from spynnaker.pyNN.types import Weights
+from spynnaker.pyNN.types import Weights, WeightScales
 from spynnaker.pyNN.types import WeightsDelysIn as _In_Types
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
@@ -372,12 +372,20 @@ class SynapseDynamicsSTDP(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Tuple[
                 List[NDArray[uint32]], List[NDArray[uint32]],
                 NDArray[uint32], NDArray[uint32]]:
         n_synapse_type_bits = get_n_bits(n_synapse_types)
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
+
+        # Pre-scale the weights here to match the ring buffer format to make
+        # addition to the ring buffer easy
+        scaled_weights = (
+            numpy.abs(connections["weight"]) *
+            numpy.array(ring_buffer_weight_scales)[
+                connections["synapse_type"]])
 
         # Get the fixed data
         fixed_plastic = (
@@ -409,7 +417,7 @@ class SynapseDynamicsSTDP(
         plastic_plastic = numpy.zeros(
             len(connections) * n_half_words, dtype=uint16)
         plastic_plastic[half_word::n_half_words] = \
-            numpy.rint(numpy.abs(connections["weight"])).astype(uint16)
+            numpy.rint(scaled_weights).astype(uint16)
 
         # Convert the plastic data into groups of bytes per connection and
         # then into rows
@@ -473,8 +481,8 @@ class SynapseDynamicsSTDP(
     def read_plastic_synaptic_data(
             self, n_synapse_types: int, pp_size: NDArray[uint32],
             pp_data: List[NDArray[uint32]], fp_size: NDArray[uint32],
-            fp_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            fp_data: List[NDArray[uint32]], max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         n_rows = len(fp_size)
 
         n_synapse_type_bits = get_n_bits(n_synapse_types)
@@ -505,6 +513,10 @@ class SynapseDynamicsSTDP(
         connections["weight"] = pp_half_words
         connections["delay"] = data_fixed >> (
             n_neuron_id_bits + n_synapse_type_bits)
+        connections["synapse_type"] = (data_fixed >> n_neuron_id_bits) & (
+            (1 << n_synapse_type_bits) - 1)
+        connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
+            connections["synapse_type"]]
         return connections
 
     @overrides(AbstractPlasticSynapseDynamics.get_weight_mean)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_stdp.py
@@ -513,10 +513,10 @@ class SynapseDynamicsSTDP(
         connections["weight"] = pp_half_words
         connections["delay"] = data_fixed >> (
             n_neuron_id_bits + n_synapse_type_bits)
-        connections["synapse_type"] = (data_fixed >> n_neuron_id_bits) & (
+        synapse_type = (data_fixed >> n_neuron_id_bits) & (
             (1 << n_synapse_type_bits) - 1)
         connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
-            connections["synapse_type"]]
+            synapse_type]
         return connections
 
     @overrides(AbstractPlasticSynapseDynamics.get_weight_mean)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changable.py
@@ -31,7 +31,7 @@ from spinn_front_end_common.utilities.constants import (
 from spynnaker.pyNN.exceptions import SynapticConfigurationException
 from spynnaker.pyNN.models.neural_projections.connectors import (
     AbstractConnector)
-from spynnaker.pyNN.types import Weights
+from spynnaker.pyNN.types import Weights, WeightScales
 from spynnaker.pyNN.types import WeightsDelysIn as _In_Types
 from spynnaker.pyNN.utilities.utility_calls import get_n_bits
 from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
@@ -204,7 +204,8 @@ class SynapseDynamicsWeightChangable(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Tuple[
                 List[NDArray[uint32]], List[NDArray[uint32]],
                 NDArray[uint32], NDArray[uint32]]:
         raise NotImplementedError(
@@ -236,7 +237,8 @@ class SynapseDynamicsWeightChangable(
             self, n_synapse_types: int, pp_size: NDArray[uint32],
             pp_data: List[NDArray[uint32]], fp_size: NDArray[uint32],
             fp_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         logger.warning(
             "Weights are only changed when a pre-spike arrives after a"
             " change-spike has been received, and so the weights might"
@@ -265,6 +267,10 @@ class SynapseDynamicsWeightChangable(
         connections["weight"] = pp_half_words
         connections["delay"] = data_fixed >> (
             n_neuron_id_bits + n_synapse_type_bits)
+        synapse_type = (data_fixed >> n_neuron_id_bits) & (
+            (1 << n_synapse_type_bits) - 1)
+        connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
+            synapse_type]
         return connections
 
     @overrides(AbstractPlasticSynapseDynamics.get_weight_mean)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -145,7 +145,7 @@ class SynapseDynamicsWeightChanger(
                 NDArray[uint32]]:
 
         # Pre-scale the weights here to match the ring buffer format to make
-        # addition to the ring buffer easy
+        # addition to the weights easier
         scaled_weights = (
             numpy.abs(connections["weight"]) *
             numpy.array(ring_buffer_weight_scales)[

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -202,6 +202,7 @@ class SynapseDynamicsWeightChanger(
             ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         data = numpy.concatenate(fp_data)
         weight = ((data >> 16) & 0xFFFF).astype(int16)
+        n_synapse_type_bits = get_n_bits(n_synapse_types)
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
         connections = numpy.zeros(data.size, dtype=NUMPY_CONNECTORS_DTYPE)
@@ -210,7 +211,8 @@ class SynapseDynamicsWeightChanger(
         connections["target"] = data & neuron_id_mask
         connections["weight"] = weight
         connections["delay"] = 1
-        synapse_type = data >> n_neuron_id_bits
+        synapse_type = (
+            (data >> n_neuron_id_bits) & ((1 << n_synapse_type_bits) - 1))
         connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
             synapse_type]
         return connections

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -210,9 +210,9 @@ class SynapseDynamicsWeightChanger(
         connections["target"] = data & neuron_id_mask
         connections["weight"] = weight
         connections["delay"] = 1
-        connections["synapse_type"] = data >> n_neuron_id_bits
+        synapse_type = data >> n_neuron_id_bits
         connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
-            connections["synapse_type"]]
+            synapse_type]
         return connections
 
     @overrides(AbstractPlasticSynapseDynamics.get_parameter_names)

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -28,11 +28,11 @@ from spynnaker.pyNN.exceptions import (
     SynapticConfigurationException, InvalidParameterType)
 from spynnaker.pyNN.models.neuron.synapse_dynamics.types import (
     NUMPY_CONNECTORS_DTYPE)
+from spynnaker.pyNN.types import WeightScales
 from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .abstract_generate_on_machine import AbstractGenerateOnMachine
 from .abstract_generate_on_machine import MatrixGeneratorID
 from .synapse_dynamics_weight_changable import SynapseDynamicsWeightChangable
-from spynnaker.pyNN.types import WeightScales
 
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.neural_projections import (

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -153,7 +153,7 @@ class SynapseDynamicsWeightChanger(
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
         fixed_plastic = (
-            ((scaled_weights.astype(uint32) & 0xFFFF) << 16) |
+            ((numpy.rint(scaled_weights).astype(uint32) & 0xFFFF) << 16) |
             (connections["synapse_type"].astype(uint32) << n_neuron_id_bits) |
             (connections["target"] & neuron_id_mask))
         fixed_plastic_rows = self.convert_per_connection_data_to_rows(

--- a/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
+++ b/spynnaker/pyNN/models/neuron/synapse_dynamics/synapse_dynamics_weight_changer.py
@@ -32,6 +32,7 @@ from .abstract_plastic_synapse_dynamics import AbstractPlasticSynapseDynamics
 from .abstract_generate_on_machine import AbstractGenerateOnMachine
 from .abstract_generate_on_machine import MatrixGeneratorID
 from .synapse_dynamics_weight_changable import SynapseDynamicsWeightChangable
+from spynnaker.pyNN.types import WeightScales
 
 if TYPE_CHECKING:
     from spynnaker.pyNN.models.neural_projections import (
@@ -138,14 +139,21 @@ class SynapseDynamicsWeightChanger(
             self, connections: ConnectionsArray,
             connection_row_indices: NDArray[integer], n_rows: int,
             n_synapse_types: int,
-            max_n_synapses: int, max_atoms_per_core: int) -> Tuple[
+            max_n_synapses: int, max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> Tuple[
                 NDArray[uint32], NDArray[uint32], NDArray[uint32],
                 NDArray[uint32]]:
-        weights = numpy.rint(numpy.abs(connections["weight"]))
+
+        # Pre-scale the weights here to match the ring buffer format to make
+        # addition to the ring buffer easy
+        scaled_weights = (
+            numpy.abs(connections["weight"]) *
+            numpy.array(ring_buffer_weight_scales)[
+                connections["synapse_type"]])
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
         neuron_id_mask = (1 << n_neuron_id_bits) - 1
         fixed_plastic = (
-            ((weights.astype(uint32) & 0xFFFF) << 16) |
+            ((scaled_weights.astype(uint32) & 0xFFFF) << 16) |
             (connections["synapse_type"].astype(uint32) << n_neuron_id_bits) |
             (connections["target"] & neuron_id_mask))
         fixed_plastic_rows = self.convert_per_connection_data_to_rows(
@@ -190,7 +198,8 @@ class SynapseDynamicsWeightChanger(
             self, n_synapse_types: int,
             pp_size: NDArray[uint32], pp_data: List[NDArray[uint32]],
             fp_size: NDArray[uint32], fp_data: List[NDArray[uint32]],
-            max_atoms_per_core: int) -> ConnectionsArray:
+            max_atoms_per_core: int,
+            ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
         data = numpy.concatenate(fp_data)
         weight = ((data >> 16) & 0xFFFF).astype(int16)
         n_neuron_id_bits = get_n_bits(max_atoms_per_core)
@@ -201,6 +210,9 @@ class SynapseDynamicsWeightChanger(
         connections["target"] = data & neuron_id_mask
         connections["weight"] = weight
         connections["delay"] = 1
+        connections["synapse_type"] = data >> n_neuron_id_bits
+        connections["weight"] /= numpy.array(ring_buffer_weight_scales)[
+            connections["synapse_type"]]
         return connections
 
     @overrides(AbstractPlasticSynapseDynamics.get_parameter_names)

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -406,7 +406,7 @@ def convert_to_connections(
         The length of each row in the data
     :param n_synapse_types:
         The number of synapse types in total
-    :param weight_scales:
+    :param ring_buffer_weight_scales:
         The weight scaling of each synapse type
     :param data:
         The raw data containing the synapses

--- a/spynnaker/pyNN/models/neuron/synapse_io.py
+++ b/spynnaker/pyNN/models/neuron/synapse_io.py
@@ -217,7 +217,8 @@ def _get_allowed_row_length(
 def get_synapses(
         connections: ConnectionsArray, synapse_info: SynapseInformation,
         n_delay_stages: int, n_synapse_types: int,
-        weight_scales: WeightScales, app_edge: ProjectionApplicationEdge,
+        ring_buffer_weight_scales: WeightScales,
+        app_edge: ProjectionApplicationEdge,
         max_row_info: MaxRowInfo, gen_undelayed: bool, gen_delayed: bool,
         max_atoms_per_core: int) -> Tuple[_RowData, _RowData]:
     """
@@ -233,7 +234,8 @@ def get_synapses(
         The number of delay stages in total to be represented
     :param n_synapse_types:
         The number of synapse types in total to be represented
-    :param weight_scales: The scaling of the weights for each synapse type
+    :param ring_buffer_weight_scales:
+        The scaling of the weights for the ring buffers of each synapse type
     :param app_edge:
         The incoming machine edge that the synapses are on
     :param max_row_info:
@@ -260,11 +262,6 @@ def get_synapses(
         connections["delay"] *
         SpynnakerDataView.get_simulation_time_step_per_ms())
 
-    # Scale weights
-    if not synapse_info.synapse_type_from_dynamics:
-        connections["weight"] = (connections["weight"] * weight_scales[
-            synapse_info.synapse_type])
-
     # Split the connections up based on the delays
     if max_delay is not None:
         plastic_delay_mask = (connections["delay"] <= max_delay)
@@ -285,7 +282,8 @@ def get_synapses(
             app_edge.pre_vertex.n_atoms, n_synapse_types,
             synapse_info.synapse_dynamics,
             max_row_info.undelayed_max_n_synapses,
-            max_row_info.undelayed_max_words, max_atoms_per_core)
+            max_row_info.undelayed_max_words, max_atoms_per_core,
+            ring_buffer_weight_scales)
         del undelayed_row_indices
     del undelayed_connections
 
@@ -311,7 +309,8 @@ def get_synapses(
             app_edge.pre_vertex.n_atoms * n_delay_stages,
             n_synapse_types, synapse_info.synapse_dynamics,
             max_row_info.delayed_max_n_synapses,
-            max_row_info.delayed_max_words, max_atoms_per_core)
+            max_row_info.delayed_max_words, max_atoms_per_core,
+            ring_buffer_weight_scales)
         del delayed_row_indices
     del delayed_connections
 
@@ -322,7 +321,8 @@ def _get_row_data(
         connections: ConnectionsArray, row_indices: NDArray[numpy.integer],
         n_rows: int, n_synapse_types: int,
         synapse_dynamics: AbstractSynapseDynamics, max_row_n_synapses: int,
-        max_row_n_words: int, max_atoms_per_core: int) -> _RowData:
+        max_row_n_words: int, max_atoms_per_core: int,
+        ring_buffer_weight_scales: WeightScales) -> _RowData:
     """
     :param connections:
         The connections to convert; the dtype is
@@ -337,6 +337,8 @@ def _get_row_data(
     :param max_row_n_synapses: The maximum number of synapses in a row
     :param max_row_n_words: The maximum number of words in a row
     :param max_atoms_per_core: The maximum number of atoms per core
+    :param ring_buffer_weight_scales:
+        The scaling of the weights for the ring buffers of each synapse type
     """
     fp_data: Union[NDArray[uint32], List[NDArray[uint32]]]
     pp_data: Union[NDArray[uint32], List[NDArray[uint32]]]
@@ -344,7 +346,8 @@ def _get_row_data(
         # Get the static data
         ff_data, ff_size = synapse_dynamics.get_static_synaptic_data(
             connections, row_indices, n_rows, n_synapse_types,
-            max_row_n_synapses, max_atoms_per_core)
+            max_row_n_synapses, max_atoms_per_core,
+            ring_buffer_weight_scales)
 
         # Blank the plastic data
         fp_data = numpy.zeros((n_rows, 0), dtype=uint32)
@@ -363,7 +366,8 @@ def _get_row_data(
         fp_data, pp_data, fp_size, pp_size = \
             synapse_dynamics.get_plastic_synaptic_data(
                 connections, row_indices, n_rows, n_synapse_types,
-                max_row_n_synapses, max_atoms_per_core)
+                max_row_n_synapses, max_atoms_per_core,
+                ring_buffer_weight_scales)
 
     # Add some padding
     row_lengths = [
@@ -385,7 +389,7 @@ def _get_row_data(
 def convert_to_connections(
         synapse_info: SynapseInformation, post_vertex_slice: Slice,
         n_pre_atoms: int, max_row_length: int, n_synapse_types: int,
-        weight_scales: WeightScales,
+        ring_buffer_weight_scales: WeightScales,
         data: bytearray | bytes | memoryview | NDArray | None,
         delayed: bool, post_vertex_max_delay_ticks: int,
         max_atoms_per_core: int) -> ConnectionsArray:
@@ -428,12 +432,14 @@ def convert_to_connections(
         # Read static data
         connections = _read_static_data(
             dynamics, n_pre_atoms, n_synapse_types, row_data, delayed,
-            post_vertex_max_delay_ticks, max_atoms_per_core)
+            post_vertex_max_delay_ticks, max_atoms_per_core,
+            ring_buffer_weight_scales)
     elif isinstance(dynamics, AbstractPlasticSynapseDynamics):
         # Read plastic data
         connections = _read_plastic_data(
             dynamics, n_pre_atoms, n_synapse_types, row_data, delayed,
-            post_vertex_max_delay_ticks, max_atoms_per_core)
+            post_vertex_max_delay_ticks, max_atoms_per_core,
+            ring_buffer_weight_scales)
     else:
         raise TypeError(f"{dynamics=} has unexpected type {type(dynamics)}")
 
@@ -448,14 +454,15 @@ def convert_to_connections(
     connections = __convert_sources_and_targets(
         connections, synapse_info.pre_vertex, post_vertex_slice)
 
-    # Return the connections after appropriate scaling
-    return _rescale_connections(connections, weight_scales, synapse_info)
+    # Return the delays values to milliseconds
+    connections["delay"] /= SpynnakerDataView.get_simulation_time_step_per_ms()
+    return connections
 
 
 def read_all_synapses(
         data: NDArray[uint32], delayed_data: NDArray[uint32],
         synapse_info: SynapseInformation, n_synapse_types: int,
-        weight_scales: WeightScales, post_vertex_slice: Slice,
+        ring_buffer_weight_scales: WeightScales, post_vertex_slice: Slice,
         n_pre_atoms: int, post_vertex_max_delay_ticks: int,
         max_row_info: MaxRowInfo, max_atoms_per_core: int
         ) -> ConnectionsArray:
@@ -471,8 +478,8 @@ def read_all_synapses(
         The synapse info that generated the synapses
     :param n_synapse_types:
         The total number of synapse types available
-    :param weight_scales:
-        A weight scale for each synapse type
+    :param ring_buffer_weight_scales:
+        The weight scale of the ring buffers for each synapse type
     :param n_pre_atoms: The number of atoms in the pre-vertex
     :param post_vertex_slice:
         The slice of the post-vertex to read the synapses for
@@ -490,12 +497,12 @@ def read_all_synapses(
     delayed_max_row_length = max_row_info.delayed_max_words
     connections.append(convert_to_connections(
         synapse_info, post_vertex_slice, n_pre_atoms, max_row_length,
-        n_synapse_types, weight_scales, data, False,
+        n_synapse_types, ring_buffer_weight_scales, data, False,
         post_vertex_max_delay_ticks, max_atoms_per_core))
     connections.append(convert_to_connections(
-        synapse_info, post_vertex_slice, n_pre_atoms,
-        delayed_max_row_length, n_synapse_types, weight_scales, delayed_data,
-        True, post_vertex_max_delay_ticks, max_atoms_per_core))
+        synapse_info, post_vertex_slice, n_pre_atoms, delayed_max_row_length,
+        n_synapse_types, ring_buffer_weight_scales, delayed_data, True,
+        post_vertex_max_delay_ticks, max_atoms_per_core))
 
     # Join the connections into a single list and return it
     return numpy.concatenate(connections)
@@ -527,8 +534,8 @@ def _parse_static_data(
 def _read_static_data(
         dynamics: AbstractStaticSynapseDynamics, n_pre_atoms: int,
         n_synapse_types: int, row_data: _RowData, delayed: bool,
-        post_vertex_max_delay_ticks: int,
-        max_atoms_per_core: int) -> ConnectionsArray:
+        post_vertex_max_delay_ticks: int, max_atoms_per_core: int,
+        ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
     """
     Read static data from row data.
 
@@ -542,6 +549,8 @@ def _read_static_data(
     :param delayed: True if data should be considered delayed
     :param post_vertex_max_delay_ticks: post vertex delay maximum
     :param max_atoms_per_core: The maximum number of atoms on a core
+    :param ring_buffer_weight_scales:
+        The scaling of the weights for the ring buffers of each synapse type
     :return: the connections read with dtype
         :py:const:`~.NUMPY_CONNECTORS_DTYPE`
     """
@@ -549,7 +558,8 @@ def _read_static_data(
         return numpy.zeros(0, dtype=NUMPY_CONNECTORS_DTYPE)
     ff_size, ff_data = _parse_static_data(row_data, dynamics)
     connections = dynamics.read_static_synaptic_data(
-        n_synapse_types, ff_size, ff_data, max_atoms_per_core)
+        n_synapse_types, ff_size, ff_data, max_atoms_per_core,
+        ring_buffer_weight_scales)
     if delayed:
         n_synapses = dynamics.get_n_synapses_in_rows(ff_size)
         connections = _convert_delayed_data(
@@ -591,8 +601,8 @@ def _parse_plastic_data(
 def _read_plastic_data(
         dynamics: AbstractPlasticSynapseDynamics, n_pre_atoms: int,
         n_synapse_types: int, row_data: Optional[_RowData], delayed: bool,
-        post_vertex_max_delay_ticks: int,
-        max_atoms_per_core: int) -> ConnectionsArray:
+        post_vertex_max_delay_ticks: int, max_atoms_per_core: int,
+        ring_buffer_weight_scales: WeightScales) -> ConnectionsArray:
     """
     Read plastic data from raw data.
 
@@ -606,6 +616,8 @@ def _read_plastic_data(
     :param delayed: True if data should be considered delayed
     :param post_vertex_max_delay_ticks: post vertex delay maximum
     :param max_atoms_per_core: The maximum number of atoms on a core
+    :param ring_buffer_weight_scales:
+        The scaling of the weights for the ring buffers of each synapse type
     :return: the connections read with dtype
         :py:const:`~.NUMPY_CONNECTORS_DTYPE`
     """
@@ -615,30 +627,13 @@ def _read_plastic_data(
         row_data, dynamics)
     connections = dynamics.read_plastic_synaptic_data(
         n_synapse_types, pp_size, pp_data, fp_size, fp_data,
-        max_atoms_per_core)
+        max_atoms_per_core, ring_buffer_weight_scales)
 
     if delayed:
         n_synapses = dynamics.get_n_synapses_in_rows(pp_size, fp_size)
         connections = _convert_delayed_data(
             n_synapses, n_pre_atoms, connections,
             post_vertex_max_delay_ticks)
-    return connections
-
-
-def _rescale_connections(
-        connections: ConnectionsArray, weight_scales: WeightScales,
-        synapse_info: SynapseInformation) -> ConnectionsArray:
-    """
-    Scale the connection data into machine values.
-
-    :param connections: The connections to be rescaled
-    :param weight_scales: The weight scale of each synapse type
-    :param synapse_info: The synapse information of the connections
-    """
-    # Return the delays values to milliseconds
-    connections["delay"] /= SpynnakerDataView.get_simulation_time_step_per_ms()
-    # Undo the weight scaling
-    connections["weight"] /= weight_scales[synapse_info.synapse_type]
     return connections
 
 


### PR DESCRIPTION
Move responsibility for weight scaling to the synapse dynamics object.  Although this has little effect on the sPyNNaker code itself, this has been done in recognition that NestML wants to represent weights differently in the synapses and the ring buffers,  This is a valid option - the scaling can be done at the time of addition of weights to the ring buffers to allow weights to be represented differently in the synapses.  

Note that this also helps with STDP rules where the weight representation might have more fractional bits to allow small updates to occur, even if those updates can't immediately affect the inputs to the ring buffers.  Multiple updates however might do so!