### PR TITLE
More flexible STDP make

### DIFF
--- a/neural_modelling/make/neural_build.mk
+++ b/neural_modelling/make/neural_build.mk
@@ -46,7 +46,6 @@ POPULATION_TABLE_IMPL := binary_search
 # Define the directories
 NEURON_DIR := $(abspath $(NEURAL_MODELLING_DIRS)/src)
 NEURON_MODIFIED_DIR := $(abspath $(NEURAL_MODELLING_DIRS)/modified_src)/
-
 SOURCE_DIRS += $(NEURON_DIR):$(NEURON_MODIFIED_DIR)
 
 include $(CURRENT_DIR)/funcs.mk
@@ -116,21 +115,6 @@ else
     SYNAPSE_DYNAMICS_C := $(call replace_source_dirs,$(SYNAPSE_DYNAMICS))
     SYNAPSE_DYNAMICS := $(call strip_source_dirs,$(SYNAPSE_DYNAMICS))
     SYNAPSE_DYNAMICS_O := $(BUILD_DIR)$(SYNAPSE_DYNAMICS:%.c=%.o)
-
-    SYNAPSE_DYNAMICS_STATIC := neuron/plasticity/synapse_dynamics_static_impl.c
-    STDP_ENABLED = 0
-    ifneq ($(SYNAPSE_DYNAMICS), $(SYNAPSE_DYNAMICS_STATIC))
-        ifndef SYNAPSE_DYNAMICS_CUSTOM
-	        STDP_ENABLED = 1
-
-	        ifndef TIMING_DEPENDENCE_H
-	            $(error TIMING_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
-	        endif
-	        ifndef WEIGHT_DEPENDENCE_H
-	            $(error WEIGHT_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
-	        endif
-	    endif
-    endif
 endif
 
 ifdef WEIGHT_DEPENDENCE
@@ -138,6 +122,7 @@ ifdef WEIGHT_DEPENDENCE
     WEIGHT_DEPENDENCE_C := $(call replace_source_dirs,$(WEIGHT_DEPENDENCE))
     WEIGHT_DEPENDENCE := $(call strip_source_dirs,$(WEIGHT_DEPENDENCE))
     WEIGHT_DEPENDENCE_O := $(BUILD_DIR)$(WEIGHT_DEPENDENCE:%.c=%.o)
+    STDP_INCLUDES := $(STDP_INCLUDES) -include $(WEIGHT_DEPENDENCE_H) 
 endif
 
 ifdef TIMING_DEPENDENCE
@@ -145,13 +130,12 @@ ifdef TIMING_DEPENDENCE
     TIMING_DEPENDENCE_C := $(call replace_source_dirs,$(TIMING_DEPENDENCE))
     TIMING_DEPENDENCE := $(call strip_source_dirs,$(TIMING_DEPENDENCE))
     TIMING_DEPENDENCE_O := $(BUILD_DIR)$(TIMING_DEPENDENCE:%.c=%.o)
+    STDP_INCLUDES := $(STDP_INCLUDES) -include $(TIMING_DEPENDENCE_H) 
 endif
 
-SYNGEN_ENABLED = 1
 ifndef SYNAPTOGENESIS_DYNAMICS
     SYNAPTOGENESIS_DYNAMICS := neuron/structural_plasticity/synaptogenesis_dynamics_static_impl.c
     SYNAPTOGENESIS_DYNAMICS_C := $(NEURON_MODIFIED_DIR)$(SYNAPTOGENESIS_DYNAMICS)
-    SYNGEN_ENABLED = 0
 else
     SYNAPTOGENESIS_DYNAMICS_C := $(call replace_source_dirs,$(SYNAPTOGENESIS_DYNAMICS))
     SYNAPTOGENESIS_DYNAMICS := $(call strip_source_dirs,$(SYNAPTOGENESIS_DYNAMICS))
@@ -172,6 +156,7 @@ ifdef PARTNER_SELECTION
     PARTNER_SELECTION_C := $(call replace_source_dirs,$(PARTNER_SELECTION))
     PARTNER_SELECTION := $(call strip_source_dirs,$(PARTNER_SELECTION))
     PARTNER_SELECTION_O := $(BUILD_DIR)$(PARTNER_SELECTION:%.c=%.o)
+    SYNGEN_INCLUDES:= $(SYNGEN_INCLUDES) -include $(PARTNER_SELECTION_H) 
 endif
 
 ifdef FORMATION
@@ -179,6 +164,7 @@ ifdef FORMATION
     FORMATION_C := $(call replace_source_dirs,$(FORMATION))
     FORMATION := $(call strip_source_dirs,$(FORMATION))
     FORMATION_O := $(BUILD_DIR)$(FORMATION:%.c=%.o)
+    SYNGEN_INCLUDES:= $(SYNGEN_INCLUDES) -include $(FORMATION_H) 
 endif
 
 ifdef ELIMINATION
@@ -186,6 +172,7 @@ ifdef ELIMINATION
     ELIMINATION_C := $(call replace_source_dirs,$(ELIMINATION))
     ELIMINATION := $(call strip_source_dirs,$(ELIMINATION))
     ELIMINATION_O := $(BUILD_DIR)$(ELIMINATION:%.c=%.o)
+    SYNGEN_INCLUDES:= $(SYNGEN_INCLUDES) -include $(ELIMINATION_H) 
 endif
 
 OTHER_SOURCES_CONVERTED := $(call strip_source_dirs,$(OTHER_SOURCES))
@@ -205,7 +192,7 @@ include $(FEC_INSTALL_DIR)/make/fec.mk
 FEC_OPT = $(OTIME)
 
 # Synapse build rules
-SYNAPSE_TYPE_COMPILE = $(CC) -DLOG_LEVEL=$(SYNAPSE_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED)
+SYNAPSE_TYPE_COMPILE = $(CC) -DLOG_LEVEL=$(SYNAPSE_DEBUG) $(CFLAGS)
 
 $(BUILD_DIR)neuron/c_main.o: $(NEURON_MODIFIED_DIR)neuron/c_main.c
 	#c_main.c
@@ -227,49 +214,27 @@ $(BUILD_DIR)neuron/population_table/population_table_binary_search_impl.o: $(NEU
 	-@mkdir -p $(dir $@)
 	$(SYNAPSE_TYPE_COMPILE) -o $@ $<
 
-SYNGEN_INCLUDES:=
-ifeq ($(SYNGEN_ENABLED), 1)
-    SYNGEN_INCLUDES:= -include $(PARTNER_SELECTION_H) -include $(FORMATION_H) -include $(ELIMINATION_H)
-endif
+STDP_COMPILE = $(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) $(STDP_INCLUDES)
 
-#STDP Build rules If and only if STDP used
-ifeq ($(STDP_ENABLED), 1)
-    STDP_INCLUDES:= -include $(WEIGHT_DEPENDENCE_H) -include $(TIMING_DEPENDENCE_H)
-    STDP_COMPILE = $(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED) -DSYNGEN_ENABLED=$(SYNGEN_ENABLED) $(STDP_INCLUDES)
-
-    $(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
+$(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
 	# SYNAPSE_DYNAMICS_O stdp
 	-@mkdir -p $(dir $@)
 	$(STDP_COMPILE) -o $@ $<
 
-    $(SYNAPTOGENESIS_DYNAMICS_O): $(SYNAPTOGENESIS_DYNAMICS_C)
+$(SYNAPTOGENESIS_DYNAMICS_O): $(SYNAPTOGENESIS_DYNAMICS_C)
 	# SYNAPTOGENESIS_DYNAMICS_O stdp
 	-@mkdir -p $(dir $@)
 	$(STDP_COMPILE) $(SYNGEN_INCLUDES) -o $@ $<
 
-    $(BUILD_DIR)neuron/plasticity/common/post_events.o: $(NEURON_MODIFIED_DIR)neuron/plasticity/common/post_events.c
+$(BUILD_DIR)neuron/plasticity/common/post_events.o: $(NEURON_MODIFIED_DIR)neuron/plasticity/common/post_events.c
 	# plasticity/common/post_events.c
 	-@mkdir -p $(dir $@)
 	$(STDP_COMPILE) -o $@ $<
 
-else
-    $(SYNAPTOGENESIS_DYNAMICS_O): $(SYNAPTOGENESIS_DYNAMICS_C)
-	# $(SYNAPTOGENESIS_DYNAMICS) Synapese
-	-@mkdir -p $(dir $@)
-	$(SYNAPSE_TYPE_COMPILE) $(SYNGEN_INCLUDES) -o $@ $<
-
-    $(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
-	# SYNAPSE_DYNAMICS_O Synapese
-	-@mkdir -p $(dir $@)
-	$(SYNAPSE_TYPE_COMPILE) -o $@ $<
-
-endif
-
 $(WEIGHT_DEPENDENCE_O): $(WEIGHT_DEPENDENCE_C) $(SYNAPSE_TYPE_H) $(MAKEFILE_LIST)
 	# WEIGHT_DEPENDENCE_O
 	-@mkdir -p $(dir $@)
-	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) \
-	        -o $@ $<
+	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -o $@ $<
 
 $(TIMING_DEPENDENCE_O): $(TIMING_DEPENDENCE_C) $(SYNAPSE_TYPE_H) \
                         $(WEIGHT_DEPENDENCE_H) $(MAKEFILE_LIST)
@@ -304,4 +269,4 @@ $(BUILD_DIR)neuron/neuron.o: $(NEURON_MODIFIED_DIR)neuron/neuron.c $(NEURON_INCL
 .PRECIOUS: $(NEURON_MODIFIED_DIR)%.c $(NEURON_MODIFIED_DIR)%.h $(LOG_DICT_FILE) $(EXTRA_PRECIOUS)
 
 clean:
-	$(RM) -r $(BUILD_DIR)
+	$(RM) -r $(BUILD_DIR) $(NEURON_MODIFIED_DIR)

--- a/neural_modelling/make/neuron_only_build.mk
+++ b/neural_modelling/make/neuron_only_build.mk
@@ -84,14 +84,15 @@ else
 		    CURRENT_SOURCE_H := $(call replace_source_dirs,$(CURRENT_SOURCE_H))
 		endif
 
-		NEURON_INCLUDES := \
-	      -include $(NEURON_MODEL_H) \
-	      -include $(SYNAPSE_TYPE_H) \
-	      -include $(INPUT_TYPE_H) \
-	      -include $(THRESHOLD_TYPE_H) \
-	      -include $(ADDITIONAL_INPUT_H) \
-	      -include $(CURRENT_SOURCE_H) \
-	      -include $(NEURON_IMPL_H)
+		NEURON_INCLUDE_FILES := \
+	      $(NEURON_MODEL_H) \
+	      $(SYNAPSE_TYPE_H) \
+	      $(INPUT_TYPE_H) \
+	      $(THRESHOLD_TYPE_H) \
+	      $(ADDITIONAL_INPUT_H) \
+	      $(CURRENT_SOURCE_H) \
+	      $(NEURON_IMPL_H)
+		NEURON_INCLUDES := $(NEURON_INCLUDE_FILES:%=-include %)
     endif
 endif
 
@@ -121,4 +122,4 @@ $(BUILD_DIR)neuron/neuron.o: $(NEURON_MODIFIED_DIR)neuron/neuron.c $(NEURON_MODE
 .PRECIOUS: $(NEURON_MODIFIED_DIR)%.c $(NEURON_MODIFIED_DIR)%.h $(LOG_DICT_FILE) $(EXTRA_PRECIOUS)
 
 clean:
-	$(RM) -r $(BUILD_DIR)
+	$(RM) -r $(BUILD_DIR) $(NEURON_MODIFIED_DIR)

--- a/neural_modelling/make/synapse_build.mk
+++ b/neural_modelling/make/synapse_build.mk
@@ -51,19 +51,6 @@ else
     SYNAPSE_DYNAMICS_C := $(call replace_source_dirs,$(SYNAPSE_DYNAMICS))
     SYNAPSE_DYNAMICS := $(call strip_source_dirs,$(SYNAPSE_DYNAMICS))
     SYNAPSE_DYNAMICS_O := $(BUILD_DIR)$(SYNAPSE_DYNAMICS:%.c=%.o)
-
-    SYNAPSE_DYNAMICS_STATIC := neuron/plasticity/synapse_dynamics_static_impl.c
-    STDP_ENABLED = 0
-    ifneq ($(SYNAPSE_DYNAMICS), $(SYNAPSE_DYNAMICS_STATIC))
-        STDP_ENABLED = 1
-
-        ifndef TIMING_DEPENDENCE_H
-            $(error TIMING_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
-        endif
-        ifndef WEIGHT_DEPENDENCE_H
-            $(error WEIGHT_DEPENDENCE_H is not set which is required when SYNAPSE_DYNAMICS ($(SYNAPSE_DYNAMICS_C)) != $(SYNAPSE_DYNAMICS_STATIC))
-        endif
-    endif
 endif
 
 ifdef WEIGHT_DEPENDENCE
@@ -71,6 +58,7 @@ ifdef WEIGHT_DEPENDENCE
     WEIGHT_DEPENDENCE_C := $(call replace_source_dirs,$(WEIGHT_DEPENDENCE))
     WEIGHT_DEPENDENCE := $(call strip_source_dirs,$(WEIGHT_DEPENDENCE))
     WEIGHT_DEPENDENCE_O := $(BUILD_DIR)$(WEIGHT_DEPENDENCE:%.c=%.o)
+    STDP_INCLUDES := $(STDP_INCLUDES) -include $(WEIGHT_DEPENDENCE_H) 
 endif
 
 ifdef TIMING_DEPENDENCE
@@ -78,13 +66,12 @@ ifdef TIMING_DEPENDENCE
     TIMING_DEPENDENCE_C := $(call replace_source_dirs,$(TIMING_DEPENDENCE))
     TIMING_DEPENDENCE := $(call strip_source_dirs,$(TIMING_DEPENDENCE))
     TIMING_DEPENDENCE_O := $(BUILD_DIR)$(TIMING_DEPENDENCE:%.c=%.o)
+    STDP_INCLUDES := $(STDP_INCLUDES) -include $(TIMING_DEPENDENCE_H) 
 endif
 
-SYNGEN_ENABLED = 1
 ifndef SYNAPTOGENESIS_DYNAMICS
     SYNAPTOGENESIS_DYNAMICS := neuron/structural_plasticity/synaptogenesis_dynamics_static_impl.c
     SYNAPTOGENESIS_DYNAMICS_C := $(NEURON_MODIFIED_DIR)$(SYNAPTOGENESIS_DYNAMICS)
-    SYNGEN_ENABLED = 0
 else
     SYNAPTOGENESIS_DYNAMICS_C := $(call replace_source_dirs,$(SYNAPTOGENESIS_DYNAMICS))
     SYNAPTOGENESIS_DYNAMICS := $(call strip_source_dirs,$(SYNAPTOGENESIS_DYNAMICS))
@@ -105,6 +92,7 @@ ifdef PARTNER_SELECTION
     PARTNER_SELECTION_C := $(call replace_source_dirs,$(PARTNER_SELECTION))
     PARTNER_SELECTION := $(call strip_source_dirs,$(PARTNER_SELECTION))
     PARTNER_SELECTION_O := $(BUILD_DIR)$(PARTNER_SELECTION:%.c=%.o)
+    SYNGEN_INCLUDES:= $(SYNGEN_INCLUDES) -include $(PARTNER_SELECTION_H) 
 endif
 
 ifdef FORMATION
@@ -112,6 +100,7 @@ ifdef FORMATION
     FORMATION_C := $(call replace_source_dirs,$(FORMATION))
     FORMATION := $(call strip_source_dirs,$(FORMATION))
     FORMATION_O := $(BUILD_DIR)$(FORMATION:%.c=%.o)
+    SYNGEN_INCLUDES:= $(SYNGEN_INCLUDES) -include $(FORMATION_H) 
 endif
 
 ifdef ELIMINATION
@@ -119,6 +108,7 @@ ifdef ELIMINATION
     ELIMINATION_C := $(call replace_source_dirs,$(ELIMINATION))
     ELIMINATION := $(call strip_source_dirs,$(ELIMINATION))
     ELIMINATION_O := $(BUILD_DIR)$(ELIMINATION:%.c=%.o)
+    SYNGEN_INCLUDES:= $(SYNGEN_INCLUDES) -include $(ELIMINATION_H) 
 endif
 
 OTHER_SOURCES_CONVERTED := $(call strip_source_dirs,$(OTHER_SOURCES))
@@ -136,89 +126,69 @@ include $(FEC_INSTALL_DIR)/make/fec.mk
 
 FEC_OPT = $(OTIME)
 
-# Extra compile options
-DO_COMPILE = $(CC) -DLOG_LEVEL=$(SYNAPSE_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED)
+# Synapse build rules
+SYNAPSE_TYPE_COMPILE = $(CC) -DLOG_LEVEL=$(SYNAPSE_DEBUG) $(CFLAGS)
 
 $(BUILD_DIR)neuron/synapses.o: $(NEURON_MODIFIED_DIR)neuron/synapses.c
 	#synapses.c
 	-@mkdir -p $(dir $@)
-	$(DO_COMPILE) -o $@ $<
+	$(SYNAPSE_TYPE_COMPILE) -o $@ $<
 
 $(BUILD_DIR)neuron/direct_synapses.o: $(NEURON_MODIFIED_DIR)neuron/direct_synapses.c
 	#direct_synapses.c
 	-mkdir -p $(dir $@)
-	$(DO_COMPILE) -o $@ $<
+	$(SYNAPSE_TYPE_COMPILE) -o $@ $<
 
 $(BUILD_DIR)neuron/spike_processing_fast.o: $(NEURON_MODIFIED_DIR)neuron/spike_processing_fast.c
 	#spike_processing_fast.c
 	-@mkdir -p $(dir $@)
-	$(DO_COMPILE) -o $@ $<
+	$(SYNAPSE_TYPE_COMPILE) -o $@ $<
 
 $(BUILD_DIR)neuron/population_table/population_table_binary_search_impl.o: $(NEURON_MODIFIED_DIR)neuron/population_table/population_table_binary_search_impl.c
 	#population_table/population_table_binary_search_impl.c
 	-@mkdir -p $(dir $@)
-	$(DO_COMPILE) -o $@ $<
+	$(SYNAPSE_TYPE_COMPILE) -o $@ $<
 
-SYNGEN_INCLUDES:=
-ifeq ($(SYNGEN_ENABLED), 1)
-    SYNGEN_INCLUDES:= -include $(PARTNER_SELECTION_H) -include $(FORMATION_H) -include $(ELIMINATION_H)
-endif
+STDP_COMPILE = $(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) $(STDP_INCLUDES)
 
-#STDP Build rules If and only if STDP used
-ifeq ($(STDP_ENABLED), 1)
-    STDP_INCLUDES:= -include $(WEIGHT_DEPENDENCE_H) -include $(TIMING_DEPENDENCE_H)
-    STDP_COMPILE = $(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -DSTDP_ENABLED=$(STDP_ENABLED) -DSYNGEN_ENABLED=$(SYNGEN_ENABLED) $(STDP_INCLUDES)
-
-    $(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
+$(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
 	# SYNAPSE_DYNAMICS_O stdp
 	-@mkdir -p $(dir $@)
 	$(STDP_COMPILE) -o $@ $<
 
-    $(SYNAPTOGENESIS_DYNAMICS_O): $(SYNAPTOGENESIS_DYNAMICS_C)
+$(SYNAPTOGENESIS_DYNAMICS_O): $(SYNAPTOGENESIS_DYNAMICS_C)
 	# SYNAPTOGENESIS_DYNAMICS_O stdp
 	-@mkdir -p $(dir $@)
 	$(STDP_COMPILE) $(SYNGEN_INCLUDES) -o $@ $<
 
-    $(BUILD_DIR)neuron/plasticity/common/post_events.o: $(NEURON_MODIFIED_DIR)neuron/plasticity/common/post_events.c
+$(BUILD_DIR)neuron/plasticity/common/post_events.o: $(NEURON_MODIFIED_DIR)neuron/plasticity/common/post_events.c
 	# plasticity/common/post_events.c
 	-@mkdir -p $(dir $@)
 	$(STDP_COMPILE) -o $@ $<
 
-else
-    $(SYNAPTOGENESIS_DYNAMICS_O): $(SYNAPTOGENESIS_DYNAMICS_C)
-    # SYNAPTOGENESIS_DYNAMICS_O without stdp
-	-@mkdir -p $(dir $@)
-	$(DO_COMPILE) $(SYNGEN_INCLUDES) -o $@ $<
-
-    $(SYNAPSE_DYNAMICS_O): $(SYNAPSE_DYNAMICS_C)
-    # SYNAPSE_DYNAMICS_O without stdp
-	-@mkdir -p $(dir $@)
-	$(DO_COMPILE) -o $@ $<
-
-endif
-
-$(WEIGHT_DEPENDENCE_O): $(WEIGHT_DEPENDENCE_C)
+$(WEIGHT_DEPENDENCE_O): $(WEIGHT_DEPENDENCE_C) $(SYNAPSE_TYPE_H) $(MAKEFILE_LIST)
 	# WEIGHT_DEPENDENCE_O
 	-@mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -o $@ $<
 
-$(TIMING_DEPENDENCE_O): $(TIMING_DEPENDENCE_C) $(WEIGHT_DEPENDENCE_H)
+$(TIMING_DEPENDENCE_O): $(TIMING_DEPENDENCE_C) $(SYNAPSE_TYPE_H) \
+                        $(WEIGHT_DEPENDENCE_H) $(MAKEFILE_LIST)
 	# TIMING_DEPENDENCE_O
 	-@mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) \
 	        -include $(WEIGHT_DEPENDENCE_H) -o $@ $<
 
-$(PARTNER_SELECTION_O): $(PARTNER_SELECTION_C)
+$(PARTNER_SELECTION_O): $(PARTNER_SELECTION_C) $(SYNAPSE_TYPE_H) $(MAKEFILE_LIST)
 	# PARTNER_SELECTION_O
 	-mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -o $@ $<
 
-$(FORMATION_O): $(FORMATION_C)
+$(FORMATION_O): $(FORMATION_C) $(SYNAPSE_TYPE_H) $(MAKEFILE_LIST)
 	# FORMATION_O
 	-mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -o $@ $<
 
-$(ELIMINATION_O): $(ELIMINATION_C)
+$(ELIMINATION_O): $(ELIMINATION_C) $(SYNAPSE_TYPE_H) $(MAKEFILE_LIST)
 	# ELIMINATION_O
 	-mkdir -p $(dir $@)
 	$(CC) -DLOG_LEVEL=$(PLASTIC_DEBUG) $(CFLAGS) -o $@ $<
@@ -226,4 +196,4 @@ $(ELIMINATION_O): $(ELIMINATION_C)
 .PRECIOUS: $(NEURON_MODIFIED_DIR)%.c $(NEURON_MODIFIED_DIR)%.h $(LOG_DICT_FILE) $(EXTRA_PRECIOUS)
 
 clean:
-	$(RM) -r $(BUILD_DIR)
+	$(RM) -r $(BUILD_DIR) $(NEURON_MODIFIED_DIR)

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_common.h
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_common.h
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+// Check for required imports
+#ifndef _TIMING_H_
+#error "Missing timing rule definition.  Make sure you define TIMING_DEPENDENCE_H in your makefile."
+#endif
+#ifndef _WEIGHT_H_
+#error "Missing weight rule definition.  Make sure you define WEIGHT_DEPENDENCE_H in your makefile."
+#endif
+
 //! \file
 //! \brief STDP core implementation
 //!

--- a/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
+++ b/neural_modelling/src/neuron/plasticity/stdp/synapse_dynamics_stdp_mad_impl.c
@@ -16,7 +16,6 @@
 
 //! \file
 //! \brief STDP core implementation
-#include "post_events.h"
 #include "synapse_dynamics_stdp_common.h"
 
 //! The format of the plastic data region of a synaptic row
@@ -195,34 +194,34 @@ void synapse_dynamics_process_post_synaptic_event(
 //---------------------------------------
 static inline plastic_synapse_t process_plastic_synapse(
         uint32_t control_word, uint32_t last_pre_time, pre_trace_t last_pre_trace,
-		pre_trace_t new_pre_trace, weight_t *ring_buffers, uint32_t time,
-		uint32_t colour_delay, plastic_synapse_t synapse) {
+        pre_trace_t new_pre_trace, weight_t *ring_buffers, uint32_t time,
+        uint32_t colour_delay, plastic_synapse_t synapse) {
     fixed_stdp_synapse s = synapse_dynamics_stdp_get_fixed(control_word, time,
             colour_delay);
 
-	// Create update state from the plastic synaptic word
-	update_state_t current_state = synapse_structure_get_update_state(
-	        synapse, s.type);
+    // Create update state from the plastic synaptic word
+    update_state_t current_state = synapse_structure_get_update_state(
+            synapse, s.type);
 
-	// Update the synapse state
-	uint32_t post_delay = s.delay_dendritic;
-	if (!params.backprop_delay) {
-		post_delay = 0;
-	}
-	final_state_t final_state = plasticity_update_synapse(
-			time - colour_delay, last_pre_time, last_pre_trace, new_pre_trace,
-			post_delay, s.delay_axonal, current_state,
-			&post_event_history[s.index]);
+    // Update the synapse state
+    uint32_t post_delay = s.delay_dendritic;
+    if (!params.backprop_delay) {
+        post_delay = 0;
+    }
+    final_state_t final_state = plasticity_update_synapse(
+            time - colour_delay, last_pre_time, last_pre_trace, new_pre_trace,
+            post_delay, s.delay_axonal, current_state,
+            &post_event_history[s.index]);
 
-	// Add weight to ring-buffer entry, but only if not too late
-	if (s.delay_axonal + s.delay_dendritic > colour_delay) {
-	    int32_t weight = synapse_structure_get_final_weight(final_state);
-	    synapse_dynamics_stdp_update_ring_buffers(ring_buffers, s, weight);
+    // Add weight to ring-buffer entry, but only if not too late
+    if (s.delay_axonal + s.delay_dendritic > colour_delay) {
+        int32_t weight = synapse_structure_get_final_weight(final_state);
+        synapse_dynamics_stdp_update_ring_buffers(ring_buffers, s, weight);
     } else {
         skipped_synapses++;
     }
 
-	return synapse_structure_get_final_synaptic_word(final_state);
+    return synapse_structure_get_final_synaptic_word(final_state);
 }
 
 bool synapse_dynamics_process_plastic_synapses(


### PR DESCRIPTION
Refactor make process a little to allow other STDP systems which don't need the weight and timing rules to be separately implemented.  This is particularly relevant to NESTML where the STDP code is generated in a single file.