### PR TITLE
venv for mypy and a few small fixex

### DIFF
--- a/mypyd.bash
+++ b/mypyd.bash
@@ -14,18 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This bash assumes that other repositories are installed in paralled
 
-# requires the latest mypy
-# pip install --upgrade mypy
+# This bash assumes that other repositories are installed in parallel
 
-utils="../SpiNNUtils/spinn_utilities"
-machine="../SpiNNMachine/spinn_machine"
-man="../SpiNNMan/spinnman"
-pacman="../PACMAN/pacman"
-spalloc="../spalloc/spalloc_client"
-fec="../SpiNNFrontEndCommon/spinn_front_end_common"
-test_base="../TestBase/spinnaker_testbase"
+if [ "$#" -eq  "0" ]
+  then
+    echo "Provide any argument to run setup"
+    source ../SupportScripts/venv/mypy_runner/bin/activate
+else
+    python3 -m venv ../SupportScripts/venv/mypy_runner
+    source ../SupportScripts/venv/mypy_runner/bin/activate
+    pip3 install --upgrade ../SpiNNUtils
+    pip3 install --upgrade ../SpiNNMachine
+    pip3 install --upgrade ../SpiNNMan
+    pip3 install --upgrade ../spalloc
+    pip3 install --upgrade ../PACMAN
+    pip3 install --upgrade ../SpiNNFrontEndCommon
+    pip3 install --upgrade ../TestBase
+    pip3 install --upgrade ../sPyNNaker[test]
+    python3 -m pip install --upgrade mypy
+fi
 
-mypy --disallow-untyped-defs $utils $machine $man $pacman $spalloc $fec $test_base spynnaker unittests spynnaker_integration_tests proxy_integration_tests
+mypy --disallow-untyped-defs spynnaker unittests spynnaker_integration_tests proxy_integration_tests
 

--- a/mypyd.bash
+++ b/mypyd.bash
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # This bash assumes that other repositories are installed in parallel
 
 if [ "$#" -eq  "0" ]

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -159,6 +159,7 @@ def default_initial_values(state_variables: Iterable[str]) -> Callable:
         return wrapper
     return wrap
 
+
 @no_type_check
 def defaults(cls: type) -> type:
     """

--- a/spynnaker/pyNN/models/defaults.py
+++ b/spynnaker/pyNN/models/defaults.py
@@ -20,7 +20,8 @@ import inspect
 import logging
 from types import MappingProxyType
 from typing import (
-    Any, Callable, FrozenSet, Iterable, List, Mapping, Optional, Tuple)
+    Any, Callable, FrozenSet, Iterable, List, Mapping, no_type_check,
+    Optional, Tuple)
 from spinn_utilities.classproperty import classproperty
 from spinn_utilities.log import FormatAdapter
 
@@ -158,7 +159,7 @@ def default_initial_values(state_variables: Iterable[str]) -> Callable:
         return wrapper
     return wrap
 
-
+@no_type_check
 def defaults(cls: type) -> type:
     """
     Deprecated! Extend AbstractProvidesDefaults instead

--- a/spynnaker/pyNN/models/populations/population.py
+++ b/spynnaker/pyNN/models/populations/population.py
@@ -672,6 +672,7 @@ class Population(PopulationBase):
             is a class to instantiate. Must be ``None`` if ``cell_class`` is an
             instantiated object.
         """
+        model: AbstractPyNNModel | PopulationApplicationVertex
         if inspect.isclass(cell_class):
             if cell_params is None:
                 model = cell_class()

--- a/spynnaker/pyNN/utilities/neo_buffer_database.py
+++ b/spynnaker/pyNN/utilities/neo_buffer_database.py
@@ -54,7 +54,7 @@ from spynnaker.pyNN.utilities.constants import SPIKES
 from spynnaker.pyNN.utilities.neo_csv import NeoCsv
 
 if TYPE_CHECKING:
-    from _csv import _writer as CSVWriter
+    from _csv import Writer as CSVWriter
     from spynnaker.pyNN.models.common.types import Names as ConcreteNames
     from spynnaker.pyNN.models.populations.population import Population
     from .data_population import DataPopulation

--- a/spynnaker/pyNN/utilities/neo_csv.py
+++ b/spynnaker/pyNN/utilities/neo_csv.py
@@ -30,7 +30,7 @@ from spinn_utilities.log import FormatAdapter
 from spynnaker.pyNN.data import SpynnakerDataView
 
 if TYPE_CHECKING:
-    from _csv import _writer as CSVWriter, _reader as CSVReader
+    from _csv import Writer as CSVWriter, Reader as CSVReader
     from spynnaker.pyNN.utilities.neo_buffer_database import Annotations
 
 logger = FormatAdapter(logging.getLogger(__name__))


### PR DESCRIPTION
some small errors and fixes/ignores

spynnaker/pyNN/models/defaults.py:193: error: "type[object]" has no attribute "default_parameters"  [attr-defined]
- method should be removed so ignore

spynnaker/pyNN/utilities/neo_csv.py:33: error: Module "_csv" has no attribute "_writer"; maybe "writer" or "Writer"?  [attr-defined]
_writer and reader where a temp thing (in csv code) for 3.9
- use Writer and Reader

spynnaker/pyNN/models/populations/population.py:687: error: Incompatible types in assignment (expression has type "AbstractPyNNModel | PopulationApplicationVertex", variable has type "AbstractPyNNModel")  [assignment]
- Define the types so mypy does not assume just one