### PR TITLE
Clean up comments related to traces

### DIFF
--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -16,7 +16,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: C Actions
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -20,7 +20,7 @@
 # that takes a long time in sPyNNaker right now.
 
 name: Python Actions
-on: [push]
+on: [push, pull_request]
 
 jobs:
   call:

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_nearest_pair_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_nearest_pair_impl.h
@@ -99,14 +99,14 @@ static inline update_state_t timing_apply_pre_spike(
 
     // Get time of event relative to last post-synaptic event
     uint32_t time_since_last_post = time - last_post_time;
-    int32_t decayed_o1 = maths_lut_exponential_decay(
+    int32_t decayed_trace = maths_lut_exponential_decay(
         time_since_last_post, tau_minus_lookup);
 
-    log_debug("\t\t\ttime_since_last_post=%u, decayed_o1=%d\n",
-            time_since_last_post, decayed_o1);
+    log_debug("\t\t\ttime_since_last_post=%u, decayed_trace=%d\n",
+            time_since_last_post, decayed_trace);
 
     // Apply depression to state (which is a weight_state)
-    return weight_one_term_apply_depression(previous_state, decayed_o1);
+    return weight_one_term_apply_depression(previous_state, decayed_trace);
 }
 
 //---------------------------------------

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_pair_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_pair_impl.h
@@ -53,7 +53,7 @@ static inline post_trace_t timing_decay_post(
     // Get time since last spike
     uint32_t delta_time = time - last_time;
 
-    // Decay previous o1 and o2 traces
+    // Decay previous trace
     return (post_trace_t) STDP_FIXED_MUL_16X16(last_trace,
             maths_lut_exponential_decay(delta_time, tau_minus_lookup));
 }
@@ -67,16 +67,15 @@ static inline post_trace_t timing_decay_post(
 static inline post_trace_t timing_add_post_spike(
         uint32_t time, uint32_t last_time, post_trace_t last_trace) {
 
-    // Decay previous o1 and o2 traces
-    int16_t decayed_o1_trace = timing_decay_post(time, last_time, last_trace);
+    // Decay previous trace
+    int16_t decayed_trace = timing_decay_post(time, last_time, last_trace);
 
     // Add energy caused by new spike to trace
-    // **NOTE** o2 trace is pre-multiplied by a3_plus
-    int16_t new_o1_trace = decayed_o1_trace + STDP_FIXED_POINT_ONE;
+    int16_t new_trace = decayed_trace + STDP_FIXED_POINT_ONE;
 
     // Return new pre- synaptic event with decayed trace values with energy
     // for new spike added
-    return (post_trace_t) new_o1_trace;
+    return (post_trace_t) new_trace;
 }
 
 //---------------------------------------
@@ -91,18 +90,18 @@ static inline pre_trace_t timing_add_pre_spike(
     // Get time since last spike
     uint32_t delta_time = time - last_time;
 
-    // Decay previous r1 and r2 traces
-    int32_t decayed_r1_trace = STDP_FIXED_MUL_16X16(last_trace,
+    // Decay previous trace
+    int32_t decayed_trace = STDP_FIXED_MUL_16X16(last_trace,
         maths_lut_exponential_decay(delta_time, tau_plus_lookup));
 
     // Add energy caused by new spike to trace
-    int32_t new_r1_trace = decayed_r1_trace + STDP_FIXED_POINT_ONE;
+    int32_t new_trace = decayed_trace + STDP_FIXED_POINT_ONE;
 
-    log_debug("\tdelta_time=%u, r1=%d\n", delta_time, new_r1_trace);
+    log_debug("\tdelta_time=%u, trace=%d\n", delta_time, new_trace);
 
     // Return new pre-synaptic event with decayed trace values with energy
     // for new spike added
-    return (pre_trace_t) new_r1_trace;
+    return (pre_trace_t) new_trace;
 }
 
 //---------------------------------------
@@ -123,14 +122,14 @@ static inline update_state_t timing_apply_pre_spike(
 
     // Get time of event relative to last post-synaptic event
     uint32_t time_since_last_post = time - last_post_time;
-    int32_t decayed_o1 = STDP_FIXED_MUL_16X16(last_post_trace,
+    int32_t decayed_trace = STDP_FIXED_MUL_16X16(last_post_trace,
         maths_lut_exponential_decay(time_since_last_post, tau_minus_lookup));
 
-    log_debug("\t\t\ttime_since_last_post_event=%u, decayed_o1=%d\n",
-            time_since_last_post, decayed_o1);
+    log_debug("\t\t\ttime_since_last_post_event=%u, decayed_trace=%d\n",
+            time_since_last_post, decayed_trace);
 
     // Apply depression to state (which is a weight_state)
-    return weight_one_term_apply_depression(previous_state, decayed_o1);
+    return weight_one_term_apply_depression(previous_state, decayed_trace);
 }
 
 //---------------------------------------
@@ -152,14 +151,14 @@ static inline update_state_t timing_apply_post_spike(
     // Get time of event relative to last pre-synaptic event
     uint32_t time_since_last_pre = time - last_pre_time;
     if (time_since_last_pre > 0) {
-        int32_t decayed_r1 = STDP_FIXED_MUL_16X16(last_pre_trace,
+        int32_t decayed_trace = STDP_FIXED_MUL_16X16(last_pre_trace,
             maths_lut_exponential_decay(time_since_last_pre, tau_plus_lookup));
 
-        log_debug("\t\t\ttime_since_last_pre_event=%u, decayed_r1=%d\n",
-                time_since_last_pre, decayed_r1);
+        log_debug("\t\t\ttime_since_last_pre_event=%u, decayed_trace=%d\n",
+                time_since_last_pre, decayed_trace);
 
         // Apply potentiation to state (which is a weight_state)
-        return weight_one_term_apply_potentiation(previous_state, decayed_r1);
+        return weight_one_term_apply_potentiation(previous_state, decayed_trace);
     } else {
         return previous_state;
     }

--- a/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_vogels_2011_impl.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/timing_dependence/timing_vogels_2011_impl.h
@@ -139,14 +139,14 @@ static inline update_state_t timing_apply_pre_spike(
     uint32_t time_since_last_post = time - last_post_time;
     int32_t exponential_decay = maths_lut_exponential_decay(
             time_since_last_post, tau_lookup);
-    int32_t decayed_o1 = STDP_FIXED_MUL_16X16(last_post_trace, exponential_decay)
+    int32_t decayed_trace = STDP_FIXED_MUL_16X16(last_post_trace, exponential_decay)
             - plasticity_trace_region_data.alpha;
 
-    log_debug("\t\t\ttime_since_last_post_event=%u, decayed_o1=%d\n",
-            time_since_last_post, decayed_o1);
+    log_debug("\t\t\ttime_since_last_post_event=%u, decayed_trace=%d\n",
+            time_since_last_post, decayed_trace);
 
     // Apply potentiation to state (which is a weight_state)
-    return weight_one_term_apply_potentiation(previous_state, decayed_o1);
+    return weight_one_term_apply_potentiation(previous_state, decayed_trace);
 
 }
 //---------------------------------------


### PR DESCRIPTION
Tiny cleanup of the naming and comments related to synaptic traces. (I believe "o1" and "o2" are related to triplet STDP rules, that's probably where this came from.)